### PR TITLE
Add missing emailVerified column for NextAuth

### DIFF
--- a/nerin-electric-site-v3-fixed/prisma/migrations/20250219090000_add_email_verified/migration.sql
+++ b/nerin-electric-site-v3-fixed/prisma/migrations/20250219090000_add_email_verified/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "emailVerified" TIMESTAMP(3);

--- a/nerin-electric-site-v3-fixed/prisma/schema.prisma
+++ b/nerin-electric-site-v3-fixed/prisma/schema.prisma
@@ -54,6 +54,7 @@ model User {
   id            String   @id @default(cuid())
   name          String   @default("")
   email         String   @unique
+  emailVerified DateTime?
   role          Role     @default(cliente)
   empresa       String?
   cuit          String?


### PR DESCRIPTION
## Summary
- add the optional `emailVerified` field to the Prisma `User` model so NextAuth can persist verification state
- create a database migration that adds the `emailVerified` column to the existing `User` table

## Testing
- npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68f3da7864a883319d8760631f4ced21