### PR TITLE
Add blog revalidation to admin item API

### DIFF
--- a/nerin-electric-site-v3-fixed/app/api/admin/item/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/item/route.ts
@@ -1,6 +1,23 @@
 import { NextResponse } from 'next/server'
+import { revalidatePath } from 'next/cache'
 import { readMarkdown, writeMarkdown, deleteMarkdown } from '@/lib/content'
 import { requireAdmin } from '@/lib/auth'
+
+class RevalidationError extends Error {
+  constructor(message: string, readonly cause?: unknown) {
+    super(message)
+    this.name = 'RevalidationError'
+  }
+}
+
+function revalidateBlogPaths(slug: string) {
+  try {
+    revalidatePath('/blog')
+    revalidatePath(`/blog/${slug}`)
+  } catch (error) {
+    throw new RevalidationError('Blog revalidation failed', error)
+  }
+}
 
 function unauthorizedResponse() {
   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -30,8 +47,30 @@ export async function POST(req: Request) {
   const type = searchParams.get('type') || 'blog'
   const slug = searchParams.get('slug')!
   const body = await req.json()
-  writeMarkdown(type, slug, body.data, body.content)
-  return NextResponse.json({ ok: true })
+
+  try {
+    writeMarkdown(type, slug, body.data, body.content)
+
+    if (type === 'blog') {
+      revalidateBlogPaths(slug)
+    }
+
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    if (error instanceof RevalidationError) {
+      console.error(`Error revalidating blog content for slug "${slug}"`, error.cause ?? error)
+      return NextResponse.json(
+        { ok: false, error: 'No se pudo refrescar el contenido del blog. Intentá nuevamente.' },
+        { status: 500 },
+      )
+    }
+
+    console.error(`Error saving markdown content for slug "${slug}"`, error)
+    return NextResponse.json(
+      { ok: false, error: 'No se pudo guardar el contenido. Intentá nuevamente.' },
+      { status: 500 },
+    )
+  }
 }
 
 export async function DELETE(req: Request) {
@@ -39,6 +78,27 @@ export async function DELETE(req: Request) {
   const { searchParams } = new URL(req.url)
   const type = searchParams.get('type') || 'blog'
   const slug = searchParams.get('slug')!
-  deleteMarkdown(type, slug)
-  return NextResponse.json({ ok: true })
+  try {
+    deleteMarkdown(type, slug)
+
+    if (type === 'blog') {
+      revalidateBlogPaths(slug)
+    }
+
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    if (error instanceof RevalidationError) {
+      console.error(`Error revalidating blog content after deleting slug "${slug}"`, error.cause ?? error)
+      return NextResponse.json(
+        { ok: false, error: 'No se pudo refrescar el contenido del blog. Intentá nuevamente.' },
+        { status: 500 },
+      )
+    }
+
+    console.error(`Error deleting markdown content for slug "${slug}"`, error)
+    return NextResponse.json(
+      { ok: false, error: 'No se pudo eliminar el contenido. Intentá nuevamente.' },
+      { status: 500 },
+    )
+  }
 }

--- a/nerin-electric-site-v3-fixed/tests/unit/admin-item-route.test.ts
+++ b/nerin-electric-site-v3-fixed/tests/unit/admin-item-route.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockRequireAdmin = vi.fn<() => Promise<void>>()
+const mockReadMarkdown = vi.fn()
+const mockWriteMarkdown = vi.fn()
+const mockDeleteMarkdown = vi.fn()
+const mockRevalidatePath = vi.fn<[string], void>()
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json(body: unknown, init?: ResponseInit) {
+      return new Response(JSON.stringify(body), init)
+    },
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: (path: string) => mockRevalidatePath(path),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}))
+
+vi.mock('@/lib/content', () => ({
+  readMarkdown: (...args: unknown[]) => mockReadMarkdown(...args),
+  writeMarkdown: (...args: unknown[]) => mockWriteMarkdown(...args),
+  deleteMarkdown: (...args: unknown[]) => mockDeleteMarkdown(...args),
+}))
+
+import { POST, DELETE } from '@/app/api/admin/item/route'
+
+describe('app/api/admin/item/route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRequireAdmin.mockResolvedValue()
+    mockRevalidatePath.mockImplementation(() => {})
+    mockWriteMarkdown.mockImplementation(() => {})
+    mockDeleteMarkdown.mockImplementation(() => {})
+  })
+
+  describe('POST', () => {
+    it('revalidates blog listing and entry after saving markdown', async () => {
+      const request = new Request('https://example.com/api/admin/item?type=blog&slug=test-post', {
+        method: 'POST',
+        body: JSON.stringify({ data: { title: 'Test' }, content: 'Hello' }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      const response = await POST(request)
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ ok: true })
+      expect(mockWriteMarkdown).toHaveBeenCalledWith('blog', 'test-post', { title: 'Test' }, 'Hello')
+      expect(mockRevalidatePath).toHaveBeenNthCalledWith(1, '/blog')
+      expect(mockRevalidatePath).toHaveBeenNthCalledWith(2, '/blog/test-post')
+    })
+
+    it('returns a 500 response when revalidation fails', async () => {
+      let callCount = 0
+      mockRevalidatePath.mockImplementation(() => {
+        callCount += 1
+        if (callCount === 2) {
+          throw new Error('revalidate error')
+        }
+      })
+
+      const request = new Request('https://example.com/api/admin/item?type=blog&slug=broken-post', {
+        method: 'POST',
+        body: JSON.stringify({ data: { title: 'Broken' }, content: 'Hello' }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      const response = await POST(request)
+
+      expect(response.status).toBe(500)
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: 'No se pudo refrescar el contenido del blog. Intentá nuevamente.',
+      })
+      expect(mockWriteMarkdown).toHaveBeenCalled()
+    })
+  })
+
+  describe('DELETE', () => {
+    it('revalidates blog listing and entry after deleting markdown', async () => {
+      const request = new Request('https://example.com/api/admin/item?type=blog&slug=to-delete', {
+        method: 'DELETE',
+      })
+
+      const response = await DELETE(request)
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ ok: true })
+      expect(mockDeleteMarkdown).toHaveBeenCalledWith('blog', 'to-delete')
+      expect(mockRevalidatePath).toHaveBeenNthCalledWith(1, '/blog')
+      expect(mockRevalidatePath).toHaveBeenNthCalledWith(2, '/blog/to-delete')
+    })
+
+    it('returns a 500 response when revalidation fails after deletion', async () => {
+      mockRevalidatePath.mockImplementation(() => {
+        throw new Error('fail')
+      })
+
+      const request = new Request('https://example.com/api/admin/item?type=blog&slug=broken-delete', {
+        method: 'DELETE',
+      })
+
+      const response = await DELETE(request)
+
+      expect(response.status).toBe(500)
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: 'No se pudo refrescar el contenido del blog. Intentá nuevamente.',
+      })
+      expect(mockDeleteMarkdown).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- call `revalidatePath` for the blog listing and detail after saving or deleting admin markdown entries
- return descriptive errors when revalidation fails so clients can react accordingly
- cover the new API behaviour with unit tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68fa55f0af6c8331a36f9a031d375e44