### PR TITLE
Ensure prisma-driven pages opt out of static rendering

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import { getSession } from '@/lib/auth'

--- a/nerin-electric-site-v3-fixed/app/clientes/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/clientes/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { getSession } from '@/lib/auth'

--- a/nerin-electric-site-v3-fixed/app/obras/[slug]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/obras/[slug]/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { notFound } from 'next/navigation'
 import { prisma } from '@/lib/prisma'
 import { Badge } from '@/components/ui/badge'


### PR DESCRIPTION
## Summary
- add the `export const dynamic = 'force-dynamic'` flag to prisma-backed pages missing it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e98d70ccfc8331bad7c0f16bce4d65