### PR TITLE
Refactor middleware authentication flow

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/layout.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/layout.tsx
@@ -1,6 +1,20 @@
 import type { ReactNode } from 'react'
+import { redirect } from 'next/navigation'
+import { requireAdmin } from '@/lib/auth'
 
-export default function AdminLayout({ children }: { children: ReactNode }) {
+export const runtime = 'nodejs'
+
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      redirect('/admin/login')
+    }
+
+    throw error
+  }
+
   return (
     <main className="mx-auto max-w-5xl space-y-10 px-6 pb-16 pt-10">
       {children}

--- a/nerin-electric-site-v3-fixed/app/admin/login/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/login/page.tsx
@@ -1,9 +1,18 @@
 import { Suspense } from 'react'
 import Link from 'next/link'
+import { redirect } from 'next/navigation'
 import { Badge } from '@/components/ui/badge'
 import { AdminLoginForm } from './login-form'
+import { getSession } from '@/lib/auth'
 
-export default function AdminLoginPage() {
+export const runtime = 'nodejs'
+
+export default async function AdminLoginPage() {
+  const session = await getSession()
+  if (session?.user?.role === 'admin') {
+    redirect('/admin')
+  }
+
   return (
     <div className="mx-auto max-w-5xl px-6 py-16">
       <div className="grid gap-12 md:grid-cols-2 md:items-start">

--- a/nerin-electric-site-v3-fixed/app/clientes/login/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/clientes/login/page.tsx
@@ -1,8 +1,21 @@
 import Link from 'next/link'
+import { redirect } from 'next/navigation'
 import { Badge } from '@/components/ui/badge'
 import { LoginForm } from './login-form'
+import { getSession } from '@/lib/auth'
 
-export default function LoginPage() {
+export const runtime = 'nodejs'
+
+export default async function LoginPage() {
+  const session = await getSession()
+  if (session?.user?.role === 'admin') {
+    redirect('/admin')
+  }
+
+  if (session?.user?.role === 'client') {
+    redirect('/clientes')
+  }
+
   return (
     <div className="mx-auto flex max-w-5xl flex-col gap-12 px-6 py-16 md:flex-row md:items-start">
       <div className="max-w-md space-y-6">

--- a/nerin-electric-site-v3-fixed/middleware.ts
+++ b/nerin-electric-site-v3-fixed/middleware.ts
@@ -1,15 +1,7 @@
-import type { NextFetchEvent, NextMiddleware, NextRequest } from 'next/server'
-import { auth } from '@/lib/auth'
+import type { NextMiddleware, NextRequest } from 'next/server'
 import { baseMiddleware } from './middleware/base'
 
-const middlewareHandler = auth(async (req) => baseMiddleware(req)) as unknown as
-  | NextMiddleware
-  | Promise<NextMiddleware>
-
-export const middleware: NextMiddleware = async (request: NextRequest, event: NextFetchEvent) => {
-  const handler = await middlewareHandler
-  return handler(request, event)
-}
+export const middleware: NextMiddleware = (request: NextRequest) => baseMiddleware(request)
 
 export default middleware
 


### PR DESCRIPTION
## Summary
- remove the NextAuth wrapper from the middleware and leave it to simple request logging
- enforce admin access and login redirects directly in server layouts and pages that run on the Node runtime
- update middleware unit tests to reflect the new pass-through behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f7e494ffe08331b0caaea7f30da58c