### PR TITLE
Fix production login routing and improve auth logging

### DIFF
--- a/nerin-electric-site-v3-fixed/app/clientes/login/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/clientes/login/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState } from 'react'
-import { signIn } from 'next-auth/react'
+import { useEffect, useState } from 'react'
+import { signIn, useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -10,6 +11,17 @@ import { Label } from '@/components/ui/label'
 export default function LoginPage() {
   const [email, setEmail] = useState('')
   const [status, setStatus] = useState<'idle' | 'loading' | 'sent'>('idle')
+  const router = useRouter()
+  const { status: sessionStatus } = useSession()
+
+  const isSessionLoading = sessionStatus === 'loading'
+  const isAuthenticated = sessionStatus === 'authenticated'
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.replace('/clientes')
+    }
+  }, [isAuthenticated, router])
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -21,7 +33,7 @@ export default function LoginPage() {
   return (
     <div className="mx-auto max-w-md space-y-6">
       <Badge>Portal de clientes</Badge>
-      <h1>Ingresá con tu email</h1>
+      <h1>{isAuthenticated ? 'Redirigiendo a tu panel...' : 'Ingresá con tu email'}</h1>
       <p className="text-sm text-slate-600">
         Te enviaremos un enlace mágico para ingresar. Si todavía no tenés acceso, escribinos a hola@nerin.com.ar.
       </p>
@@ -35,9 +47,10 @@ export default function LoginPage() {
             value={email}
             onChange={(event) => setEmail(event.target.value)}
             placeholder="correo@empresa.com"
+            disabled={isSessionLoading || isAuthenticated}
           />
         </div>
-        <Button type="submit" disabled={status === 'loading'}>
+        <Button type="submit" disabled={status === 'loading' || isSessionLoading || isAuthenticated}>
           {status === 'loading' ? 'Enviando enlace...' : 'Enviar enlace de acceso'}
         </Button>
         {status === 'sent' && (

--- a/nerin-electric-site-v3-fixed/lib/logging.ts
+++ b/nerin-electric-site-v3-fixed/lib/logging.ts
@@ -1,0 +1,60 @@
+type SanitizedError = {
+  name: string
+  message: string
+  stack?: string
+}
+
+export function sanitizeError(error: unknown): SanitizedError {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: process.env.NODE_ENV === 'development' ? error.stack ?? undefined : undefined,
+    }
+  }
+
+  return {
+    name: 'UnknownError',
+    message: typeof error === 'string' ? error : JSON.stringify(error),
+  }
+}
+
+const sensitiveKeywords = ['secret', 'token', 'cookie', 'authorization']
+
+type Metadata = Record<string, unknown> | undefined
+
+export function sanitizeMetadata(metadata: Metadata) {
+  if (!metadata) {
+    return undefined
+  }
+
+  return Object.entries(metadata).reduce<Record<string, unknown>>((acc, [key, value]) => {
+    if (value instanceof Error) {
+      acc[key] = sanitizeError(value)
+      return acc
+    }
+
+    if (typeof value === 'string') {
+      const lowerKey = key.toLowerCase()
+      if (sensitiveKeywords.some((keyword) => lowerKey.includes(keyword))) {
+        acc[key] = '[redacted]'
+        return acc
+      }
+      acc[key] = value
+      return acc
+    }
+
+    if (Array.isArray(value)) {
+      acc[key] = value.map((item) => (item instanceof Error ? sanitizeError(item) : item))
+      return acc
+    }
+
+    if (value && typeof value === 'object') {
+      acc[key] = '[object]'
+      return acc
+    }
+
+    acc[key] = value as unknown
+    return acc
+  }, {})
+}

--- a/nerin-electric-site-v3-fixed/middleware.ts
+++ b/nerin-electric-site-v3-fixed/middleware.ts
@@ -1,9 +1,41 @@
+import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
+import { sanitizeError } from '@/lib/logging'
 
-const clientWhitelist = ['/clientes/login', '/clientes/verificar']
+const clientWhitelist = new Set(['/clientes/login', '/clientes/verificar'])
 
-export default auth(async (req) => {
+const adminDashboardRoute = '/admin' as const
+const clientDashboardRoute = '/clientes' as const
+
+async function resolveSession(req: NextRequest) {
+  try {
+    const session = await auth(req)
+    if (session?.user) {
+      console.info('[MIDDLEWARE] Session resolved', {
+        userId: session.user.id,
+        role: session.user.role,
+      })
+    }
+    return session
+  } catch (error) {
+    console.error('[MIDDLEWARE] Failed to resolve session', sanitizeError(error))
+    return null
+  }
+}
+
+function buildLogContext(req: NextRequest, normalizedPathname: string) {
+  return {
+    method: req.method,
+    pathname: req.nextUrl.pathname,
+    normalizedPathname,
+    host: req.headers.get('host') ?? undefined,
+    referer: req.headers.get('referer') ?? undefined,
+    userAgent: req.headers.get('user-agent') ?? undefined,
+  }
+}
+
+export default async function middleware(req: NextRequest) {
   const { pathname, locale } = req.nextUrl
 
   const normalizedPathname =
@@ -11,35 +43,60 @@ export default auth(async (req) => {
       ? pathname.slice(locale.length + 1) || '/'
       : pathname
 
-  if (clientWhitelist.includes(normalizedPathname)) {
+  console.info('[MIDDLEWARE] Incoming request', buildLogContext(req, normalizedPathname))
+
+  if (clientWhitelist.has(normalizedPathname)) {
+    if (normalizedPathname === '/clientes/login') {
+      const session = await resolveSession(req)
+      if (session?.user) {
+        const destination = session.user.role === 'admin' ? adminDashboardRoute : clientDashboardRoute
+        console.info('[MIDDLEWARE] Redirecting authenticated user away from login', {
+          destination,
+          userId: session.user.id,
+        })
+        const redirectUrl = req.nextUrl.clone()
+        redirectUrl.pathname = destination
+        return NextResponse.redirect(redirectUrl)
+      }
+    }
+
+    console.info('[MIDDLEWARE] Allowing public access', { pathname: normalizedPathname })
     return NextResponse.next()
   }
 
-  const session = req.auth
+  const session = await resolveSession(req)
 
   if (pathname.startsWith('/admin')) {
     if (!session) {
+      console.info('[MIDDLEWARE] Blocking unauthenticated admin request, redirecting to login')
       const signInUrl = req.nextUrl.clone()
       signInUrl.pathname = '/clientes/login'
       return NextResponse.redirect(signInUrl)
     }
     if (session.user?.role !== 'admin') {
+      console.info('[MIDDLEWARE] Blocking non-admin access to admin area', {
+        userId: session.user?.id,
+        role: session.user?.role,
+      })
       const clientUrl = req.nextUrl.clone()
-      clientUrl.pathname = '/clientes'
+      clientUrl.pathname = clientDashboardRoute
       return NextResponse.redirect(clientUrl)
     }
+    console.info('[MIDDLEWARE] Admin access granted', { userId: session.user?.id })
   }
 
   if (normalizedPathname.startsWith('/clientes')) {
     if (!session) {
+      console.info('[MIDDLEWARE] Redirecting unauthenticated client request to login')
       const signInUrl = req.nextUrl.clone()
       signInUrl.pathname = '/clientes/login'
       return NextResponse.redirect(signInUrl)
     }
+    console.info('[MIDDLEWARE] Client access granted', { userId: session.user?.id })
   }
 
   return NextResponse.next()
-})
+}
 
 export const config = {
   matcher: ['/admin/:path*', '/clientes/:path*'],


### PR DESCRIPTION
## Summary
- add middleware logging, protect client routes, and redirect authenticated users away from the public login form
- harden NextAuth configuration by trusting the proxy host, surfacing sanitized errors, and guarding against missing secrets in production
- update the client login page to auto-redirect authenticated sessions and disable the form while authentication state loads

## Testing
- ⚠️ `npm run lint` *(fails locally because npm install is blocked by repeated tarball corruption in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee3dc3ca78833190f5aefff6107218