### PR TITLE
Add admin interfaces for managing case studies and packs

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/(dashboard)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/(dashboard)/page.tsx
@@ -32,6 +32,14 @@ export default async function AdminPage() {
           Administrá packs, adicionales, planes de mantenimiento, casos de éxito y certificados de avance. Todos los
           cambios impactan en el sitio público y en el portal de clientes.
         </p>
+        <div className="flex flex-wrap gap-3 pt-2">
+          <Button variant="outline" asChild>
+            <Link href="/admin/noticias">Gestionar noticias</Link>
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href="/admin/packs">Gestionar packs comerciales</Link>
+          </Button>
+        </div>
       </header>
 
       <section className="grid gap-6 lg:grid-cols-2">

--- a/nerin-electric-site-v3-fixed/app/admin/noticias/layout.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/noticias/layout.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+import { redirect } from 'next/navigation'
+import { requireAdmin } from '@/lib/auth'
+
+export const runtime = 'nodejs'
+
+export default async function AdminNoticiasLayout({ children }: { children: ReactNode }) {
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      redirect('/admin/login')
+    }
+
+    throw error
+  }
+
+  return <main className="mx-auto max-w-5xl space-y-10 px-6 pb-16 pt-10">{children}</main>
+}

--- a/nerin-electric-site-v3-fixed/app/admin/noticias/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/noticias/page.tsx
@@ -1,0 +1,429 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Table, TableCell, TableHead, TableRow } from '@/components/ui/table'
+import { Textarea } from '@/components/ui/textarea'
+
+type Metric = { label: string; value: string }
+
+type CaseStudy = {
+  id: string
+  titulo: string
+  slug: string
+  resumen: string
+  contenido: string
+  metricas: Metric[]
+  fotos: string[]
+  publicado: boolean
+}
+
+type CaseStudyResponse = {
+  items: CaseStudy[]
+}
+
+type FormState = {
+  id: string | null
+  titulo: string
+  slug: string
+  resumen: string
+  contenido: string
+  metricasText: string
+  fotosText: string
+  publicado: boolean
+}
+
+const emptyForm: FormState = {
+  id: null,
+  titulo: '',
+  slug: '',
+  resumen: '',
+  contenido: '',
+  metricasText: '',
+  fotosText: '',
+  publicado: true,
+}
+
+function metricsToText(metricas: Metric[]): string {
+  return metricas.map((metric) => `${metric.label} | ${metric.value}`).join('\n')
+}
+
+function textToMetrics(text: string): Metric[] {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [label, ...rest] = line.split('|')
+      const value = rest.join('|')
+      const trimmedLabel = label?.trim() ?? ''
+      const trimmedValue = value.trim()
+
+      if (!trimmedLabel || !trimmedValue) {
+        return null
+      }
+
+      return { label: trimmedLabel, value: trimmedValue }
+    })
+    .filter((item): item is Metric => Boolean(item))
+}
+
+function textToFotos(text: string): string[] {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+export default function AdminNoticiasPage() {
+  const [items, setItems] = useState<CaseStudy[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const [form, setForm] = useState<FormState>(emptyForm)
+  const [saving, setSaving] = useState(false)
+
+  const isEditing = useMemo(() => Boolean(form.id), [form.id])
+
+  const resetForm = useCallback(() => {
+    setForm(emptyForm)
+    setMessage(null)
+  }, [])
+
+  const loadItems = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch('/api/admin/case-studies', {
+        cache: 'no-store',
+      })
+
+      if (response.status === 401) {
+        setError('No tenés permisos para ver esta sección. Iniciá sesión nuevamente.')
+        setItems([])
+        return
+      }
+
+      if (!response.ok) {
+        throw new Error('No se pudo cargar la información')
+      }
+
+      const data = (await response.json()) as CaseStudyResponse
+      setItems(data.items ?? [])
+    } catch (err) {
+      console.error('Error fetching case studies', err)
+      setError('Ocurrió un error al cargar las noticias. Intentá nuevamente más tarde.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadItems()
+  }, [loadItems])
+
+  const handleEdit = useCallback((item: CaseStudy) => {
+    setForm({
+      id: item.id,
+      titulo: item.titulo,
+      slug: item.slug,
+      resumen: item.resumen,
+      contenido: item.contenido,
+      metricasText: metricsToText(item.metricas),
+      fotosText: item.fotos.join('\n'),
+      publicado: item.publicado,
+    })
+    setMessage(null)
+  }, [])
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      const confirmed = window.confirm('¿Seguro que querés eliminar esta noticia? Esta acción no se puede deshacer.')
+      if (!confirmed) return
+
+      setSaving(true)
+      setMessage(null)
+      setError(null)
+
+      try {
+        const response = await fetch(`/api/admin/case-studies?id=${id}`, {
+          method: 'DELETE',
+        })
+
+        if (response.status === 401) {
+          setError('No tenés permisos para realizar esta acción.')
+          return
+        }
+
+        if (!response.ok) {
+          throw new Error('No se pudo eliminar la noticia')
+        }
+
+        setItems((prev) => prev.filter((item) => item.id !== id))
+        setMessage('Noticia eliminada correctamente.')
+        if (form.id === id) {
+          resetForm()
+        }
+      } catch (err) {
+        console.error('Error deleting case study', err)
+        setError('No se pudo eliminar la noticia. Intentá nuevamente.')
+      } finally {
+        setSaving(false)
+      }
+    },
+    [form.id, resetForm],
+  )
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      setSaving(true)
+      setMessage(null)
+      setError(null)
+
+      const payload = {
+        id: form.id ?? undefined,
+        titulo: form.titulo.trim(),
+        slug: form.slug.trim() || undefined,
+        resumen: form.resumen.trim(),
+        contenido: form.contenido.trim(),
+        metricas: textToMetrics(form.metricasText),
+        fotos: textToFotos(form.fotosText),
+        publicado: form.publicado,
+      }
+
+      const method = isEditing ? 'PUT' : 'POST'
+
+      try {
+        const response = await fetch('/api/admin/case-studies', {
+          method,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        })
+
+        if (response.status === 401) {
+          setError('No tenés permisos para realizar esta acción.')
+          return
+        }
+
+        if (!response.ok) {
+          const errorData = (await response.json().catch(() => null)) as { error?: string } | null
+          throw new Error(errorData?.error ?? 'No se pudo guardar la noticia')
+        }
+
+        const data = (await response.json()) as { item: CaseStudy }
+        const item = data.item
+
+        setItems((prev) => {
+          const withoutItem = prev.filter((cs) => cs.id !== item.id)
+          return [item, ...withoutItem]
+        })
+
+        setMessage(isEditing ? 'Noticia actualizada correctamente.' : 'Noticia creada correctamente.')
+        setForm({
+          id: item.id,
+          titulo: item.titulo,
+          slug: item.slug,
+          resumen: item.resumen,
+          contenido: item.contenido,
+          metricasText: metricsToText(item.metricas),
+          fotosText: item.fotos.join('\n'),
+          publicado: item.publicado,
+        })
+      } catch (err) {
+        console.error('Error saving case study', err)
+        setError(err instanceof Error ? err.message : 'No se pudo guardar la noticia.')
+      } finally {
+        setSaving(false)
+      }
+    },
+    [form, isEditing],
+  )
+
+  return (
+    <div className="space-y-10">
+      <header className="space-y-2">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">Panel administrativo</p>
+            <h1 className="text-2xl font-semibold text-foreground">Noticias y casos de éxito</h1>
+            <p className="text-sm text-slate-600">
+              Gestioná las noticias del blog y los casos de éxito publicados en el sitio.
+            </p>
+          </div>
+          <Button variant="secondary" asChild>
+            <Link href="/admin">Volver al panel</Link>
+          </Button>
+        </div>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>{isEditing ? 'Editar noticia' : 'Nueva noticia'}</CardTitle>
+            {isEditing && (
+              <Button variant="ghost" type="button" onClick={resetForm}>
+                Crear nueva
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <form className="grid gap-4" onSubmit={handleSubmit}>
+            <div className="grid gap-2">
+              <Label htmlFor="titulo">Título</Label>
+              <Input
+                id="titulo"
+                value={form.titulo}
+                onChange={(event) => setForm((prev) => ({ ...prev, titulo: event.target.value }))}
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="slug">Slug (opcional)</Label>
+              <Input
+                id="slug"
+                placeholder="ej: obra-corporativa"
+                value={form.slug}
+                onChange={(event) => setForm((prev) => ({ ...prev, slug: event.target.value }))}
+              />
+              <p className="text-xs text-slate-500">Si lo dejás vacío se genera automáticamente a partir del título.</p>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="resumen">Resumen</Label>
+              <Textarea
+                id="resumen"
+                value={form.resumen}
+                onChange={(event) => setForm((prev) => ({ ...prev, resumen: event.target.value }))}
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="contenido">Contenido</Label>
+              <Textarea
+                id="contenido"
+                rows={6}
+                value={form.contenido}
+                onChange={(event) => setForm((prev) => ({ ...prev, contenido: event.target.value }))}
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="metricas">Métricas (una por línea usando formato Etiqueta | Valor)</Label>
+              <Textarea
+                id="metricas"
+                placeholder={'Tiempo de obra | 90 días'}
+                value={form.metricasText}
+                onChange={(event) => setForm((prev) => ({ ...prev, metricasText: event.target.value }))}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="fotos">URLs de fotos (una por línea)</Label>
+              <Textarea
+                id="fotos"
+                value={form.fotosText}
+                onChange={(event) => setForm((prev) => ({ ...prev, fotosText: event.target.value }))}
+              />
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600">
+              <input
+                type="checkbox"
+                checked={form.publicado}
+                onChange={(event) => setForm((prev) => ({ ...prev, publicado: event.target.checked }))}
+              />
+              Publicar en el sitio público
+            </label>
+            <Button type="submit" disabled={saving}>
+              {saving ? 'Guardando...' : isEditing ? 'Guardar cambios' : 'Crear noticia'}
+            </Button>
+          </form>
+          {message && <p className="mt-4 text-sm text-emerald-600">{message}</p>}
+          {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
+        </CardContent>
+      </Card>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-foreground">Noticias publicadas</h2>
+          <Button variant="secondary" onClick={loadItems} disabled={loading}>
+            {loading ? 'Actualizando...' : 'Actualizar listado'}
+          </Button>
+        </div>
+        <div className="overflow-x-auto rounded-xl border border-border">
+          <Table>
+            <thead>
+              <TableRow>
+                <TableHead>Título</TableHead>
+                <TableHead>Slug</TableHead>
+                <TableHead>Estado</TableHead>
+                <TableHead className="hidden md:table-cell">Métricas</TableHead>
+                <TableHead>Acciones</TableHead>
+              </TableRow>
+            </thead>
+            <tbody>
+              {items.map((item) => (
+                <TableRow key={item.id} className="align-top">
+                  <TableCell className="font-medium text-foreground">
+                    <div className="space-y-1">
+                      <p>{item.titulo}</p>
+                      <p className="text-xs text-slate-500">{item.resumen}</p>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-xs text-slate-500">{item.slug}</TableCell>
+                  <TableCell>
+                    <span
+                      className={
+                        item.publicado
+                          ? 'rounded-full bg-emerald-100 px-2 py-1 text-xs font-semibold text-emerald-700'
+                          : 'rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600'
+                      }
+                    >
+                      {item.publicado ? 'Publicado' : 'Borrador'}
+                    </span>
+                  </TableCell>
+                  <TableCell className="hidden text-xs text-slate-500 md:table-cell">
+                    <ul className="space-y-1">
+                      {item.metricas.map((metric) => (
+                        <li key={`${item.id}-${metric.label}`}>{metric.label}: {metric.value}</li>
+                      ))}
+                    </ul>
+                  </TableCell>
+                  <TableCell className="space-y-2 text-sm">
+                    <Button variant="ghost" size="sm" onClick={() => handleEdit(item)}>
+                      Editar
+                    </Button>
+                    <Button variant="ghost" size="sm" className="text-red-600" onClick={() => handleDelete(item.id)}>
+                      Eliminar
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {!items.length && !loading && (
+                <TableRow>
+                  <TableCell colSpan={5} className="py-6 text-center text-sm text-slate-500">
+                    No hay noticias cargadas todavía.
+                  </TableCell>
+                </TableRow>
+              )}
+              {loading && (
+                <TableRow>
+                  <TableCell colSpan={5} className="py-6 text-center text-sm text-slate-500">
+                    Cargando noticias...
+                  </TableCell>
+                </TableRow>
+              )}
+            </tbody>
+          </Table>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/nerin-electric-site-v3-fixed/app/admin/packs/layout.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/packs/layout.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+import { redirect } from 'next/navigation'
+import { requireAdmin } from '@/lib/auth'
+
+export const runtime = 'nodejs'
+
+export default async function AdminPacksLayout({ children }: { children: ReactNode }) {
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      redirect('/admin/login')
+    }
+
+    throw error
+  }
+
+  return <main className="mx-auto max-w-5xl space-y-10 px-6 pb-16 pt-10">{children}</main>
+}

--- a/nerin-electric-site-v3-fixed/app/admin/packs/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/packs/page.tsx
@@ -1,0 +1,411 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Table, TableCell, TableHead, TableRow } from '@/components/ui/table'
+import { Textarea } from '@/components/ui/textarea'
+
+type PricingPlan = {
+  title: string
+  price: string
+  slug: string
+  features: string[]
+  active?: boolean
+}
+
+type PricingResponse = {
+  plans?: PricingPlan[]
+}
+
+type PlanState = {
+  title: string
+  price: string
+  slug: string
+  features: string[]
+  active: boolean
+}
+
+type FormState = {
+  originalSlug: string | null
+  title: string
+  price: string
+  slug: string
+  featuresText: string
+  active: boolean
+}
+
+const emptyForm: FormState = {
+  originalSlug: null,
+  title: '',
+  price: '',
+  slug: '',
+  featuresText: '',
+  active: true,
+}
+
+function normalizePlan(plan: PricingPlan): PlanState {
+  return {
+    title: plan.title ?? '',
+    price: plan.price ?? '',
+    slug: plan.slug ?? '',
+    features: Array.isArray(plan.features) ? plan.features.map((item) => String(item)) : [],
+    active: plan.active ?? true,
+  }
+}
+
+function featuresToText(features: string[]): string {
+  return features.join('\n')
+}
+
+function textToFeatures(value: string): string[] {
+  return value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+export default function AdminPacksPage() {
+  const [plans, setPlans] = useState<PlanState[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const [form, setForm] = useState<FormState>(emptyForm)
+
+  const isEditing = useMemo(() => Boolean(form.originalSlug), [form.originalSlug])
+
+  const resetForm = useCallback(() => {
+    setForm(emptyForm)
+    setMessage(null)
+  }, [])
+
+  const loadPlans = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch('/api/admin/pricing', { cache: 'no-store' })
+
+      if (response.status === 401) {
+        setError('No tenés permisos para ver esta sección. Iniciá sesión nuevamente.')
+        setPlans([])
+        return
+      }
+
+      if (!response.ok) {
+        throw new Error('No se pudieron cargar los packs')
+      }
+
+      const data = (await response.json()) as PricingResponse
+      const normalized = (data.plans ?? []).map(normalizePlan)
+      setPlans(normalized)
+    } catch (err) {
+      console.error('Error fetching pricing plans', err)
+      setError('Ocurrió un error al cargar los packs. Intentá nuevamente más tarde.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadPlans()
+  }, [loadPlans])
+
+  const persistPlans = useCallback(
+    async (updatedPlans: PlanState[], successMessage: string) => {
+      setSaving(true)
+      setError(null)
+      setMessage(null)
+
+      try {
+        const response = await fetch('/api/admin/pricing', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            plans: updatedPlans.map((plan) => ({
+              title: plan.title,
+              price: plan.price,
+              slug: plan.slug,
+              features: plan.features,
+              active: plan.active,
+            })),
+          }),
+        })
+
+        if (response.status === 401) {
+          setError('No tenés permisos para realizar esta acción.')
+          return false
+        }
+
+        if (!response.ok) {
+          const errorData = (await response.json().catch(() => null)) as { error?: string } | null
+          throw new Error(errorData?.error ?? 'No se pudo guardar la información')
+        }
+
+        setPlans(updatedPlans)
+        setMessage(successMessage)
+        return true
+      } catch (err) {
+        console.error('Error saving pricing plans', err)
+        setError(err instanceof Error ? err.message : 'No se pudo guardar la información.')
+        return false
+      } finally {
+        setSaving(false)
+      }
+    },
+    [],
+  )
+
+  const handleEdit = useCallback((plan: PlanState) => {
+    setForm({
+      originalSlug: plan.slug,
+      title: plan.title,
+      price: plan.price,
+      slug: plan.slug,
+      featuresText: featuresToText(plan.features),
+      active: plan.active,
+    })
+    setMessage(null)
+  }, [])
+
+  const handleDelete = useCallback(
+    async (slug: string) => {
+      const confirmed = window.confirm('¿Seguro que querés eliminar este pack? Esta acción no se puede deshacer.')
+      if (!confirmed) return
+
+      const updated = plans.filter((plan) => plan.slug !== slug)
+      const success = await persistPlans(updated, 'Pack eliminado correctamente.')
+      if (success && form.originalSlug === slug) {
+        resetForm()
+      }
+    },
+    [plans, persistPlans, form.originalSlug, resetForm],
+  )
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      if (!form.title.trim() || !form.slug.trim() || !form.price.trim()) {
+        setError('Completá los campos obligatorios antes de guardar.')
+        return
+      }
+
+      const normalizedSlug = form.slug.trim()
+      const existingSlug = plans.find((plan) => plan.slug === normalizedSlug)
+      const editingSlug = form.originalSlug
+
+      if (!editingSlug && existingSlug) {
+        setError('Ese slug ya está en uso. Elegí otro identificador.')
+        return
+      }
+
+      if (editingSlug && existingSlug && existingSlug.slug !== editingSlug) {
+        setError('Ese slug ya está en uso por otro pack.')
+        return
+      }
+
+      const newPlan: PlanState = {
+        title: form.title.trim(),
+        price: form.price.trim(),
+        slug: normalizedSlug,
+        features: textToFeatures(form.featuresText),
+        active: form.active,
+      }
+
+      let updatedPlans: PlanState[]
+      let successMessage = 'Pack creado correctamente.'
+
+      if (editingSlug) {
+        updatedPlans = plans.map((plan) => (plan.slug === editingSlug ? newPlan : plan))
+        successMessage = 'Pack actualizado correctamente.'
+      } else {
+        updatedPlans = [newPlan, ...plans]
+      }
+
+      const success = await persistPlans(updatedPlans, successMessage)
+
+      if (success) {
+        setForm({
+          originalSlug: newPlan.slug,
+          title: newPlan.title,
+          price: newPlan.price,
+          slug: newPlan.slug,
+          featuresText: featuresToText(newPlan.features),
+          active: newPlan.active,
+        })
+      }
+    },
+    [form, plans, persistPlans],
+  )
+
+  return (
+    <div className="space-y-10">
+      <header className="space-y-2">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">Panel administrativo</p>
+            <h1 className="text-2xl font-semibold text-foreground">Packs y planes comerciales</h1>
+            <p className="text-sm text-slate-600">
+              Actualizá los packs disponibles en el sitio y controlá qué planes se muestran como destacados.
+            </p>
+          </div>
+          <Button variant="secondary" asChild>
+            <Link href="/admin">Volver al panel</Link>
+          </Button>
+        </div>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>{isEditing ? 'Editar pack' : 'Nuevo pack'}</CardTitle>
+            {isEditing && (
+              <Button variant="ghost" type="button" onClick={resetForm}>
+                Crear nuevo
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <form className="grid gap-4" onSubmit={handleSubmit}>
+            <div className="grid gap-2">
+              <Label htmlFor="titulo">Título</Label>
+              <Input
+                id="titulo"
+                value={form.title}
+                onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="slug">Slug</Label>
+              <Input
+                id="slug"
+                placeholder="ej: pack-premium"
+                value={form.slug}
+                onChange={(event) => setForm((prev) => ({ ...prev, slug: event.target.value }))}
+                required
+              />
+              <p className="text-xs text-slate-500">Usá minúsculas y guiones para identificar el pack.</p>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="price">Precio</Label>
+              <Input
+                id="price"
+                placeholder="$1.000.000 + IVA"
+                value={form.price}
+                onChange={(event) => setForm((prev) => ({ ...prev, price: event.target.value }))}
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="features">Características (una por línea)</Label>
+              <Textarea
+                id="features"
+                value={form.featuresText}
+                onChange={(event) => setForm((prev) => ({ ...prev, featuresText: event.target.value }))}
+              />
+            </div>
+            <label className="flex items-center gap-2 text-sm text-slate-600">
+              <input
+                type="checkbox"
+                checked={form.active}
+                onChange={(event) => setForm((prev) => ({ ...prev, active: event.target.checked }))}
+              />
+              Mostrar como activo en el sitio
+            </label>
+            <Button type="submit" disabled={saving}>
+              {saving ? 'Guardando...' : isEditing ? 'Guardar cambios' : 'Crear pack'}
+            </Button>
+          </form>
+          {message && <p className="mt-4 text-sm text-emerald-600">{message}</p>}
+          {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
+        </CardContent>
+      </Card>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-foreground">Packs configurados</h2>
+          <Button variant="secondary" onClick={loadPlans} disabled={loading}>
+            {loading ? 'Actualizando...' : 'Actualizar listado'}
+          </Button>
+        </div>
+        <div className="overflow-x-auto rounded-xl border border-border">
+          <Table>
+            <thead>
+              <TableRow>
+                <TableHead>Título</TableHead>
+                <TableHead>Slug</TableHead>
+                <TableHead>Precio</TableHead>
+                <TableHead>Estado</TableHead>
+                <TableHead className="hidden md:table-cell">Características</TableHead>
+                <TableHead>Acciones</TableHead>
+              </TableRow>
+            </thead>
+            <tbody>
+              {plans.map((plan) => (
+                <TableRow key={plan.slug} className="align-top">
+                  <TableCell className="font-medium text-foreground">{plan.title}</TableCell>
+                  <TableCell className="text-xs text-slate-500">{plan.slug}</TableCell>
+                  <TableCell>{plan.price}</TableCell>
+                  <TableCell>
+                    <span
+                      className={
+                        plan.active
+                          ? 'rounded-full bg-emerald-100 px-2 py-1 text-xs font-semibold text-emerald-700'
+                          : 'rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600'
+                      }
+                    >
+                      {plan.active ? 'Activo' : 'Oculto'}
+                    </span>
+                  </TableCell>
+                  <TableCell className="hidden text-xs text-slate-500 md:table-cell">
+                    <ul className="space-y-1">
+                      {plan.features.map((feature, index) => (
+                        <li key={`${plan.slug}-feature-${index}`}>{feature}</li>
+                      ))}
+                    </ul>
+                  </TableCell>
+                  <TableCell className="space-y-2 text-sm">
+                    <Button variant="ghost" size="sm" onClick={() => handleEdit(plan)}>
+                      Editar
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-red-600"
+                      onClick={() => handleDelete(plan.slug)}
+                    >
+                      Eliminar
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {!plans.length && !loading && (
+                <TableRow>
+                  <TableCell colSpan={6} className="py-6 text-center text-sm text-slate-500">
+                    Todavía no cargaste packs.
+                  </TableCell>
+                </TableRow>
+              )}
+              {loading && (
+                <TableRow>
+                  <TableCell colSpan={6} className="py-6 text-center text-sm text-slate-500">
+                    Cargando packs...
+                  </TableCell>
+                </TableRow>
+              )}
+            </tbody>
+          </Table>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/nerin-electric-site-v3-fixed/app/api/admin/case-studies/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/case-studies/route.ts
@@ -1,0 +1,287 @@
+import { NextResponse } from 'next/server'
+import { revalidatePath } from 'next/cache'
+import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+import { parseJson, parseStringArray, serializeJson, serializeStringArray } from '@/lib/serialization'
+
+type Metric = { label: string; value: string }
+
+type CaseStudyPayload = {
+  id?: string
+  titulo?: string
+  slug?: string
+  resumen?: string
+  contenido?: string
+  metricas?: unknown
+  fotos?: unknown
+  publicado?: unknown
+}
+
+function unauthorizedResponse() {
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+}
+
+function badRequestResponse(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 })
+}
+
+function parseMetrics(value: unknown): Metric[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((item) => {
+      if (item && typeof item === 'object' && 'label' in item && 'value' in item) {
+        const label = String((item as Record<string, unknown>).label ?? '')
+        const metricValue = String((item as Record<string, unknown>).value ?? '')
+
+        if (label.trim() && metricValue.trim()) {
+          return { label: label.trim(), value: metricValue.trim() }
+        }
+      }
+      return null
+    })
+    .filter((item): item is Metric => Boolean(item))
+}
+
+function parseFotos(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((item) => String(item ?? '').trim())
+    .filter((item) => Boolean(item))
+}
+
+function slugify(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+async function ensureUniqueSlug(desired: string, excludeId?: string): Promise<string> {
+  const fallback = 'caso-de-exito'
+  const baseSlug = slugify(desired) || fallback
+
+  let candidate = baseSlug
+  let suffix = 2
+
+  while (true) {
+    const existing = await prisma.caseStudy.findUnique({ where: { slug: candidate } })
+
+    if (!existing || existing.id === excludeId) {
+      return candidate
+    }
+
+    candidate = `${baseSlug}-${suffix}`
+    suffix += 1
+  }
+}
+
+function serializeMetrics(metricas: Metric[]): string | null {
+  if (!metricas.length) {
+    return null
+  }
+
+  return serializeJson(metricas)
+}
+
+function formatCaseStudy(caseStudy: {
+  id: string
+  titulo: string
+  slug: string
+  resumen: string
+  contenido: string
+  metricas: string | null
+  fotos: string
+  publicado: boolean
+  createdAt: Date
+  updatedAt: Date
+}) {
+  return {
+    id: caseStudy.id,
+    titulo: caseStudy.titulo,
+    slug: caseStudy.slug,
+    resumen: caseStudy.resumen,
+    contenido: caseStudy.contenido,
+    metricas: parseMetrics(parseJson(caseStudy.metricas) ?? []),
+    fotos: parseStringArray(caseStudy.fotos),
+    publicado: caseStudy.publicado,
+    createdAt: caseStudy.createdAt,
+    updatedAt: caseStudy.updatedAt,
+  }
+}
+
+function revalidateCaseStudyPaths(slug?: string) {
+  try {
+    revalidatePath('/blog')
+    revalidatePath('/blog/[slug]')
+    if (slug) {
+      revalidatePath(`/blog/${slug}`)
+    }
+    revalidatePath('/admin')
+  } catch (error) {
+    console.error('Error al revalidar las rutas del blog', error)
+  }
+}
+
+export async function GET() {
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return unauthorizedResponse()
+    }
+
+    throw error
+  }
+
+  const caseStudies = await prisma.caseStudy.findMany({
+    orderBy: { createdAt: 'desc' },
+  })
+
+  return NextResponse.json({
+    items: caseStudies.map((caseStudy) => formatCaseStudy(caseStudy)),
+  })
+}
+
+export async function POST(req: Request) {
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return unauthorizedResponse()
+    }
+
+    throw error
+  }
+
+  const body = (await req.json()) as CaseStudyPayload
+  const titulo = body.titulo?.trim()
+  const resumen = body.resumen?.trim()
+  const contenido = body.contenido?.trim()
+
+  if (!titulo || !resumen || !contenido) {
+    return badRequestResponse('Faltan datos obligatorios para crear la noticia.')
+  }
+
+  const metricas = parseMetrics(body.metricas)
+  const fotos = parseFotos(body.fotos)
+  const publicado = Boolean(body.publicado)
+
+  const desiredSlug = body.slug?.trim() || titulo
+  const uniqueSlug = await ensureUniqueSlug(desiredSlug)
+
+  const created = await prisma.caseStudy.create({
+    data: {
+      titulo,
+      resumen,
+      contenido,
+      slug: uniqueSlug,
+      metricas: serializeMetrics(metricas),
+      fotos: serializeStringArray(fotos),
+      publicado,
+    },
+  })
+
+  revalidateCaseStudyPaths(created.slug)
+
+  return NextResponse.json({ item: formatCaseStudy(created) }, { status: 201 })
+}
+
+export async function PUT(req: Request) {
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return unauthorizedResponse()
+    }
+
+    throw error
+  }
+
+  const body = (await req.json()) as CaseStudyPayload
+  const id = body.id
+
+  if (!id) {
+    return badRequestResponse('Falta el identificador de la noticia.')
+  }
+
+  const existing = await prisma.caseStudy.findUnique({ where: { id } })
+
+  if (!existing) {
+    return NextResponse.json({ error: 'Noticia no encontrada.' }, { status: 404 })
+  }
+
+  const titulo = body.titulo?.trim() || existing.titulo
+  const resumen = body.resumen?.trim() || existing.resumen
+  const contenido = body.contenido?.trim() || existing.contenido
+  const metricas = body.metricas ? parseMetrics(body.metricas) : parseMetrics(parseJson(existing.metricas) ?? [])
+  const fotos = body.fotos ? parseFotos(body.fotos) : parseStringArray(existing.fotos)
+  const publicado = body.publicado !== undefined ? Boolean(body.publicado) : existing.publicado
+
+  const desiredSlug = body.slug?.trim() || existing.slug
+  const uniqueSlug = await ensureUniqueSlug(desiredSlug, existing.id)
+  const previousSlug = existing.slug
+
+  const updated = await prisma.caseStudy.update({
+    where: { id },
+    data: {
+      titulo,
+      resumen,
+      contenido,
+      slug: uniqueSlug,
+      metricas: serializeMetrics(metricas),
+      fotos: serializeStringArray(fotos),
+      publicado,
+    },
+  })
+
+  revalidateCaseStudyPaths(updated.slug)
+  if (previousSlug !== updated.slug) {
+    revalidateCaseStudyPaths(previousSlug)
+  }
+
+  return NextResponse.json({ item: formatCaseStudy(updated) })
+}
+
+export async function DELETE(req: Request) {
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return unauthorizedResponse()
+    }
+
+    throw error
+  }
+
+  const { searchParams } = new URL(req.url)
+  const idFromQuery = searchParams.get('id') ?? undefined
+  const body = idFromQuery ? null : ((await req.json().catch(() => null)) as CaseStudyPayload | null)
+  const id = idFromQuery ?? body?.id
+
+  if (!id) {
+    return badRequestResponse('Falta el identificador de la noticia.')
+  }
+
+  const existing = await prisma.caseStudy.findUnique({ where: { id } })
+
+  if (!existing) {
+    return NextResponse.json({ error: 'Noticia no encontrada.' }, { status: 404 })
+  }
+
+  await prisma.caseStudy.delete({ where: { id } })
+
+  revalidateCaseStudyPaths(existing.slug)
+
+  return NextResponse.json({ ok: true })
+}


### PR DESCRIPTION
## Summary
- add secured case study CRUD API with automatic slug collision handling and required revalidation hooks
- build admin views for managing noticias and packs from the dashboard, backed by the existing admin APIs
- link the main admin panel to the new sections for quick navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68faf0149dec8331a43ae4a0aa3d1bf1