### PR TITLE
Fix Prisma seed and config for SQLite deployment

### DIFF
--- a/nerin-electric-site-v3-fixed/package.json
+++ b/nerin-electric-site-v3-fixed/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "prisma generate && next build",
-    "start": "prisma db push --skip-generate && node .next/standalone/server.js",
+    "start": "prisma migrate deploy || prisma db push && node .next/standalone/server.js",
     "lint": "next lint",
     "format": "prettier --write .",
     "test": "vitest run",

--- a/nerin-electric-site-v3-fixed/prisma/seed.ts
+++ b/nerin-electric-site-v3-fixed/prisma/seed.ts
@@ -89,7 +89,6 @@ async function main() {
         ]),
       },
     ],
-    skipDuplicates: true,
   })
 
   await prisma.additionalItem.createMany({
@@ -155,7 +154,6 @@ async function main() {
         precioUnitarioManoObra: 120000,
       },
     ],
-    skipDuplicates: true,
   })
 
   await prisma.maintenancePlan.createMany({
@@ -197,7 +195,6 @@ async function main() {
         cantidadesFijasInalterables: true,
       },
     ],
-    skipDuplicates: true,
   })
 
   await prisma.brand.createMany({
@@ -208,7 +205,6 @@ async function main() {
       { nombre: 'Daisa' },
       { nombre: 'Genrock' },
     ],
-    skipDuplicates: true,
   })
 
   await prisma.caseStudy.createMany({
@@ -240,7 +236,6 @@ async function main() {
         publicado: true,
       },
     ],
-    skipDuplicates: true,
   })
 
   const project = await prisma.project.upsert({
@@ -274,7 +269,6 @@ async function main() {
         paidAt: new Date(),
       },
     ],
-    skipDuplicates: true,
   })
 
   await prisma.invoice.createMany({
@@ -286,7 +280,6 @@ async function main() {
         urlPdf: 'https://example.com/factura-nerin.pdf',
       },
     ],
-    skipDuplicates: true,
   })
 
   await prisma.siteSetting.upsert({

--- a/nerin-electric-site-v3-fixed/tsconfig.json
+++ b/nerin-electric-site-v3-fixed/tsconfig.json
@@ -21,5 +21,5 @@
     "plugins": [{ "name": "next" }]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "prisma/seed.ts"]
 }


### PR DESCRIPTION
## Summary
- remove `skipDuplicates` usage from the Prisma seed so SQLite seeding works reliably
- exclude the seed script from the TypeScript build to avoid compilation failures
- update the start script to attempt migrations first and fall back to `prisma db push` before launching the standalone server

## Testing
- npm ci
- CI=1 npm run build
- DATABASE_URL="file:/workspace/NERIN/nerin-electric-site-v3-fixed/prisma/dev.db" NEXTAUTH_URL="http://localhost:3000" AUTH_SECRET="development-secret" NEXTAUTH_SECRET="development-secret" STORAGE_PROVIDER="local" STORAGE_DIR=".data/uploads" PORT="3000" npm run start
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68f93a681f20833183245577c06ffd4d