### PR TITLE
Set home page to force dynamic rendering

### DIFF
--- a/nerin-electric-site-v3-fixed/app/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import Image from 'next/image'
 import Link from 'next/link'
 import { prisma } from '@/lib/prisma'


### PR DESCRIPTION
## Summary
- add a dynamic export at the top of the home page to force runtime rendering when Prisma is used

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e98d09fb44833188601d394f61b32f