### PR TITLE
Fix middleware matcher for clientes routes

### DIFF
--- a/nerin-electric-site-v3-fixed/middleware.ts
+++ b/nerin-electric-site-v3-fixed/middleware.ts
@@ -31,5 +31,5 @@ export default auth(async (req) => {
 })
 
 export const config = {
-  matcher: ['/admin/:path*', '/clientes', '/clientes/(?!login$|verificar$).*'],
+  matcher: ['/admin/:path*', '/clientes/:path*'],
 }


### PR DESCRIPTION
## Summary
- replace the invalid clientes middleware matcher with a supported glob pattern
- keep middleware coverage for admin and clientes routes without excluding login/verificar paths explicitly

## Testing
- npm run build *(fails: prisma CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecfe2932948331a1dfaed994aa9146