### PR TITLE
Mejoras de usabilidad en gestión de servicios

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/services/[slug]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/services/[slug]/page.tsx
@@ -1,26 +1,169 @@
 'use client'
+
 import { useEffect, useState } from 'react'
-import { useParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
+
+type ServiceData = {
+  title: string
+  excerpt: string
+  cover: string
+}
+
 export default function EditServices(){
-  const params = useParams(); const slug = String(params.slug)
-  const [data,setData] = useState<any>({title:'',excerpt:'',cover:''})
-  const [content,setContent] = useState(''); const [saved,setSaved]=useState(false)
-  useEffect(()=>{ fetch('/api/admin/item?type=services&slug=' + slug).then(r=>r.json()).then(j=>{ setData(j.data||{}); setContent(j.content||'') }) },[slug])
-  async function save(){ setSaved(false); const res = await fetch('/api/admin/item?type=services&slug=' + slug,{method:'POST',body:JSON.stringify({data,content})}); if(res.ok) setSaved(true) }
-  async function del(){ if(!confirm('Eliminar?')) return; const res = await fetch('/api/admin/item?type=services&slug=' + slug,{method:'DELETE'}); if(res.ok) window.location.href='/admin/services' }
-  return (<div className="py-10 grid md:grid-cols-2 gap-8">
-    <div className="space-y-4">
-      <h1 className="text-3xl font-extrabold">Editar: {slug}</h1>
-      {['title','excerpt','cover'].map(k => (
-        <div key={k}><label>{k}</label><input value={data[k]||''} onChange={e=>setData({...data,[k]:e.target.value})}/></div>
-      ))}
-      <button className="btn" onClick={save}>Guardar</button>
-      <button className="btn" onClick={del}>Eliminar</button>
-      {saved && <span className="text-green-700 text-sm">Guardado.</span>}
+  const params = useParams()
+  const router = useRouter()
+  const slug = String(params.slug)
+
+  const [data, setData] = useState<ServiceData>({ title: '', excerpt: '', cover: '' })
+  const [content, setContent] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [feedback, setFeedback] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  useEffect(()=>{
+    async function load(){
+      setLoading(true)
+      setLoadError(null)
+      try {
+        const response = await fetch('/api/admin/item?type=services&slug=' + slug)
+        if (!response.ok) {
+          throw new Error('No se pudo cargar la información del servicio.')
+        }
+        const payload = await response.json()
+        setData({
+          title: payload.data?.title ?? '',
+          excerpt: payload.data?.excerpt ?? '',
+          cover: payload.data?.cover ?? ''
+        })
+        setContent(payload.content ?? '')
+      } catch (err) {
+        console.error(err)
+        setLoadError('Ocurrió un error al cargar el servicio. Actualizá la página para intentar nuevamente.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [slug])
+
+  async function save(){
+    setSaving(true)
+    setFeedback(null)
+    setError(null)
+    try {
+      const response = await fetch('/api/admin/item?type=services&slug=' + slug, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data, content })
+      })
+      if (!response.ok) {
+        throw new Error('No se pudieron guardar los cambios.')
+      }
+      setFeedback('Cambios guardados correctamente.')
+    } catch (err) {
+      console.error(err)
+      setError(err instanceof Error ? err.message : 'Ocurrió un error inesperado.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function del(){
+    if(!confirm('¿Eliminar este servicio? Esta acción no se puede deshacer.')) return
+    setDeleting(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/admin/item?type=services&slug=' + slug,{ method:'DELETE' })
+      if(!response.ok){
+        throw new Error('No se pudo eliminar el servicio.')
+      }
+      router.push('/admin/services')
+    } catch (err){
+      console.error(err)
+      setError(err instanceof Error ? err.message : 'Ocurrió un error inesperado.')
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  if (loading) {
+    return <div className="py-10">Cargando…</div>
+  }
+
+  if (loadError) {
+    return (
+      <div className="py-10">
+        <h1 className="text-2xl font-semibold mb-2">Editar servicio</h1>
+        <p className="text-sm text-red-600">{loadError}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="py-10 space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-3xl font-extrabold">{data.title || 'Editar servicio'}</h1>
+        <p className="text-sm text-gray-600">La URL pública es <code className="bg-gray-100 px-1 rounded text-xs">/services/{slug}</code>.</p>
+      </header>
+
+      <div className="grid md:grid-cols-2 gap-8">
+        <div className="space-y-5">
+          <div>
+            <label>Título del servicio</label>
+            <input
+              value={data.title}
+              onChange={event=>setData(current => ({ ...current, title: event.target.value }))}
+              placeholder="Ej. Mantenimiento de subestaciones"
+            />
+          </div>
+
+          <div>
+            <label>Resumen corto</label>
+            <textarea
+              rows={4}
+              value={data.excerpt}
+              onChange={event=>setData(current => ({ ...current, excerpt: event.target.value }))}
+              placeholder="Texto breve que aparece en la tarjeta del servicio."
+            />
+            <p className="text-xs text-gray-500 mt-1">Se recomienda entre 1 y 2 oraciones.</p>
+          </div>
+
+          <div>
+            <label>Imagen de portada (URL)</label>
+            <input
+              value={data.cover}
+              onChange={event=>setData(current => ({ ...current, cover: event.target.value }))}
+              placeholder="https://tusitio.com/imagenes/servicio.jpg"
+            />
+            <p className="text-xs text-gray-500 mt-1">Usá una imagen horizontal. Podés cargar archivos desde la sección “Media”.</p>
+          </div>
+
+          <div className="flex flex-wrap gap-3 items-center">
+            <button className="btn" onClick={save} disabled={saving}>
+              {saving ? 'Guardando…' : 'Guardar cambios'}
+            </button>
+            <button className="btn" onClick={del} disabled={deleting}>
+              {deleting ? 'Eliminando…' : 'Eliminar servicio'}
+            </button>
+            {feedback && <span className="text-sm text-green-700">{feedback}</span>}
+            {error && <span className="text-sm text-red-600">{error}</span>}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label>Detalle del servicio (Markdown)</label>
+          <textarea
+            rows={24}
+            value={content}
+            onChange={event=>setContent(event.target.value)}
+            placeholder={"## ¿Qué incluye?\nDescribí el alcance, entregables y materiales."}
+          />
+          <p className="text-xs text-gray-500">Podés usar títulos, listas y negritas con sintaxis Markdown.</p>
+        </div>
+      </div>
     </div>
-    <div>
-      <label>Contenido (Markdown)</label>
-      <textarea rows={24} value={content} onChange={e=>setContent(e.target.value)} />
-    </div>
-  </div>)
+  )
 }

--- a/nerin-electric-site-v3-fixed/app/admin/services/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/services/page.tsx
@@ -1,29 +1,145 @@
 'use client'
+
 import Link from 'next/link'
 import type { Route } from 'next'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+
+function slugify(value: string){
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+}
+
+function formatSlugLabel(value: string){
+  return value
+    .split('-')
+    .filter(Boolean)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
 export default function ServicesAdmin(){
   const [items, setItems] = useState<string[]>([])
+  const [name, setName] = useState('')
   const [slug, setSlug] = useState('')
-  useEffect(()=>{ fetch('/api/admin/list?type=services').then(r=>r.json()).then(setItems) },[])
-  async function create(){
-    const s = slug.trim().toLowerCase().replace(/\s+/g,'-'); if(!s) return
-    const res = await fetch('/api/admin/item?type=services&slug=' + s, { method:'POST', body: JSON.stringify({data:{title:s}, content:''}) })
-    if(res.ok) window.location.href='/admin/services/' + s
+  const [slugTouched, setSlugTouched] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(()=>{
+    fetch('/api/admin/list?type=services').then(r=>r.json()).then(setItems)
+  },[])
+
+  const computedSlug = useMemo(()=> slugify(slugTouched ? slug : name), [name, slug, slugTouched])
+
+  function handleNameChange(value: string){
+    setName(value)
+    if (!slugTouched) {
+      setSlug(slugify(value))
+    }
   }
-  return (<div className="py-10">
-    <h1 className="text-3xl font-extrabold mb-6">Services</h1>
-    <div className="card mb-6 flex gap-3 items-end">
-      <div><label>Nuevo slug</label><input value={slug} onChange={e=>setSlug(e.target.value)} placeholder="mi-item" /></div>
-      <button className="btn" onClick={create}>Crear</button>
+
+  async function create(){
+    setError(null)
+    const trimmedName = name.trim()
+    const finalSlug = slugify(slugTouched ? slug : trimmedName)
+    if (!trimmedName) {
+      setError('Ingresá un nombre para el servicio.')
+      return
+    }
+    if (!finalSlug) {
+      setError('No pudimos generar la URL. Revisá el nombre o escribí una manualmente.')
+      return
+    }
+    setCreating(true)
+    try {
+      const response = await fetch('/api/admin/item?type=services&slug=' + finalSlug, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          data: { title: trimmedName, excerpt: '', cover: '' },
+          content: ''
+        })
+      })
+      if (!response.ok) {
+        throw new Error('No se pudo crear el servicio. Probá con otro nombre.')
+      }
+      window.location.href = '/admin/services/' + finalSlug
+    } catch (err) {
+      console.error(err)
+      setError(err instanceof Error ? err.message : 'Ocurrió un error inesperado.')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="py-10 space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-3xl font-extrabold">Servicios</h1>
+        <p className="text-sm text-gray-600">Creá, editá y ordená la información que se muestra en la sección de servicios del sitio.</p>
+      </header>
+
+      <div className="card space-y-4">
+        <div>
+          <h2 className="font-semibold text-lg">Agregar un servicio nuevo</h2>
+          <p className="text-sm text-gray-600">Usá un nombre descriptivo. La URL pública se genera automáticamente pero podés ajustarla.</p>
+        </div>
+
+        <div>
+          <label>Nombre del servicio</label>
+          <input
+            value={name}
+            onChange={(event)=>handleNameChange(event.target.value)}
+            placeholder="Ej. Mantenimiento de subestaciones"
+          />
+        </div>
+
+        <div>
+          <label>URL pública</label>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-500">/services/</span>
+            <input
+              value={slugTouched ? slug : computedSlug}
+              onChange={(event)=>{ setSlug(event.target.value); setSlugTouched(true) }}
+              placeholder="mantenimiento-industrial"
+            />
+          </div>
+          <p className="text-xs text-gray-500 mt-1">Solo letras minúsculas, números y guiones medios.</p>
+        </div>
+
+        {error && <p className="text-sm text-red-600">{error}</p>}
+
+        <button className="btn" onClick={create} disabled={creating}>
+          {creating ? 'Creando…' : 'Crear servicio'}
+        </button>
+      </div>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="font-semibold text-lg">Servicios existentes</h2>
+          <p className="text-sm text-gray-600">Hacé clic en cualquiera para editar su contenido y las imágenes.</p>
+        </div>
+        {items.length === 0 ? (
+          <p className="text-sm text-gray-600">Todavía no hay servicios cargados.</p>
+        ) : (
+          <ul className="grid md:grid-cols-3 gap-4">
+            {items.map(slugValue => (
+              <li key={slugValue} className="card flex flex-col gap-1">
+                <span className="font-medium">{formatSlugLabel(slugValue)}</span>
+                <span className="text-xs text-gray-500">/services/{slugValue}</span>
+                <div className="flex gap-2">
+                  <Link className="btn" href={`/admin/services/${slugValue}` as Route}>Editar</Link>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
     </div>
-    <ul className="grid md:grid-cols-3 gap-4">
-      {items.map(s => (
-        <li key={s} className="card flex justify-between items-center">
-          <span>{s}</span>
-          <div className="flex gap-2"><Link className="btn" href={`/admin/services/${s}` as Route}>Editar</Link></div>
-        </li>
-      ))}
-    </ul>
-  </div>)
+  )
 }


### PR DESCRIPTION
## Resumen
- Simplifiqué la creación de servicios con un formulario guiado que sugiere la URL automáticamente y valida los datos antes de guardar.
- Mejoré la lista de servicios existentes con títulos legibles y recordatorios de la URL pública.
- Rediseñé la pantalla de edición para mostrar etiquetas en español, mensajes de estado y ayudas contextuales sobre el contenido y las imágenes.

## Pruebas
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc109c793c8331886c6e5b654b9316