### PR TITLE
chore: update dependencies and harden admin routes

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/blog/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/blog/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import Link from 'next/link'
+import type { Route } from 'next'
 import { useEffect, useState } from 'react'
 export default function BlogAdmin(){
   const [items, setItems] = useState<string[]>([])
@@ -20,7 +21,7 @@ export default function BlogAdmin(){
       {items.map(s => (
         <li key={s} className="card flex justify-between items-center">
           <span>{s}</span>
-          <div className="flex gap-2"><Link className="btn" href={'/admin/blog/' + s}>Editar</Link></div>
+          <div className="flex gap-2"><Link className="btn" href={`/admin/blog/${s}` as Route}>Editar</Link></div>
         </li>
       ))}
     </ul>

--- a/nerin-electric-site-v3-fixed/app/admin/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { requireAdmin } from '@/lib/auth'
 import { readSite } from '@/lib/content'
+export const dynamic = 'force-dynamic'
 export default async function AdminHome(){
   await requireAdmin()
   const site = readSite()

--- a/nerin-electric-site-v3-fixed/app/admin/pages/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/pages/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import Link from 'next/link'
+import type { Route } from 'next'
 import { useEffect, useState } from 'react'
 export default function PagesAdmin(){
   const [items, setItems] = useState<string[]>([])
@@ -20,7 +21,7 @@ export default function PagesAdmin(){
       {items.map(s => (
         <li key={s} className="card flex justify-between items-center">
           <span>{s}</span>
-          <div className="flex gap-2"><Link className="btn" href={'/admin/pages/' + s}>Editar</Link></div>
+          <div className="flex gap-2"><Link className="btn" href={`/admin/pages/${s}` as Route}>Editar</Link></div>
         </li>
       ))}
     </ul>

--- a/nerin-electric-site-v3-fixed/app/admin/projects/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/projects/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import Link from 'next/link'
+import type { Route } from 'next'
 import { useEffect, useState } from 'react'
 export default function ProjectsAdmin(){
   const [items, setItems] = useState<string[]>([])
@@ -20,7 +21,7 @@ export default function ProjectsAdmin(){
       {items.map(s => (
         <li key={s} className="card flex justify-between items-center">
           <span>{s}</span>
-          <div className="flex gap-2"><Link className="btn" href={'/admin/projects/' + s}>Editar</Link></div>
+          <div className="flex gap-2"><Link className="btn" href={`/admin/projects/${s}` as Route}>Editar</Link></div>
         </li>
       ))}
     </ul>

--- a/nerin-electric-site-v3-fixed/app/admin/services/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/services/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import Link from 'next/link'
+import type { Route } from 'next'
 import { useEffect, useState } from 'react'
 export default function ServicesAdmin(){
   const [items, setItems] = useState<string[]>([])
@@ -20,7 +21,7 @@ export default function ServicesAdmin(){
       {items.map(s => (
         <li key={s} className="card flex justify-between items-center">
           <span>{s}</span>
-          <div className="flex gap-2"><Link className="btn" href={'/admin/services/' + s}>Editar</Link></div>
+          <div className="flex gap-2"><Link className="btn" href={`/admin/services/${s}` as Route}>Editar</Link></div>
         </li>
       ))}
     </ul>

--- a/nerin-electric-site-v3-fixed/lib/content.ts
+++ b/nerin-electric-site-v3-fixed/lib/content.ts
@@ -9,6 +9,16 @@ export function getStorageDir(){
 
 const SITE_FILE = 'site.json'
 
+function getTypeDir(type: string){
+  const dir = path.join(getStorageDir(), type)
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+function getItemFile(type: string, slug: string){
+  return path.join(getTypeDir(type), `${slug}.json`)
+}
+
 export function readSite(){
   const dir = getStorageDir()
   const file = path.join(dir, SITE_FILE)
@@ -36,4 +46,34 @@ export function writeSite(data: any){
   const file = path.join(dir, SITE_FILE)
   fs.writeFileSync(file, JSON.stringify(data, null, 2))
   return true
+}
+
+export function listItems(type: string){
+  const dir = getTypeDir(type)
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.json'))
+    .map(f => f.replace(/\.json$/, ''))
+    .sort()
+}
+
+export function readMarkdown(type: string, slug: string){
+  const file = getItemFile(type, slug)
+  if (!fs.existsSync(file)) return null
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf-8'))
+  } catch {
+    return null
+  }
+}
+
+export function writeMarkdown(type: string, slug: string, data: any, content: string){
+  const file = getItemFile(type, slug)
+  const payload = { data: data ?? {}, content: content ?? '' }
+  fs.writeFileSync(file, JSON.stringify(payload, null, 2))
+  return payload
+}
+
+export function deleteMarkdown(type: string, slug: string){
+  const file = getItemFile(type, slug)
+  if (fs.existsSync(file)) fs.unlinkSync(file)
 }

--- a/nerin-electric-site-v3-fixed/next-env.d.ts
+++ b/nerin-electric-site-v3-fixed/next-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/nerin-electric-site-v3-fixed/package-lock.json
+++ b/nerin-electric-site-v3-fixed/package-lock.json
@@ -10,18 +10,20 @@
       "hasInstallScript": true,
       "dependencies": {
         "marked": "^16.3.0",
-        "next": "14.2.5",
+        "next": "^14.2.32",
         "react": "18.3.1",
         "react-dom": "18.3.1"
       },
       "devDependencies": {
+        "@types/node": "24.5.1",
+        "@types/react": "19.1.13",
         "autoprefixer": "10.4.19",
         "postcss": "8.4.38",
         "tailwindcss": "3.4.9",
         "typescript": "5.5.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": "20.x"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -95,15 +97,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.5.tgz",
-      "integrity": "sha512-/zZGkrTOsraVfYjGP8uM0p6r0BDT6xWpkjdVbcz66PJVSpwXX3yNiRycxAuDfBKGWBrZBXRuK/YVlkNgxHGwmA==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.32.tgz",
+      "integrity": "sha512-n9mQdigI6iZ/DF6pCTwMKeWgF2e8lg7qgt5M7HXMLtyhZYMnf/u905M18sSpPmHL9MKp9JHo56C6jrD2EvWxng==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.5.tgz",
-      "integrity": "sha512-/9zVxJ+K9lrzSGli1///ujyRfon/ZneeZ+v4ptpiPoOU+GKZnm8Wj8ELWU1Pm7GHltYRBklmXMTUqM/DqQ99FQ==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.32.tgz",
+      "integrity": "sha512-osHXveM70zC+ilfuFa/2W6a1XQxJTvEhzEycnjUaVE8kpUS09lDpiDDX2YLdyFCzoUbvbo5r0X1Kp4MllIOShw==",
       "cpu": [
         "arm64"
       ],
@@ -117,9 +119,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.5.tgz",
-      "integrity": "sha512-vXHOPCwfDe9qLDuq7U1OYM2wUY+KQ4Ex6ozwsKxp26BlJ6XXbHleOUldenM67JRyBfVjv371oneEvYd3H2gNSA==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.32.tgz",
+      "integrity": "sha512-P9NpCAJuOiaHHpqtrCNncjqtSBi1f6QUdHK/+dNabBIXB2RUFWL19TY1Hkhu74OvyNQEYEzzMJCMQk5agjw1Qg==",
       "cpu": [
         "x64"
       ],
@@ -133,9 +135,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.5.tgz",
-      "integrity": "sha512-vlhB8wI+lj8q1ExFW8lbWutA4M2ZazQNvMWuEDqZcuJJc78iUnLdPPunBPX8rC4IgT6lIx/adB+Cwrl99MzNaA==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.32.tgz",
+      "integrity": "sha512-v7JaO0oXXt6d+cFjrrKqYnR2ubrD+JYP7nQVRZgeo5uNE5hkCpWnHmXm9vy3g6foMO8SPwL0P3MPw1c+BjbAzA==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +151,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.5.tgz",
-      "integrity": "sha512-NpDB9NUR2t0hXzJJwQSGu1IAOYybsfeB+LxpGsXrRIb7QOrYmidJz3shzY8cM6+rO4Aojuef0N/PEaX18pi9OA==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.32.tgz",
+      "integrity": "sha512-tA6sIKShXtSJBTH88i0DRd6I9n3ZTirmwpwAqH5zdJoQF7/wlJXR8DkPmKwYl5mFWhEKr5IIa3LfpMW9RRwKmQ==",
       "cpu": [
         "arm64"
       ],
@@ -165,9 +167,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.5.tgz",
-      "integrity": "sha512-8XFikMSxWleYNryWIjiCX+gU201YS+erTUidKdyOVYi5qUQo/gRxv/3N1oZFCgqpesN6FPeqGM72Zve+nReVXQ==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.32.tgz",
+      "integrity": "sha512-7S1GY4TdnlGVIdeXXKQdDkfDysoIVFMD0lJuVVMeb3eoVjrknQ0JNN7wFlhCvea0hEk0Sd4D1hedVChDKfV2jw==",
       "cpu": [
         "x64"
       ],
@@ -181,9 +183,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.5.tgz",
-      "integrity": "sha512-6QLwi7RaYiQDcRDSU/os40r5o06b5ue7Jsk5JgdRBGGp8l37RZEh9JsLSM8QF0YDsgcosSeHjglgqi25+m04IQ==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.32.tgz",
+      "integrity": "sha512-OHHC81P4tirVa6Awk6eCQ6RBfWl8HpFsZtfEkMpJ5GjPsJ3nhPe6wKAJUZ/piC8sszUkAgv3fLflgzPStIwfWg==",
       "cpu": [
         "x64"
       ],
@@ -197,9 +199,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.5.tgz",
-      "integrity": "sha512-1GpG2VhbspO+aYoMOQPQiqc/tG3LzmsdBH0LhnDS3JrtDx2QmzXe0B6mSZZiN3Bq7IOMXxv1nlsjzoS1+9mzZw==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.32.tgz",
+      "integrity": "sha512-rORQjXsAFeX6TLYJrCG5yoIDj+NKq31Rqwn8Wpn/bkPNy5rTHvOXkW8mLFonItS7QC6M+1JIIcLe+vOCTOYpvg==",
       "cpu": [
         "arm64"
       ],
@@ -213,9 +215,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.5.tgz",
-      "integrity": "sha512-Igh9ZlxwvCDsu6438FXlQTHlRno4gFpJzqPjSIBZooD22tKeI4fE/YMRoHVJHmrQ2P5YL1DoZ0qaOKkbeFWeMg==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.32.tgz",
+      "integrity": "sha512-jHUeDPVHrgFltqoAqDB6g6OStNnFxnc7Aks3p0KE0FbwAvRg6qWKYF5mSTdCTxA3axoSAUwxYdILzXJfUwlHhA==",
       "cpu": [
         "ia32"
       ],
@@ -229,9 +231,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.5.tgz",
-      "integrity": "sha512-tEQ7oinq1/CjSG9uSTerca3v4AZ+dFa+4Yu6ihaG8Ud8ddqLQgFGcnwYls13H5X5CPDPZJdYxyeMui6muOLd4g==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.32.tgz",
+      "integrity": "sha512-2N0lSoU4GjfLSO50wvKpMQgKd4HdI2UHEhQPPPnlgfBJlOgJxkjpkYBqzk08f1gItBB6xF/n+ykso2hgxuydsA==",
       "cpu": [
         "x64"
       ],
@@ -307,6 +309,26 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.1.tgz",
+      "integrity": "sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
+      "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/ansi-regex": {
@@ -630,6 +652,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -1078,12 +1107,12 @@
       }
     },
     "node_modules/next": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.5.tgz",
-      "integrity": "sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.32.tgz",
+      "integrity": "sha512-fg5g0GZ7/nFc09X8wLe6pNSU8cLWbLRG3TZzPJ1BJvi2s9m7eF991se67wliM9kR5yLHRkyGKU49MMx58s3LJg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.5",
+        "@next/env": "14.2.32",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -1098,15 +1127,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.5",
-        "@next/swc-darwin-x64": "14.2.5",
-        "@next/swc-linux-arm64-gnu": "14.2.5",
-        "@next/swc-linux-arm64-musl": "14.2.5",
-        "@next/swc-linux-x64-gnu": "14.2.5",
-        "@next/swc-linux-x64-musl": "14.2.5",
-        "@next/swc-win32-arm64-msvc": "14.2.5",
-        "@next/swc-win32-ia32-msvc": "14.2.5",
-        "@next/swc-win32-x64-msvc": "14.2.5"
+        "@next/swc-darwin-arm64": "14.2.32",
+        "@next/swc-darwin-x64": "14.2.32",
+        "@next/swc-linux-arm64-gnu": "14.2.32",
+        "@next/swc-linux-arm64-musl": "14.2.32",
+        "@next/swc-linux-x64-gnu": "14.2.32",
+        "@next/swc-linux-x64-musl": "14.2.32",
+        "@next/swc-win32-arm64-msvc": "14.2.32",
+        "@next/swc-win32-ia32-msvc": "14.2.32",
+        "@next/swc-win32-x64-msvc": "14.2.32"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -1901,6 +1930,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/nerin-electric-site-v3-fixed/package.json
+++ b/nerin-electric-site-v3-fixed/package.json
@@ -13,11 +13,13 @@
   },
   "dependencies": {
     "marked": "^16.3.0",
-    "next": "14.2.5",
+    "next": "^14.2.32",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },
   "devDependencies": {
+    "@types/node": "24.5.1",
+    "@types/react": "19.1.13",
     "autoprefixer": "10.4.19",
     "postcss": "8.4.38",
     "tailwindcss": "3.4.9",

--- a/nerin-electric-site-v3-fixed/tsconfig.json
+++ b/nerin-electric-site-v3-fixed/tsconfig.json
@@ -25,12 +25,18 @@
     },
     "types": [
       "node"
+    ],
+    "plugins": [
+      {
+        "name": "next"
+      }
     ]
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- upgrade Next.js and related tooling to resolve the audit report while keeping Next 14.2 compatibility
- add filesystem-backed helpers for listing, reading and mutating markdown content used by the blog and admin APIs
- adjust admin navigation to satisfy typed route checks and ensure the dashboard renders dynamically under auth

## Testing
- npm run build
- npm audit

------
https://chatgpt.com/codex/tasks/task_e_68cb258888bc8331a5455fd728028af6