### PR TITLE
Add marketing data fallbacks for marketing pages

### DIFF
--- a/nerin-electric-site-v3-fixed/app/empresa/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/empresa/page.tsx
@@ -2,15 +2,12 @@ export const dynamic = 'force-dynamic'
 import Image from 'next/image'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { prisma } from '@/lib/db'
+import { getTechniciansForMarketing } from '@/lib/marketing-data'
 
 export const revalidate = 60
 
 export default async function EmpresaPage() {
-  const technicians = await prisma.technician.findMany({
-    where: { activo: true },
-    include: { user: true },
-  })
+  const technicians = await getTechniciansForMarketing()
 
   return (
     <div className="space-y-12">
@@ -57,7 +54,7 @@ export default async function EmpresaPage() {
           {technicians.map((tech) => (
             <Card key={tech.id} className="space-y-3">
               <CardHeader>
-                <CardTitle>{tech.user?.name}</CardTitle>
+                <CardTitle>{tech.nombre}</CardTitle>
                 <p className="text-sm text-slate-500">{tech.credenciales.join(' · ')}</p>
               </CardHeader>
               {tech.fotoUrl ? (
@@ -65,7 +62,7 @@ export default async function EmpresaPage() {
                   src={tech.fotoUrl}
                   width={400}
                   height={300}
-                  alt={`Técnico NERIN ${tech.user?.name}`}
+                  alt={`Técnico NERIN ${tech.nombre}`}
                   className="h-40 w-full rounded-2xl object-cover"
                 />
               ) : (

--- a/nerin-electric-site-v3-fixed/app/mantenimiento/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/mantenimiento/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic'
 import Link from 'next/link'
-import { prisma } from '@/lib/db'
+import { getMaintenancePlansForMarketing } from '@/lib/marketing-data'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 export const revalidate = 60
 
 export default async function MantenimientoPage() {
-  const plans = await prisma.maintenancePlan.findMany({ orderBy: { precioMensual: 'asc' } })
+  const plans = await getMaintenancePlansForMarketing()
 
   return (
     <div className="space-y-12">

--- a/nerin-electric-site-v3-fixed/app/obras/[slug]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/obras/[slug]/page.tsx
@@ -1,7 +1,7 @@
 export const dynamic = 'force-dynamic'
 
 import { notFound } from 'next/navigation'
-import { prisma } from '@/lib/db'
+import { getCaseStudyBySlug } from '@/lib/marketing-data'
 import { Badge } from '@/components/ui/badge'
 
 export const revalidate = 60
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export default async function ObraDetallePage({ params }: Props) {
-  const caseStudy = await prisma.caseStudy.findUnique({ where: { slug: params.slug } })
+  const caseStudy = await getCaseStudyBySlug(params.slug)
   if (!caseStudy) {
     notFound()
   }
@@ -26,9 +26,9 @@ export default async function ObraDetallePage({ params }: Props) {
           <p key={index}>{paragraph}</p>
         ))}
       </div>
-      {caseStudy.metricas && Array.isArray(caseStudy.metricas) && (
+      {caseStudy.metricas.length > 0 && (
         <section className="grid gap-4 md:grid-cols-3">
-          {(caseStudy.metricas as Array<{ label: string; value: string }>).map((metric) => (
+          {caseStudy.metricas.map((metric) => (
             <div key={metric.label} className="rounded-2xl border border-border bg-white p-4 shadow-subtle">
               <p className="text-sm text-slate-500">{metric.label}</p>
               <p className="text-lg font-semibold text-foreground">{metric.value}</p>

--- a/nerin-electric-site-v3-fixed/app/obras/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/obras/page.tsx
@@ -1,13 +1,13 @@
 export const dynamic = 'force-dynamic'
 import Link from 'next/link'
-import { prisma } from '@/lib/db'
+import { getCaseStudiesForMarketing } from '@/lib/marketing-data'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 export const revalidate = 60
 
 export default async function ObrasPage() {
-  const caseStudies = await prisma.caseStudy.findMany({ orderBy: { createdAt: 'desc' } })
+  const caseStudies = await getCaseStudiesForMarketing()
 
   return (
     <div className="space-y-8">

--- a/nerin-electric-site-v3-fixed/app/packs/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/packs/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic'
 import Link from 'next/link'
-import { prisma } from '@/lib/db'
+import { getPacksForMarketing } from '@/lib/marketing-data'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -8,12 +8,7 @@ import { Badge } from '@/components/ui/badge'
 export const revalidate = 60
 
 export default async function PacksPage() {
-  const packs = await prisma.pack.findMany({
-    include: {
-      additionalItems: true,
-    },
-    orderBy: { precioManoObraBase: 'asc' },
-  })
+  const packs = await getPacksForMarketing()
 
   return (
     <div className="space-y-16">

--- a/nerin-electric-site-v3-fixed/app/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic'
 
 import Image from 'next/image'
 import Link from 'next/link'
-import { prisma } from '@/lib/db'
+import { getMarketingHomeData } from '@/lib/marketing-data'
 import { siteConfig } from '@/lib/config'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -59,18 +59,8 @@ const faqs = [
   },
 ]
 
-async function getData() {
-  const [packs, plans, caseStudies, brands] = await Promise.all([
-    prisma.pack.findMany({ orderBy: { precioManoObraBase: 'asc' }, take: 3 }),
-    prisma.maintenancePlan.findMany({ orderBy: { precioMensual: 'asc' } }),
-    prisma.caseStudy.findMany({ where: { publicado: true }, take: 2 }),
-    prisma.brand.findMany({ take: 8 }),
-  ])
-  return { packs, plans, caseStudies, brands }
-}
-
 export default async function HomePage() {
-  const { packs, plans, caseStudies, brands } = await getData()
+  const { packs, plans, caseStudies, brands } = await getMarketingHomeData()
 
   return (
     <div className="space-y-24">

--- a/nerin-electric-site-v3-fixed/app/presupuestador/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/presupuestador/page.tsx
@@ -1,13 +1,12 @@
 export const dynamic = 'force-dynamic'
-import { prisma } from '@/lib/db'
+import { getConfiguratorData } from '@/lib/marketing-data'
 import { Badge } from '@/components/ui/badge'
 import { ConfiguratorWizard } from '@/components/configurator/ConfiguratorWizard'
 
 export const revalidate = 60
 
 export default async function PresupuestadorPage({ searchParams }: { searchParams: { pack?: string } }) {
-  const packs = await prisma.pack.findMany({ orderBy: { precioManoObraBase: 'asc' } })
-  const adicionales = await prisma.additionalItem.findMany({ orderBy: { nombre: 'asc' } })
+  const { packs, adicionales } = await getConfiguratorData()
   const defaultPack = searchParams.pack
     ? packs.find((pack) => pack.slug === searchParams.pack)?.id
     : undefined
@@ -28,7 +27,7 @@ export default async function PresupuestadorPage({ searchParams }: { searchParam
     descripcion: item.descripcion,
     unidad: item.unidad,
     precioUnitarioManoObra: item.precioUnitarioManoObra,
-    reglasCompatibilidad: item.reglasCompatibilidad,
+    reglasCompatibilidad: item.reglasCompatibilidad ?? null,
     packId: item.packId,
   }))
 

--- a/nerin-electric-site-v3-fixed/components/configurator/types.ts
+++ b/nerin-electric-site-v3-fixed/components/configurator/types.ts
@@ -1,13 +1,23 @@
-import { AdditionalItem, Pack } from '@prisma/client'
-
-export type WizardPack = Pick<Pack, 'id' | 'slug' | 'nombre' | 'descripcion' | 'bocasIncluidas' | 'ambientesReferencia' | 'precioManoObraBase'> & {
+export interface WizardPack {
+  id: string
+  slug: string
+  nombre: string
+  descripcion: string
   alcanceDetallado: string[]
+  bocasIncluidas: number
+  ambientesReferencia: number
+  precioManoObraBase: number
 }
 
-export type WizardAdditional = Pick<
-  AdditionalItem,
-  'id' | 'nombre' | 'descripcion' | 'unidad' | 'precioUnitarioManoObra' | 'reglasCompatibilidad'
-> & { packId?: string | null }
+export interface WizardAdditional {
+  id: string
+  nombre: string
+  descripcion: string
+  unidad: string
+  precioUnitarioManoObra: number
+  reglasCompatibilidad?: Record<string, unknown> | null
+  packId?: string | null
+}
 
 export interface WizardSummary {
   packId: string

--- a/nerin-electric-site-v3-fixed/lib/marketing-data.ts
+++ b/nerin-electric-site-v3-fixed/lib/marketing-data.ts
@@ -1,0 +1,522 @@
+import { prisma } from '@/lib/db'
+
+export interface AdditionalItemForUI {
+  id: string
+  nombre: string
+  descripcion: string
+  unidad: string
+  precioUnitarioManoObra: number
+  reglasCompatibilidad?: Record<string, unknown> | null
+  packId?: string | null
+}
+
+export interface PackForUI {
+  id: string
+  slug: string
+  nombre: string
+  descripcion: string
+  alcanceDetallado: string[]
+  bocasIncluidas: number
+  ambientesReferencia: number
+  precioManoObraBase: number
+  soloManoObra?: boolean
+  additionalItems: AdditionalItemForUI[]
+}
+
+export interface MaintenancePlanForUI {
+  id: string
+  slug: string
+  nombre: string
+  incluyeTareasFijas: string[]
+  visitasMes: number
+  precioMensual: number
+  cantidadesFijasInalterables?: boolean
+}
+
+export interface CaseStudyForUI {
+  id: string
+  slug: string
+  titulo: string
+  resumen: string
+  contenido: string
+  metricas: Array<{ label: string; value: string }>
+  fotos: string[]
+}
+
+export interface BrandForUI {
+  id: string
+  nombre: string
+  logoUrl?: string | null
+}
+
+export interface TechnicianForUI {
+  id: string
+  nombre: string
+  credenciales: string[]
+  fotoUrl?: string | null
+}
+
+const fallbackAdditionalItems: AdditionalItemForUI[] = [
+  {
+    id: 'fallback-add-1',
+    nombre: 'Colocación de artefacto de iluminación',
+    descripcion: 'Montaje, conexionado y puesta en marcha de artefactos provistos por el cliente.',
+    unidad: 'unidad',
+    precioUnitarioManoObra: 15000,
+    reglasCompatibilidad: null,
+    packId: null,
+  },
+  {
+    id: 'fallback-add-2',
+    nombre: 'Tablero seccional adicional',
+    descripcion: 'Armado de tablero con protecciones termomagnéticas y diferencial.',
+    unidad: 'tablero',
+    precioUnitarioManoObra: 320000,
+    reglasCompatibilidad: null,
+    packId: null,
+  },
+  {
+    id: 'fallback-add-3',
+    nombre: 'CCTV por cámara',
+    descripcion: 'Instalación y conexionado de cámara CCTV con ajuste y prueba.',
+    unidad: 'cámara',
+    precioUnitarioManoObra: 42000,
+    reglasCompatibilidad: null,
+    packId: null,
+  },
+  {
+    id: 'fallback-add-4',
+    nombre: 'Punto de datos categoría 6A',
+    descripcion: 'Cableado y certificación de punto de red para oficina u hogar.',
+    unidad: 'punto',
+    precioUnitarioManoObra: 28000,
+    reglasCompatibilidad: null,
+    packId: null,
+  },
+  {
+    id: 'fallback-add-5',
+    nombre: 'Circuito para bomba elevadora',
+    descripcion: 'Cañería, cableado y protecciones dedicadas para bomba.',
+    unidad: 'circuito',
+    precioUnitarioManoObra: 180000,
+    reglasCompatibilidad: null,
+    packId: null,
+  },
+  {
+    id: 'fallback-add-6',
+    nombre: 'Preinstalación de split',
+    descripcion: 'Cañería de cobre, desagüe y alimentación eléctrica independiente.',
+    unidad: 'equipo',
+    precioUnitarioManoObra: 95000,
+    reglasCompatibilidad: null,
+    packId: null,
+  },
+  {
+    id: 'fallback-add-7',
+    nombre: 'Cableado de audio distribuido',
+    descripcion: 'Canalización y tendido para sistema de audio multizona.',
+    unidad: 'zona',
+    precioUnitarioManoObra: 70000,
+    reglasCompatibilidad: null,
+    packId: null,
+  },
+  {
+    id: 'fallback-add-8',
+    nombre: 'Zanjeo y cañería exterior',
+    descripcion: 'Zanja con cañería PVC reforzada para alimentaciones exteriores.',
+    unidad: 'metro lineal',
+    precioUnitarioManoObra: 35000,
+    reglasCompatibilidad: null,
+    packId: null,
+  },
+  {
+    id: 'fallback-add-9',
+    nombre: 'Puesta a tierra suplementaria',
+    descripcion: 'Instalación de jabalina adicional con medición final.',
+    unidad: 'jabalina',
+    precioUnitarioManoObra: 120000,
+    reglasCompatibilidad: null,
+    packId: null,
+  },
+]
+
+const fallbackPacks: PackForUI[] = [
+  {
+    id: 'fallback-pack-1',
+    slug: 'vivienda-estandar',
+    nombre: 'Vivienda Estándar',
+    descripcion: 'Pack para departamentos o PH hasta 120 m². Incluye tablero principal, cableado y puesta a tierra básica.',
+    alcanceDetallado: [
+      'Canalización EMT y bandejas vistas donde aplique',
+      'Tablero principal con protecciones curvas C',
+      'Circuitos independientes para AA, cocina y tomas generales',
+      'Puesta a tierra con jabalina de 2.4 m',
+      'Certificado de mediciones',
+    ],
+    bocasIncluidas: 60,
+    ambientesReferencia: 6,
+    precioManoObraBase: 2_500_000,
+    soloManoObra: true,
+    additionalItems: fallbackAdditionalItems.slice(0, 4),
+  },
+  {
+    id: 'fallback-pack-2',
+    slug: 'casa-country-1',
+    nombre: 'Casa Country 1',
+    descripcion: 'Pack para viviendas premium hasta 250 m² con doble tablero y previsión de domótica.',
+    alcanceDetallado: [
+      'Doble tablero con seccional por planta',
+      'Circuito exclusivo para piscina y bomba',
+      'Preinstalación domótica y cableado de datos categoría 6A',
+      'Puesta a tierra mejorada con anillo perimetral',
+      'Documentación completa y ensayos finales',
+    ],
+    bocasIncluidas: 120,
+    ambientesReferencia: 10,
+    precioManoObraBase: 5_200_000,
+    soloManoObra: true,
+    additionalItems: fallbackAdditionalItems.slice(2, 7),
+  },
+  {
+    id: 'fallback-pack-3',
+    slug: 'casa-country-2',
+    nombre: 'Casa Country 2',
+    descripcion: 'Pack para residencias superiores a 250 m² con tableros múltiples y backup.',
+    alcanceDetallado: [
+      'Tableros seccionales por planta y exteriores',
+      'Integración con grupo electrógeno y UPS',
+      'Circuito para sala de máquinas y presurizadora',
+      'Canalizaciones ocultas con bandejas portacables',
+      'Planos, memorias y certificación final',
+    ],
+    bocasIncluidas: 180,
+    ambientesReferencia: 14,
+    precioManoObraBase: 7_800_000,
+    soloManoObra: true,
+    additionalItems: fallbackAdditionalItems.slice(4),
+  },
+]
+
+const fallbackMaintenancePlans: MaintenancePlanForUI[] = [
+  {
+    id: 'fallback-plan-basic',
+    slug: 'basic',
+    nombre: 'BASIC',
+    incluyeTareasFijas: ['Revisión de 10 lámparas LED', 'Chequeo de tableros', 'Informe mensual'],
+    visitasMes: 1,
+    precioMensual: 180_000,
+    cantidadesFijasInalterables: true,
+  },
+  {
+    id: 'fallback-plan-pro',
+    slug: 'pro',
+    nombre: 'PRO',
+    incluyeTareasFijas: ['20 lámparas LED', 'Termografía bimestral', 'Chequeo de bombas'],
+    visitasMes: 2,
+    precioMensual: 320_000,
+    cantidadesFijasInalterables: true,
+  },
+  {
+    id: 'fallback-plan-enterprise',
+    slug: 'enterprise',
+    nombre: 'ENTERPRISE',
+    incluyeTareasFijas: ['40 lámparas LED', 'Guardia de urgencias', 'Reportes ejecutivos'],
+    visitasMes: 4,
+    precioMensual: 620_000,
+    cantidadesFijasInalterables: true,
+  },
+]
+
+const fallbackCaseStudies: CaseStudyForUI[] = [
+  {
+    id: 'fallback-case-1',
+    slug: 'edificio-4000',
+    titulo: 'Edificio corporativo 4.000 m²',
+    resumen: 'Adecuación completa de tablero general, CCTV y grupo electrógeno para edificio AAA.',
+    contenido:
+      'El desafío fue migrar la instalación existente sin cortar suministro crítico. Implementamos tableros modulares, cableado LSZH y monitoreo remoto. Cumplimos normativa AEA 90364-7-771 y entregamos documentación completa.',
+    metricas: [
+      { label: 'Tiempo de obra', value: '90 días' },
+      { label: 'Circuitos', value: '120' },
+    ],
+    fotos: [],
+  },
+  {
+    id: 'fallback-case-2',
+    slug: 'smart-fit',
+    titulo: 'Smart Fit - Red de gimnasios',
+    resumen: 'Implementación de tableros, datos y CCTV para múltiples sedes simultáneas.',
+    contenido:
+      'Coordinamos logística y montaje nocturno para minimizar cierres. Cada sede recibió tableros nuevos, canalizaciones ocultas y cableado estructurado certificado. Implementamos checklist digital y reportes diarios.',
+    metricas: [
+      { label: 'Sedes', value: '6' },
+      { label: 'Horas fuera de servicio', value: '<4 h por sede' },
+    ],
+    fotos: [],
+  },
+]
+
+const fallbackBrands: BrandForUI[] = [
+  { id: 'fallback-brand-1', nombre: 'Schneider Electric' },
+  { id: 'fallback-brand-2', nombre: 'Prysmian' },
+  { id: 'fallback-brand-3', nombre: 'Gimsa' },
+  { id: 'fallback-brand-4', nombre: 'Daisa' },
+  { id: 'fallback-brand-5', nombre: 'Genrock' },
+]
+
+const fallbackTechnicians: TechnicianForUI[] = [
+  {
+    id: 'fallback-tech-1',
+    nombre: 'Ing. Laura Fernández',
+    credenciales: ['Mat. COPIME 12345', 'Especialista en Tableros BT'],
+    fotoUrl: null,
+  },
+  {
+    id: 'fallback-tech-2',
+    nombre: 'Téc. Martín Gómez',
+    credenciales: ['Habilitación ENRE', 'Termografía nivel II'],
+    fotoUrl: null,
+  },
+  {
+    id: 'fallback-tech-3',
+    nombre: 'Ing. Paula Ríos',
+    credenciales: ['Project Manager', 'AEA 90364-7-771'],
+    fotoUrl: null,
+  },
+]
+
+function logFallback(context: string, error: unknown) {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(`[marketing-data] ${context}: ${message}`)
+}
+
+function parseMetricas(metricas: unknown): Array<{ label: string; value: string }> {
+  if (!Array.isArray(metricas)) {
+    return []
+  }
+  return metricas
+    .map((item) => {
+      if (item && typeof item === 'object' && 'label' in item && 'value' in item) {
+        const label = String((item as Record<string, unknown>).label)
+        const value = String((item as Record<string, unknown>).value)
+        return { label, value }
+      }
+      return null
+    })
+    .filter((item): item is { label: string; value: string } => Boolean(item))
+}
+
+export async function getPacksForMarketing(): Promise<PackForUI[]> {
+  try {
+    const packs = await prisma.pack.findMany({
+      include: { additionalItems: true },
+      orderBy: { precioManoObraBase: 'asc' },
+    })
+
+    if (!packs.length) {
+      return fallbackPacks
+    }
+
+    return packs.map((pack) => ({
+      id: pack.id,
+      slug: pack.slug,
+      nombre: pack.nombre,
+      descripcion: pack.descripcion,
+      alcanceDetallado: pack.alcanceDetallado,
+      bocasIncluidas: pack.bocasIncluidas,
+      ambientesReferencia: pack.ambientesReferencia,
+      precioManoObraBase: Number(pack.precioManoObraBase),
+      soloManoObra: pack.soloManoObra,
+      additionalItems:
+        pack.additionalItems?.map((item) => ({
+          id: item.id,
+          nombre: item.nombre,
+          descripcion: item.descripcion,
+          unidad: item.unidad,
+          precioUnitarioManoObra: Number(item.precioUnitarioManoObra),
+          reglasCompatibilidad: (item.reglasCompatibilidad as Record<string, unknown> | null) ?? null,
+          packId: item.packId,
+        })) ?? [],
+    }))
+  } catch (error) {
+    logFallback('packs', error)
+    return fallbackPacks
+  }
+}
+
+export async function getMaintenancePlansForMarketing(): Promise<MaintenancePlanForUI[]> {
+  try {
+    const plans = await prisma.maintenancePlan.findMany({
+      orderBy: { precioMensual: 'asc' },
+    })
+
+    if (!plans.length) {
+      return fallbackMaintenancePlans
+    }
+
+    return plans.map((plan) => ({
+      id: plan.id,
+      slug: plan.slug,
+      nombre: plan.nombre,
+      incluyeTareasFijas: plan.incluyeTareasFijas,
+      visitasMes: plan.visitasMes,
+      precioMensual: Number(plan.precioMensual),
+      cantidadesFijasInalterables: plan.cantidadesFijasInalterables,
+    }))
+  } catch (error) {
+    logFallback('maintenance plans', error)
+    return fallbackMaintenancePlans
+  }
+}
+
+export async function getCaseStudiesForMarketing(): Promise<CaseStudyForUI[]> {
+  try {
+    const caseStudies = await prisma.caseStudy.findMany({
+      where: { publicado: true },
+      orderBy: { createdAt: 'desc' },
+    })
+
+    if (!caseStudies.length) {
+      return fallbackCaseStudies
+    }
+
+    return caseStudies.map((cs) => ({
+      id: cs.id,
+      slug: cs.slug,
+      titulo: cs.titulo,
+      resumen: cs.resumen,
+      contenido: cs.contenido,
+      metricas: parseMetricas(cs.metricas),
+      fotos: cs.fotos ?? [],
+    }))
+  } catch (error) {
+    logFallback('case studies', error)
+    return fallbackCaseStudies
+  }
+}
+
+export async function getCaseStudyBySlug(slug: string): Promise<CaseStudyForUI | null> {
+  try {
+    const caseStudy = await prisma.caseStudy.findUnique({ where: { slug } })
+    if (!caseStudy) {
+      return fallbackCaseStudies.find((item) => item.slug === slug) ?? null
+    }
+
+    return {
+      id: caseStudy.id,
+      slug: caseStudy.slug,
+      titulo: caseStudy.titulo,
+      resumen: caseStudy.resumen,
+      contenido: caseStudy.contenido,
+      metricas: parseMetricas(caseStudy.metricas),
+      fotos: caseStudy.fotos ?? [],
+    }
+  } catch (error) {
+    logFallback(`case study ${slug}`, error)
+    return fallbackCaseStudies.find((item) => item.slug === slug) ?? null
+  }
+}
+
+export async function getBrandsForMarketing(): Promise<BrandForUI[]> {
+  try {
+    const brands = await prisma.brand.findMany({ orderBy: { nombre: 'asc' } })
+    if (!brands.length) {
+      return fallbackBrands
+    }
+    return brands.map((brand) => ({
+      id: brand.id,
+      nombre: brand.nombre,
+      logoUrl: brand.logoUrl,
+    }))
+  } catch (error) {
+    logFallback('brands', error)
+    return fallbackBrands
+  }
+}
+
+export async function getTechniciansForMarketing(): Promise<TechnicianForUI[]> {
+  try {
+    const technicians = await prisma.technician.findMany({
+      where: { activo: true },
+      include: { user: true },
+    })
+
+    if (!technicians.length) {
+      return fallbackTechnicians
+    }
+
+    return technicians.map((tech) => ({
+      id: tech.id,
+      nombre: tech.user?.name ?? 'Equipo NERIN',
+      credenciales: tech.credenciales,
+      fotoUrl: tech.fotoUrl,
+    }))
+  } catch (error) {
+    logFallback('technicians', error)
+    return fallbackTechnicians
+  }
+}
+
+export async function getConfiguratorData(): Promise<{
+  packs: PackForUI[]
+  adicionales: AdditionalItemForUI[]
+}> {
+  try {
+    const [packs, adicionales] = await Promise.all([
+      prisma.pack.findMany({ orderBy: { precioManoObraBase: 'asc' } }),
+      prisma.additionalItem.findMany({ orderBy: { nombre: 'asc' } }),
+    ])
+
+    const normalizedPacks = packs.map((pack) => ({
+      id: pack.id,
+      slug: pack.slug,
+      nombre: pack.nombre,
+      descripcion: pack.descripcion,
+      alcanceDetallado: pack.alcanceDetallado,
+      bocasIncluidas: pack.bocasIncluidas,
+      ambientesReferencia: pack.ambientesReferencia,
+      precioManoObraBase: Number(pack.precioManoObraBase),
+      soloManoObra: pack.soloManoObra,
+      additionalItems: [],
+    }))
+
+    const normalizedAdicionales = adicionales.map((item) => ({
+      id: item.id,
+      nombre: item.nombre,
+      descripcion: item.descripcion,
+      unidad: item.unidad,
+      precioUnitarioManoObra: Number(item.precioUnitarioManoObra),
+      reglasCompatibilidad: (item.reglasCompatibilidad as Record<string, unknown> | null) ?? null,
+      packId: item.packId,
+    }))
+
+    return {
+      packs: normalizedPacks.length ? normalizedPacks : fallbackPacks,
+      adicionales: normalizedAdicionales.length ? normalizedAdicionales : fallbackAdditionalItems,
+    }
+  } catch (error) {
+    logFallback('configurator data', error)
+    return { packs: fallbackPacks, adicionales: fallbackAdditionalItems }
+  }
+}
+
+export async function getMarketingHomeData(): Promise<{
+  packs: PackForUI[]
+  plans: MaintenancePlanForUI[]
+  caseStudies: CaseStudyForUI[]
+  brands: BrandForUI[]
+}> {
+  const [packs, plans, caseStudies, brands] = await Promise.all([
+    getPacksForMarketing(),
+    getMaintenancePlansForMarketing(),
+    getCaseStudiesForMarketing(),
+    getBrandsForMarketing(),
+  ])
+
+  return {
+    packs: packs.slice(0, 3),
+    plans: plans,
+    caseStudies: caseStudies.slice(0, 2),
+    brands: brands.slice(0, 8),
+  }
+}


### PR DESCRIPTION
## Summary
- add `lib/marketing-data` with static fallbacks and helpers to normalize Prisma results for marketing content
- switch marketing-oriented routes to the new helpers so they keep rendering when tables are missing
- update configurator types to be Prisma-agnostic and ensure the wizard continues working with fallback data

## Testing
- not run (npm install fails in container with ENOTEMPTY while cleaning node_modules)

------
https://chatgpt.com/codex/tasks/task_e_68ea7a484580833199fb25b796ba23a8