### PR TITLE
Use client session provider

### DIFF
--- a/nerin-electric-site-v3-fixed/components/Header.tsx
+++ b/nerin-electric-site-v3-fixed/components/Header.tsx
@@ -1,8 +1,10 @@
+'use client'
+
 import Link from 'next/link'
 import { siteConfig } from '@/lib/config'
 import { Logo } from './Logo'
 import { Button } from './ui/button'
-import { getSession } from '@/lib/auth'
+import { useSession } from 'next-auth/react'
 
 const navigation = [
   { href: '/servicios', label: 'Servicios' },
@@ -17,8 +19,8 @@ const navigation = [
 const adminDashboardRoute = '/admin' as const
 const clientDashboardRoute = '/clientes' as const
 
-export async function Header() {
-  const session = await getSession()
+export function Header() {
+  const { data: session } = useSession()
 
   return (
     <header className="sticky top-0 z-50 border-b border-border/60 bg-white/90 backdrop-blur">

--- a/nerin-electric-site-v3-fixed/components/Providers.tsx
+++ b/nerin-electric-site-v3-fixed/components/Providers.tsx
@@ -1,10 +1,15 @@
 'use client'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { SessionProvider } from 'next-auth/react'
 import { ReactNode, useState } from 'react'
 
 export function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient())
 
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  return (
+    <SessionProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </SessionProvider>
+  )
 }


### PR DESCRIPTION
## Summary
- wrap the React Query provider with NextAuth's SessionProvider so client components can access session data
- convert the header to a client component that relies on useSession to drive the CTA state instead of getSession

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7e3c2c8b88331a2461541b12497b7