### PR TITLE
Set default SQLite path for deployments

### DIFF
--- a/nerin-electric-site-v3-fixed/.env.example
+++ b/nerin-electric-site-v3-fixed/.env.example
@@ -1,6 +1,7 @@
 # Base de datos
 # Por defecto usamos SQLite para simplificar el despliegue.
-DATABASE_URL="file:./dev.db"
+DATABASE_URL="file:/var/data/nerin.db"
+# En desarrollo podés seguir usando SQLite local con DATABASE_URL="file:./dev.db".
 # Si preferís PostgreSQL, cambiá el provider en prisma/schema.prisma y establecé DIRECT_URL/DATABASE_URL acorde.
 # DIRECT_URL="postgresql://nerin:password@localhost:5432/nerin"
 

--- a/nerin-electric-site-v3-fixed/Dockerfile
+++ b/nerin-electric-site-v3-fixed/Dockerfile
@@ -20,4 +20,4 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/prisma ./prisma
-CMD ["node", "server.js"]
+CMD ["sh", "-c", "export DATABASE_URL=\"${DATABASE_URL:-file:/var/data/nerin.db}\" && node server.js"]

--- a/nerin-electric-site-v3-fixed/lib/db.ts
+++ b/nerin-electric-site-v3-fixed/lib/db.ts
@@ -1,5 +1,20 @@
 // lib/db.ts
+import { existsSync } from 'node:fs'
+
 import { PrismaClient } from '@prisma/client'
+
+const VAR_DATA_DB_URL = 'file:/var/data/nerin.db'
+const DEV_DB_URL = 'file:./dev.db'
+
+const isDatabaseUrlMissing =
+  !process.env.DATABASE_URL || process.env.DATABASE_URL.trim().length === 0
+
+if (isDatabaseUrlMissing && existsSync('/var/data')) {
+  process.env.DATABASE_URL = VAR_DATA_DB_URL
+}
+
+const databaseUrl = process.env.DATABASE_URL?.trim()
+const resolvedDatabaseUrl = databaseUrl && databaseUrl.length > 0 ? databaseUrl : DEV_DB_URL
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
@@ -10,7 +25,7 @@ const prismaClient =
   new PrismaClient({
     datasources: {
       db: {
-        url: process.env.DATABASE_URL || 'file:./dev.db',
+        url: resolvedDatabaseUrl,
       },
     },
     log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],

--- a/nerin-electric-site-v3-fixed/package.json
+++ b/nerin-electric-site-v3-fixed/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "prisma generate && next build",
-    "start": "prisma db push && next start",
+    "start": "export DATABASE_URL=\"${DATABASE_URL:-file:/var/data/nerin.db}\" && prisma db push && next start",
     "lint": "next lint",
     "format": "prettier --write .",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- update the sample environment file to default to `/var/data/nerin.db` while documenting the local `dev.db` option
- auto-select the `/var/data` SQLite database when the directory exists and no `DATABASE_URL` is provided
- export a default `DATABASE_URL` before starting the app in both the npm start script and Docker runtime

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68faa9d2fdf08331885a265a0092638c