### PR TITLE
Exclude login routes from auth middleware

### DIFF
--- a/nerin-electric-site-v3-fixed/middleware.ts
+++ b/nerin-electric-site-v3-fixed/middleware.ts
@@ -31,5 +31,5 @@ export default auth(async (req) => {
 })
 
 export const config = {
-  matcher: ['/admin/:path*', '/clientes/:path*'],
+  matcher: ['/admin/:path*', '/clientes', '/clientes/(?!login$|verificar$).*'],
 }


### PR DESCRIPTION
## Summary
- update the auth middleware matcher so the login and verification routes bypass session checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ecef00ae148331ab39995edb4d6dcf