### PR TITLE
Handle magic link emails without Resend API key

### DIFF
--- a/nerin-electric-site-v3-fixed/lib/auth.ts
+++ b/nerin-electric-site-v3-fixed/lib/auth.ts
@@ -56,6 +56,12 @@ export const { handlers, auth, signIn, signOut } = NextAuth(async () => {
     sendVerificationRequest: async ({ identifier, url }) => {
       const to = identifier
 
+      const resendApiKey = process.env.RESEND_API_KEY
+      if (!resendApiKey || resendApiKey.startsWith('re_mock')) {
+        console.info('[AUTH:magic-link]', { to, url })
+        return
+      }
+
       await resendClient.emails.send({
         from: fromEmail,
         to,


### PR DESCRIPTION
## Summary
- prevent the email magic-link flow from calling Resend when no API key is configured
- log the generated magic link in development/mock environments so admins can still sign in

## Testing
- npm run lint *(fails: `next` CLI is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ece7513b6c833194e0bbf6987d9972