### PR TITLE
Mark accordion component as client component

### DIFF
--- a/nerin-electric-site-v3-fixed/components/ui/accordion.tsx
+++ b/nerin-electric-site-v3-fixed/components/ui/accordion.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 


### PR DESCRIPTION
## Summary
- declare the accordion component module as a client component so its stateful logic runs correctly on the client

## Testing
- npm run build *(fails: prisma command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea8bdc206c83318d7e426b97561c59