### PR TITLE
Document AUTH secret configuration

### DIFF
--- a/nerin-electric-site-v3-fixed/.env.example
+++ b/nerin-electric-site-v3-fixed/.env.example
@@ -4,7 +4,10 @@ DIRECT_URL="postgresql://nerin:password@localhost:5432/nerin"
 
 # NextAuth
 NEXTAUTH_URL="http://localhost:3000"
-NEXTAUTH_SECRET="change-me"
+# Generá un secreto seguro con `openssl rand -base64 32`
+AUTH_SECRET="please-generate-using-openssl-rand-base64-32"
+# Mantener sincronizado con AUTH_SECRET para compatibilidad
+NEXTAUTH_SECRET="please-generate-using-openssl-rand-base64-32"
 EMAIL_SERVER_FROM="NERIN <hola@nerin.com.ar>"
 EMAIL_SERVER_RESEND_API_KEY="re_XXXXXXXXXXXXXXXXXXXXXXXX"
 

--- a/nerin-electric-site-v3-fixed/README.md
+++ b/nerin-electric-site-v3-fixed/README.md
@@ -24,7 +24,7 @@ Proyecto completo basado en **Next.js 14 (App Router)** + **TypeScript** para co
 
 ```bash
 cp .env.example .env
-# editar con tus claves: DATABASE_URL, NEXTAUTH_SECRET, RESEND_API_KEY, MP_ACCESS_TOKEN, etc.
+# editar con tus claves: DATABASE_URL, AUTH_SECRET (openssl rand -base64 32), RESEND_API_KEY, MP_ACCESS_TOKEN, etc.
 npm install
 ```
 
@@ -106,11 +106,12 @@ Disponible en `/admin` (rol admin). Permite:
 2. Crear **Web Service** (Node 20) con este repo.
 3. Variables de entorno mínimas:
    - `DATABASE_URL`
-   - `NEXTAUTH_SECRET`
+   - `AUTH_SECRET` (o `NEXTAUTH_SECRET`)
    - `RESEND_API_KEY`
    - `EMAIL_SERVER_FROM`
    - `MERCADOPAGO_ACCESS_TOKEN`, `MERCADOPAGO_PUBLIC_KEY`, `MERCADOPAGO_WEBHOOK_SECRET`
    - `STORAGE_DIR` (si usás Disk, ej. `/var/data`)
+   > Generá `AUTH_SECRET` con `openssl rand -base64 32` y cargalo en el panel de variables del despliegue.
 4. Commands:
    - Build: `npm ci && npm run build`
    - Start: `npm run start`


### PR DESCRIPTION
## Summary
- document AUTH_SECRET alongside NEXTAUTH_SECRET in `.env.example`
- update deployment docs to emphasise generating a secure auth secret with `openssl rand -base64 32`

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f846b545e883319eff69b8726889dd