### PR TITLE
Ensure tsconfig includes baseUrl alias mapping

### DIFF
--- a/nerin-electric-site-v3-fixed/tsconfig.json
+++ b/nerin-electric-site-v3-fixed/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
     "target": "ES2022",
     "lib": ["dom", "dom.iterable", "es2022"],
     "allowJs": false,
@@ -13,10 +17,6 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./*"]
-    },
     "types": ["node"],
     "plugins": [{ "name": "next" }]
   },


### PR DESCRIPTION
## Summary
- move the `baseUrl` and `paths` options to the top of `compilerOptions` in `tsconfig.json` to highlight the project alias configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e97f44dbf08331a0fabbfb6ff659a1