### PR TITLE
Add admin credential login and fix Render start command

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/login/login-form.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/login/login-form.tsx
@@ -1,15 +1,20 @@
-import { MagicLinkForm, type MagicLinkFormCopy } from '@/components/auth/magic-link-form'
+import {
+  AdminCredentialsForm,
+  type AdminCredentialsCopy,
+} from '@/components/auth/admin-credentials-form'
 
-const copy: MagicLinkFormCopy = {
-  cardTitle: 'Solicitá acceso seguro',
-  cardDescription: 'Usá tu correo corporativo para recibir el enlace de ingreso al panel.',
-  emailLabel: 'Correo corporativo',
-  placeholder: 'nombre@nerin.com.ar',
-  submitLabel: 'Enviar acceso al panel',
-  pendingLabel: 'Enviando enlace...',
-  successMessage: 'Abrí el enlace del correo para entrar al panel administrativo.',
+const copy: AdminCredentialsCopy = {
+  cardTitle: 'Ingresá con tu clave única',
+  cardDescription: 'Usá la cuenta administradora configurada para Render y accedé directo al panel.',
+  emailLabel: 'Correo administrador',
+  emailPlaceholder: 'admin@nerin.com.ar',
+  passwordLabel: 'Contraseña',
+  passwordPlaceholder: 'Tu contraseña segura',
+  submitLabel: 'Entrar al panel',
+  pendingLabel: 'Validando credenciales...',
+  errorMessage: 'Credenciales inválidas. Verificá el correo y la contraseña que configuraste.',
 }
 
 export function AdminLoginForm() {
-  return <MagicLinkForm {...copy} />
+  return <AdminCredentialsForm {...copy} />
 }

--- a/nerin-electric-site-v3-fixed/app/admin/login/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/login/page.tsx
@@ -10,17 +10,17 @@ export default function AdminLoginPage() {
           <Badge>Panel administrativo</Badge>
           <h1 className="text-3xl font-semibold tracking-tight">Ingresá al panel de administración</h1>
           <p className="text-sm text-slate-600">
-            Recibís un enlace de un solo uso en tu correo corporativo. Ese enlace te lleva directo al tablero para publicar
-            packs, casos de éxito y certificados de avance.
+            Ingresá usando la cuenta administradora configurada en Render. Con ese usuario único accedés directo al tablero
+            para publicar packs, casos de éxito y certificados de avance.
           </p>
           <ol className="space-y-3 text-sm text-slate-600">
             <li className="flex gap-2">
               <span className="mt-1 h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
-              Ingresá tu correo @nerin para verificar tu identidad.
+              Ingresá tu correo administrador.
             </li>
             <li className="flex gap-2">
               <span className="mt-1 h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
-              Abrí el enlace mágico y llegás directo al panel.
+              Escribí la contraseña segura que definiste en las variables de entorno.
             </li>
             <li className="flex gap-2">
               <span className="mt-1 h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
@@ -28,7 +28,7 @@ export default function AdminLoginPage() {
             </li>
           </ol>
           <p className="text-xs text-slate-500">
-            ¿Necesitás sumar a alguien del equipo? Escribinos a{' '}
+            ¿Necesitás sumar más cuentas o restablecer la clave? Escribinos a{' '}
             <a className="font-medium underline" href="mailto:hola@nerin.com.ar">
               hola@nerin.com.ar
             </a>

--- a/nerin-electric-site-v3-fixed/components/auth/admin-credentials-form.tsx
+++ b/nerin-electric-site-v3-fixed/components/auth/admin-credentials-form.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { signIn } from 'next-auth/react'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+export interface AdminCredentialsCopy {
+  cardTitle: string
+  cardDescription: string
+  emailLabel: string
+  emailPlaceholder: string
+  passwordLabel: string
+  passwordPlaceholder: string
+  submitLabel: string
+  pendingLabel: string
+  errorMessage: string
+}
+
+export function AdminCredentialsForm({
+  cardTitle,
+  cardDescription,
+  emailLabel,
+  emailPlaceholder,
+  passwordLabel,
+  passwordPlaceholder,
+  submitLabel,
+  pendingLabel,
+  errorMessage,
+}: AdminCredentialsCopy) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle')
+  const [message, setMessage] = useState('')
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const isLoading = status === 'loading'
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!email || !password) {
+      setStatus('error')
+      setMessage('Completá tu correo y contraseña para continuar.')
+      return
+    }
+
+    setStatus('loading')
+    setMessage('')
+
+    try {
+      const callbackUrl = searchParams?.get('callbackUrl') ?? '/admin'
+      const result = await signIn('admin-credentials', {
+        email,
+        password,
+        redirect: false,
+        callbackUrl,
+      })
+
+      if (!result || result.error) {
+        setStatus('error')
+        setMessage(errorMessage)
+        return
+      }
+
+      router.replace(result.url ?? callbackUrl)
+    } catch (error) {
+      console.error('[LOGIN] Error iniciando sesión administrador', error)
+      setStatus('error')
+      setMessage('No pudimos iniciar sesión. Intentá nuevamente en unos segundos.')
+    } finally {
+      setStatus('idle')
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-sm shrink-0 border border-emerald-100/60 shadow-lg shadow-emerald-100/40">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-lg">{cardTitle}</CardTitle>
+        <CardDescription>{cardDescription}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="email">{emailLabel}</Label>
+            <Input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(event) => {
+                setEmail(event.target.value)
+                if (status === 'error') {
+                  setStatus('idle')
+                  setMessage('')
+                }
+              }}
+              placeholder={emailPlaceholder}
+              autoComplete="username"
+              disabled={isLoading}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">{passwordLabel}</Label>
+            <Input
+              id="password"
+              type="password"
+              required
+              value={password}
+              onChange={(event) => {
+                setPassword(event.target.value)
+                if (status === 'error') {
+                  setStatus('idle')
+                  setMessage('')
+                }
+              }}
+              placeholder={passwordPlaceholder}
+              autoComplete="current-password"
+              disabled={isLoading}
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? pendingLabel : submitLabel}
+          </Button>
+          {message && <p className="text-xs text-red-600">{message}</p>}
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/nerin-electric-site-v3-fixed/lib/auth-adapter.ts
+++ b/nerin-electric-site-v3-fixed/lib/auth-adapter.ts
@@ -1,0 +1,80 @@
+import { PrismaAdapter } from '@auth/prisma-adapter'
+import type { Adapter, VerificationToken } from 'next-auth/adapters'
+import type { PrismaClient } from '@prisma/client'
+import { Prisma } from '@prisma/client'
+
+import { sanitizeError } from './logging'
+
+function normalizeIdentifier(identifier: string | undefined) {
+  return identifier?.trim().toLowerCase()
+}
+
+export function createAuthAdapter(prisma: PrismaClient): Adapter {
+  const baseAdapter = PrismaAdapter(prisma)
+
+  return {
+    ...baseAdapter,
+    async createVerificationToken(data) {
+      const identifier = normalizeIdentifier(data.identifier)
+
+      return baseAdapter.createVerificationToken?.({
+        ...data,
+        identifier,
+      } as VerificationToken)
+    },
+    async useVerificationToken(params) {
+      const identifier = normalizeIdentifier(params.identifier)
+
+      const resolveWithBaseAdapter = async () => {
+        try {
+          return await baseAdapter.useVerificationToken?.({
+            ...params,
+            identifier,
+          })
+        } catch (error) {
+          if (
+            error instanceof Prisma.PrismaClientKnownRequestError &&
+            error.code === 'P2025'
+          ) {
+            return null
+          }
+          throw error
+        }
+      }
+
+      const baseResult = await resolveWithBaseAdapter()
+      if (baseResult) {
+        return baseResult
+      }
+
+      try {
+        const tokenRecord = await prisma.verificationToken.findUnique({
+          where: { token: params.token },
+        })
+
+        if (!tokenRecord) {
+          return null
+        }
+
+        await prisma.verificationToken.delete({
+          where: {
+            identifier_token: {
+              identifier: tokenRecord.identifier,
+              token: tokenRecord.token,
+            },
+          },
+        })
+
+        return tokenRecord
+      } catch (error) {
+        console.error(
+          '[AUTH] Failed to resolve verification token with fallback lookup',
+          sanitizeError(error),
+        )
+        throw error
+      }
+    },
+  }
+}
+
+export default createAuthAdapter

--- a/nerin-electric-site-v3-fixed/package.json
+++ b/nerin-electric-site-v3-fixed/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "prisma generate && next build",
-    "start": "prisma migrate deploy && next start -p $PORT",
+    "start": "prisma migrate deploy && node .next/standalone/server.js",
     "lint": "next lint",
     "format": "prettier --write .",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- add a custom Prisma adapter wrapper that normalizes identifiers and falls back to lookup tokens by hash only
- switch NextAuth to use the new adapter so email verification links survive identifier mismatches
- add a credentials-based admin login flow with a dedicated form and configurable fallback credentials
- update the Render start command to boot the standalone server entrypoint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f6aae611208331b5224e248581d547