### PR TITLE
Fix admin dashboard redirect to login when unauthenticated

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/page.tsx
@@ -1,9 +1,13 @@
 import Link from 'next/link'
-import { requireAdmin } from '@/lib/auth'
+import { getSession } from '@/lib/auth'
+import { redirect } from 'next/navigation'
 import { readSite } from '@/lib/content'
 export const dynamic = 'force-dynamic'
 export default async function AdminHome(){
-  await requireAdmin()
+  const session = await getSession()
+  if (!session.user || session.user.role !== 'admin') {
+    redirect('/admin/login')
+  }
   const site = readSite()
   return (
     <div className="py-10">


### PR DESCRIPTION
## Summary
- redirect unauthenticated visits to the admin dashboard to the login page to avoid server errors

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb38b0e3508331a6a8aba10f442a08