### PR TITLE
Fix email magic link sign-in for admin login

### DIFF
--- a/nerin-electric-site-v3-fixed/app/clientes/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/clientes/page.tsx
@@ -17,6 +17,8 @@ export default async function ClienteDashboard() {
     redirect('/clientes/login')
   }
 
+  const displayName = session.user.name?.trim() || session.user.email || 'usuario'
+
   const client = await prisma.client.findUnique({
     where: { userId: session.user.id },
     include: {
@@ -33,7 +35,7 @@ export default async function ClienteDashboard() {
     <div className="space-y-10">
       <header className="space-y-2">
         <Badge>Portal de clientes</Badge>
-        <h1>Hola {session.user.name}</h1>
+        <h1>Hola {displayName}</h1>
         <p className="text-sm text-slate-600">
           {client?.approved
             ? 'Visualizá tus proyectos, certificados de avance y facturas en un solo lugar.'

--- a/nerin-electric-site-v3-fixed/lib/auth.ts
+++ b/nerin-electric-site-v3-fixed/lib/auth.ts
@@ -46,7 +46,7 @@ export const authOptions: NextAuthConfig = {
       if (session.user) {
         session.user.id = user.id
         session.user.role = user.role
-        session.user.name = user.name
+        session.user.name = user.name || user.email || session.user.name
         session.user.email = user.email
       }
       return session

--- a/nerin-electric-site-v3-fixed/prisma/migrations/20250218120000_add_default_user_name/migration.sql
+++ b/nerin-electric-site-v3-fixed/prisma/migrations/20250218120000_add_default_user_name/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "name" SET DEFAULT '';

--- a/nerin-electric-site-v3-fixed/prisma/schema.prisma
+++ b/nerin-electric-site-v3-fixed/prisma/schema.prisma
@@ -52,7 +52,7 @@ enum InvoiceStatus {
 
 model User {
   id            String   @id @default(cuid())
-  name          String
+  name          String   @default("")
   email         String   @unique
   role          Role     @default(cliente)
   empresa       String?


### PR DESCRIPTION
## Summary
- allow Prisma to create users without an explicit name and keep the schema in sync
- ensure session data and the client dashboard greet users with a sensible fallback when no name is stored

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f229caabbc8331a02828791473e3b1