### PR TITLE
Set Render node engine to 20

### DIFF
--- a/nerin-electric-site-v3-fixed/package.json
+++ b/nerin-electric-site-v3-fixed/package.json
@@ -9,7 +9,7 @@
     "postinstall": "tailwindcss -i ./app/globals.css -o ./app/globals.css || true"
   },
   "engines": {
-    "node": ">=18"
+    "node": "20.x"
   },
   "dependencies": {
     "marked": "^16.3.0",


### PR DESCRIPTION
## Summary
- set the package.json engines.node entry to 20.x for Render
- keep Next.js scripts pointing to the expected dev/build/start commands

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb24b347748331b9e2b5b4c2be5eb6