### PR TITLE
Fix Prisma schema to avoid requiring DIRECT_URL

### DIFF
--- a/nerin-electric-site-v3-fixed/prisma/schema.prisma
+++ b/nerin-electric-site-v3-fixed/prisma/schema.prisma
@@ -8,7 +8,6 @@ generator client {
 datasource db {
   provider = "postgresql"
   url       = env("DATABASE_URL")
-  directUrl = env("DIRECT_URL") // OK si no está seteada; Prisma la ignora
 }
 
 enum Role {


### PR DESCRIPTION
## Summary
- remove the directUrl configuration from the Prisma datasource so deployments without the DIRECT_URL variable succeed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea63e67004833180063eb80a755092