### PR TITLE
Add missing oauth4webapi dependency for NextAuth

### DIFF
--- a/nerin-electric-site-v3-fixed/package-lock.json
+++ b/nerin-electric-site-v3-fixed/package-lock.json
@@ -26,6 +26,7 @@
         "next-auth": "^5.0.0-beta.29",
         "next-sitemap": "4.2.3",
         "nodemailer": "^6.10.1",
+        "oauth4webapi": "^3.8.2",
         "pdfkit": "0.13.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",

--- a/nerin-electric-site-v3-fixed/package.json
+++ b/nerin-electric-site-v3-fixed/package.json
@@ -41,6 +41,7 @@
     "nodemailer": "^6.10.1",
     "pdfkit": "0.13.0",
     "nodemailer": "6.9.16",
+    "oauth4webapi": "^3.8.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-hook-form": "7.53.0",


### PR DESCRIPTION
## Summary
- add oauth4webapi to the app dependencies so NextAuth's OAuth helpers are available during the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ea5ee1f8b08331bd7a636ca9231942