### PR TITLE
Fix admin login redirects for typed routes

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/login/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/login/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import Link from 'next/link'
 import { Badge } from '@/components/ui/badge'
 import { AdminLoginForm } from './login-form'
@@ -43,7 +44,13 @@ export default function AdminLoginPage() {
           </p>
         </div>
         <div className="flex justify-center md:justify-end">
-          <AdminLoginForm />
+          <Suspense
+            fallback={
+              <div className="w-full max-w-sm shrink-0 rounded-lg border border-emerald-100/60 p-6 shadow-lg shadow-emerald-100/40" />
+            }
+          >
+            <AdminLoginForm />
+          </Suspense>
         </div>
       </div>
     </div>

--- a/nerin-electric-site-v3-fixed/lib/auth-adapter.ts
+++ b/nerin-electric-site-v3-fixed/lib/auth-adapter.ts
@@ -5,8 +5,12 @@ import { Prisma } from '@prisma/client'
 
 import { sanitizeError } from './logging'
 
-function normalizeIdentifier(identifier: string | undefined) {
-  return identifier?.trim().toLowerCase()
+function normalizeIdentifier(identifier: string | null | undefined) {
+  if (typeof identifier !== 'string') {
+    return undefined
+  }
+
+  return identifier.trim().toLowerCase()
 }
 
 export function createAuthAdapter(prisma: PrismaClient): Adapter {
@@ -15,7 +19,7 @@ export function createAuthAdapter(prisma: PrismaClient): Adapter {
   return {
     ...baseAdapter,
     async createVerificationToken(data) {
-      const identifier = normalizeIdentifier(data.identifier)
+      const identifier = normalizeIdentifier(data.identifier) ?? data.identifier
 
       return baseAdapter.createVerificationToken?.({
         ...data,
@@ -23,7 +27,7 @@ export function createAuthAdapter(prisma: PrismaClient): Adapter {
       } as VerificationToken)
     },
     async useVerificationToken(params) {
-      const identifier = normalizeIdentifier(params.identifier)
+      const identifier = normalizeIdentifier(params.identifier) ?? params.identifier
 
       const resolveWithBaseAdapter = async () => {
         try {

--- a/nerin-electric-site-v3-fixed/lib/auth.ts
+++ b/nerin-electric-site-v3-fixed/lib/auth.ts
@@ -83,8 +83,13 @@ const adminCredentialsProvider = Credentials({
     },
   },
   authorize: async (credentials) => {
-    const email = credentials?.email?.trim().toLowerCase()
-    const password = credentials?.password || ''
+    const emailInput =
+      typeof credentials?.email === 'string' ? credentials.email : undefined
+    const passwordInput =
+      typeof credentials?.password === 'string' ? credentials.password : undefined
+
+    const email = emailInput?.trim().toLowerCase() || ''
+    const password = passwordInput || ''
 
     if (!email || !password) {
       return null


### PR DESCRIPTION
## Summary
- ensure the admin credentials form resolves typed callback URLs before redirecting
- guard NextAuth identifier and credential normalization against undefined values
- wrap the admin login form in a suspense boundary so useSearchParams can run on the client

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f6ba8b923c83318aff2ea04f352afc