### PR TITLE
Implement unique slug generation for case studies

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/(dashboard)/case-study-form.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/(dashboard)/case-study-form.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useFormState } from 'react-dom'
+
+import { initialCaseStudyState, upsertCaseStudy } from '../actions'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+
+export function CaseStudyForm() {
+  const [state, formAction] = useFormState(upsertCaseStudy, initialCaseStudyState)
+
+  return (
+    <form action={formAction} className="grid gap-4">
+      <div className="grid gap-2">
+        <Label htmlFor="case-titulo">Título</Label>
+        <Input id="case-titulo" name="titulo" required />
+      </div>
+      <p className="text-xs text-slate-500">El slug se genera automáticamente a partir del título.</p>
+      <div className="grid gap-2">
+        <Label htmlFor="case-resumen">Resumen</Label>
+        <Textarea id="case-resumen" name="resumen" required />
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="case-contenido">Contenido</Label>
+        <Textarea id="case-contenido" name="contenido" rows={6} required />
+      </div>
+      <Button type="submit">Publicar caso</Button>
+      {state.error ? (
+        <p className="text-sm text-red-600">{state.error}</p>
+      ) : state.success ? (
+        <p className="text-sm text-emerald-600">Caso de éxito guardado correctamente.</p>
+      ) : null}
+    </form>
+  )
+}

--- a/nerin-electric-site-v3-fixed/app/admin/(dashboard)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/(dashboard)/page.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link'
 import { prisma } from '@/lib/db'
 import {
   createAdditional,
-  createCaseStudy,
   createCertificate,
   createMaintenance,
   createPack,
@@ -13,8 +12,9 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { CaseStudyForm } from './case-study-form'
 
 export const revalidate = 0
 
@@ -146,25 +146,7 @@ export default async function AdminPage() {
             <CardTitle>Nuevo caso de éxito</CardTitle>
           </CardHeader>
           <CardContent>
-            <form action={createCaseStudy} className="grid gap-4">
-              <div className="grid gap-2">
-                <Label htmlFor="case-titulo">Título</Label>
-                <Input id="case-titulo" name="titulo" required />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="case-slug">Slug</Label>
-                <Input id="case-slug" name="slug" required />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="case-resumen">Resumen</Label>
-                <Textarea id="case-resumen" name="resumen" required />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="case-contenido">Contenido</Label>
-                <Textarea id="case-contenido" name="contenido" rows={6} required />
-              </div>
-              <Button type="submit">Publicar caso</Button>
-            </form>
+            <CaseStudyForm />
           </CardContent>
         </Card>
       </section>

--- a/nerin-electric-site-v3-fixed/lib/slug.ts
+++ b/nerin-electric-site-v3-fixed/lib/slug.ts
@@ -1,0 +1,31 @@
+import { prisma } from '@/lib/db'
+
+function slugify(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export async function makeUniqueSlug(title: string): Promise<string> {
+  const fallback = 'caso-de-exito'
+  const baseSlug = slugify(title) || fallback
+
+  let candidate = baseSlug
+  let suffix = 2
+
+  while (true) {
+    const exists = await prisma.caseStudy.findUnique({ where: { slug: candidate } })
+    if (!exists) {
+      return candidate
+    }
+
+    candidate = `${baseSlug}-${suffix}`
+    suffix += 1
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared helper to normalize titles and generate unique case study slugs
- update the admin case study action to use an upsert with slug de-duplication and error handling
- refresh the admin dashboard form to auto-generate the slug and surface validation errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fa2e6d36c48331b17d2297a1375fa5