### PR TITLE
Fix admin server actions exports and revalidation

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/(dashboard)/case-study-form.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/(dashboard)/case-study-form.tsx
@@ -2,7 +2,8 @@
 
 import { useFormState } from 'react-dom'
 
-import { initialCaseStudyState, upsertCaseStudy } from '../actions'
+import { upsertCaseStudy } from '../actions'
+import { initialCaseStudyState } from '../constants'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'

--- a/nerin-electric-site-v3-fixed/app/admin/(dashboard)/maintenance-form.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/(dashboard)/maintenance-form.tsx
@@ -6,7 +6,8 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import { createMaintenance, initialMaintenanceFormState } from '../actions'
+import { createMaintenance } from '../actions'
+import { initialMaintenanceFormState } from '../constants'
 
 export function MaintenanceForm() {
   const [state, formAction] = useFormState(createMaintenance, initialMaintenanceFormState)

--- a/nerin-electric-site-v3-fixed/app/admin/(dashboard)/pack-form.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/(dashboard)/pack-form.tsx
@@ -6,7 +6,8 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import { createPack, initialPackFormState } from '../actions'
+import { createPack } from '../actions'
+import { initialPackFormState } from '../constants'
 
 export function PackForm() {
   const [state, formAction] = useFormState(createPack, initialPackFormState)

--- a/nerin-electric-site-v3-fixed/app/admin/actions.ts
+++ b/nerin-electric-site-v3-fixed/app/admin/actions.ts
@@ -6,6 +6,11 @@ import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/db'
 import { serializeStringArray } from '@/lib/serialization'
 import { makeUniqueSlug } from '@/lib/slug'
+import type {
+  CaseStudyFormState,
+  MaintenanceFormState,
+  PackFormState,
+} from './constants'
 
 const PackSchema = z.object({
   nombre: z.string().min(3),
@@ -16,15 +21,6 @@ const PackSchema = z.object({
   precioManoObraBase: z.coerce.number().min(0),
   alcanceDetallado: z.string().min(5),
 })
-
-export type PackFormState = {
-  success: boolean
-  error?: string
-}
-
-export const initialPackFormState: PackFormState = {
-  success: false,
-}
 
 export async function createPack(
   _prevState: PackFormState,
@@ -119,15 +115,6 @@ const MaintenanceSchema = z.object({
   incluye: z.string().min(5),
 })
 
-export type MaintenanceFormState = {
-  success: boolean
-  error?: string
-}
-
-export const initialMaintenanceFormState: MaintenanceFormState = {
-  success: false,
-}
-
 export async function createMaintenance(
   _prevState: MaintenanceFormState,
   formData: FormData,
@@ -188,15 +175,6 @@ const CaseStudySchema = z.object({
   contenido: z.string().min(20),
 })
 
-export type CaseStudyFormState = {
-  success: boolean
-  error?: string
-}
-
-export const initialCaseStudyState: CaseStudyFormState = {
-  success: false,
-}
-
 export async function upsertCaseStudy(
   _prevState: CaseStudyFormState,
   formData: FormData,
@@ -239,6 +217,8 @@ export async function upsertCaseStudy(
 
     revalidatePath('/admin')
     revalidatePath('/obras')
+    revalidatePath('/blog')
+    revalidatePath('/blog/[slug]')
 
     return { success: true }
   } catch (error) {

--- a/nerin-electric-site-v3-fixed/app/admin/constants.ts
+++ b/nerin-electric-site-v3-fixed/app/admin/constants.ts
@@ -1,0 +1,26 @@
+export type PackFormState = {
+  success: boolean
+  error?: string
+}
+
+export const initialPackFormState: PackFormState = {
+  success: false,
+}
+
+export type MaintenanceFormState = {
+  success: boolean
+  error?: string
+}
+
+export const initialMaintenanceFormState: MaintenanceFormState = {
+  success: false,
+}
+
+export type CaseStudyFormState = {
+  success: boolean
+  error?: string
+}
+
+export const initialCaseStudyState: CaseStudyFormState = {
+  success: false,
+}


### PR DESCRIPTION
## Summary
- move admin form state types and initial values into a dedicated constants module so server action files only export async functions
- update admin server actions to revalidate blog routes after case study changes and keep middleware exclusions intact
- point dashboard forms at the new constants module to load initial server action state

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68faadae8fe08331b5e693709336f131