### PR TITLE
Set Prisma directUrl to use DATABASE_URL fallback

### DIFF
--- a/nerin-electric-site-v3-fixed/prisma/schema.prisma
+++ b/nerin-electric-site-v3-fixed/prisma/schema.prisma
@@ -8,6 +8,8 @@ generator client {
 datasource db {
   provider = "postgresql"
   url       = env("DATABASE_URL")
+  // Render no define DIRECT_URL por defecto; Prisma requiere un valor si la clave existe
+  directUrl = env("DATABASE_URL")
 }
 
 enum Role {


### PR DESCRIPTION
## Summary
- configure Prisma's directUrl to reuse DATABASE_URL so deployments without DIRECT_URL succeed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea6eb44ed88331b56447bb1fd8119f