### PR TITLE
Restore default port fallback in start script

### DIFF
--- a/nerin-electric-site-v3-fixed/package.json
+++ b/nerin-electric-site-v3-fixed/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "prisma generate && next build",
-    "start": "prisma migrate deploy && next start -p $PORT",
+    "start": "prisma migrate deploy && next start -p ${PORT:-3000}",
     "lint": "next lint",
     "format": "prettier --write .",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- restore the default port fallback when running the Next.js start command so npm start works without a PORT env var

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e9b0d65e08833182527abfad5b400f