### PR TITLE
Protect admin GET routes with requireAdmin guard

### DIFF
--- a/nerin-electric-site-v3-fixed/app/api/admin/calculator/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/calculator/route.ts
@@ -4,15 +4,32 @@ import path from 'path'
 import { getStorageDir } from '@/lib/content'
 import { requireAdmin } from '@/lib/auth'
 
-function filePath(){ const storage = getStorageDir(); return path.join(storage, 'calculator.json') }
-
-export async function GET(){
-  const fp = filePath()
-  if (!fs.existsSync(fp)) return NextResponse.json({ currency:'ARS', items: [] })
-  return NextResponse.json(JSON.parse(fs.readFileSync(fp,'utf8')))
+function filePath() {
+  const storage = getStorageDir()
+  return path.join(storage, 'calculator.json')
 }
 
-export async function POST(req: Request){
+export async function GET() {
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    throw error
+  }
+
+  const fp = filePath()
+
+  if (!fs.existsSync(fp)) {
+    return NextResponse.json({ currency: 'ARS', items: [] })
+  }
+
+  return NextResponse.json(JSON.parse(fs.readFileSync(fp, 'utf8')))
+}
+
+export async function POST(req: Request) {
   await requireAdmin()
   const body = await req.json()
   fs.writeFileSync(filePath(), JSON.stringify(body, null, 2))

--- a/nerin-electric-site-v3-fixed/app/api/admin/item/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/item/route.ts
@@ -1,14 +1,30 @@
 import { NextResponse } from 'next/server'
 import { readMarkdown, writeMarkdown, deleteMarkdown } from '@/lib/content'
 import { requireAdmin } from '@/lib/auth'
-export async function GET(req: Request){
+
+function unauthorizedResponse() {
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+}
+
+export async function GET(req: Request) {
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return unauthorizedResponse()
+    }
+
+    throw error
+  }
+
   const { searchParams } = new URL(req.url)
   const type = searchParams.get('type') || 'blog'
   const slug = searchParams.get('slug')!
   const item = readMarkdown(type, slug)
-  return NextResponse.json(item || { data:{}, content:'' })
+  return NextResponse.json(item || { data: {}, content: '' })
 }
-export async function POST(req: Request){
+
+export async function POST(req: Request) {
   await requireAdmin()
   const { searchParams } = new URL(req.url)
   const type = searchParams.get('type') || 'blog'
@@ -17,7 +33,8 @@ export async function POST(req: Request){
   writeMarkdown(type, slug, body.data, body.content)
   return NextResponse.json({ ok: true })
 }
-export async function DELETE(req: Request){
+
+export async function DELETE(req: Request) {
   await requireAdmin()
   const { searchParams } = new URL(req.url)
   const type = searchParams.get('type') || 'blog'

--- a/nerin-electric-site-v3-fixed/app/api/admin/list/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/list/route.ts
@@ -1,6 +1,18 @@
 import { NextResponse } from 'next/server'
 import { listItems } from '@/lib/content'
-export async function GET(req: Request){
+import { requireAdmin } from '@/lib/auth'
+
+export async function GET(req: Request) {
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    throw error
+  }
+
   const { searchParams } = new URL(req.url)
   const type = searchParams.get('type') || 'blog'
   return NextResponse.json(listItems(type))

--- a/nerin-electric-site-v3-fixed/app/api/admin/pricing/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/pricing/route.ts
@@ -3,6 +3,36 @@ import { getStorageDir } from '@/lib/content'
 import { requireAdmin } from '@/lib/auth'
 import fs from 'fs'
 import path from 'path'
-function filePath(){ const storage = getStorageDir(); return path.join(storage, 'pricing.json') }
-export async function GET(){ const p=filePath(); if(!fs.existsSync(p)) return NextResponse.json({plans:[]}); const j=JSON.parse(fs.readFileSync(p,'utf8')); return NextResponse.json(j) }
-export async function POST(req: Request){ await requireAdmin(); const body = await req.json(); fs.writeFileSync(filePath(), JSON.stringify(body,null,2)); return NextResponse.json({ ok: true }) }
+
+function filePath() {
+  const storage = getStorageDir()
+  return path.join(storage, 'pricing.json')
+}
+
+export async function GET() {
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    throw error
+  }
+
+  const filepath = filePath()
+
+  if (!fs.existsSync(filepath)) {
+    return NextResponse.json({ plans: [] })
+  }
+
+  const json = JSON.parse(fs.readFileSync(filepath, 'utf8'))
+  return NextResponse.json(json)
+}
+
+export async function POST(req: Request) {
+  await requireAdmin()
+  const body = await req.json()
+  fs.writeFileSync(filePath(), JSON.stringify(body, null, 2))
+  return NextResponse.json({ ok: true })
+}

--- a/nerin-electric-site-v3-fixed/app/api/admin/site/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/site/route.ts
@@ -1,5 +1,24 @@
 import { NextResponse } from 'next/server'
 import { readSite, writeSite } from '@/lib/content'
 import { requireAdmin } from '@/lib/auth'
-export async function GET(){ return NextResponse.json(readSite()) }
-export async function POST(req: Request){ await requireAdmin(); const body = await req.json(); writeSite(body); return NextResponse.json({ ok: true }) }
+
+export async function GET() {
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    throw error
+  }
+
+  return NextResponse.json(readSite())
+}
+
+export async function POST(req: Request) {
+  await requireAdmin()
+  const body = await req.json()
+  writeSite(body)
+  return NextResponse.json({ ok: true })
+}

--- a/nerin-electric-site-v3-fixed/tests/unit/admin-site-route.test.ts
+++ b/nerin-electric-site-v3-fixed/tests/unit/admin-site-route.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockRequireAdmin = vi.fn<() => Promise<void>>()
+const mockReadSite = vi.fn<() => unknown>()
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json(body: unknown, init?: ResponseInit) {
+      return new Response(JSON.stringify(body), init)
+    },
+  },
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}))
+
+vi.mock('@/lib/content', () => ({
+  readSite: () => mockReadSite(),
+  writeSite: vi.fn(),
+}))
+
+import { GET } from '@/app/api/admin/site/route'
+
+describe('app/api/admin/site/route GET', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockReadSite.mockReturnValue({ title: 'Mock site' })
+  })
+
+  it('returns 401 when the admin session is missing', async () => {
+    mockRequireAdmin.mockRejectedValueOnce(new Error('Unauthorized'))
+
+    const response = await GET()
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+  })
+
+  it('returns site content when admin session is present', async () => {
+    mockRequireAdmin.mockResolvedValueOnce(undefined)
+
+    const response = await GET()
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ title: 'Mock site' })
+  })
+})


### PR DESCRIPTION
## Summary
- invoke `requireAdmin` at the start of every admin GET route and return a 401 JSON response when the check fails
- leave existing POST handlers reusing the shared guard and keep their behavior intact
- add a unit test covering the admin site GET handler for both authorized and unauthorized flows

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f8b337df48833182e0b9a7075175d5