### PR TITLE
Enhance admin dashboard and marketing configuration

### DIFF
--- a/nerin-electric-site-v3-fixed/.gitignore
+++ b/nerin-electric-site-v3-fixed/.gitignore
@@ -1,0 +1,18 @@
+node_modules/
+.next/
+.out/
+.vercel/
+.env
+.env.*
+# Prisma local database
+prisma/dev.db
+# Local storage for admin content
+.data/
+# Testing and coverage artifacts
+coverage/
+playwright-report/
+playwright/.cache/
+
+# OS artifacts
+.DS_Store
+Thumbs.db

--- a/nerin-electric-site-v3-fixed/app/admin/(dashboard)/BlogManager.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/(dashboard)/BlogManager.tsx
@@ -1,0 +1,333 @@
+
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Table, TableCell, TableHead, TableRow } from '@/components/ui/table'
+
+interface BlogSummary {
+  slug: string
+  title: string
+  publishedAt?: string
+}
+
+interface BlogPayload {
+  slug: string
+  title: string
+  excerpt: string
+  content: string
+  publishedAt: string
+  heroImage?: string
+  tags: string[]
+}
+
+type MessageState = { type: 'success' | 'error'; message: string } | null
+
+const EMPTY_FORM: BlogPayload = {
+  slug: '',
+  title: '',
+  excerpt: '',
+  content: '',
+  publishedAt: new Date().toISOString().slice(0, 10),
+  heroImage: '',
+  tags: [],
+}
+
+export function BlogManager() {
+  const [posts, setPosts] = useState<BlogSummary[]>([])
+  const [form, setForm] = useState<BlogPayload>(EMPTY_FORM)
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState<MessageState>(null)
+
+  const isEditing = useMemo(() => Boolean(selectedSlug), [selectedSlug])
+
+  const loadList = useCallback(async () => {
+    try {
+      const response = await fetch('/api/admin/list?type=blog', { cache: 'no-store' })
+      if (!response.ok) {
+        throw new Error('No se pudo cargar la lista de artículos')
+      }
+      const slugs = (await response.json()) as string[]
+      setPosts(slugs.map((slug) => ({ slug, title: slug })))
+    } catch (error) {
+      console.error('Failed to load blog list', error)
+      setMessage({ type: 'error', message: 'Error al cargar la lista del blog.' })
+    }
+  }, [])
+
+  const loadPost = useCallback(async (slug: string) => {
+    setLoading(true)
+    setMessage(null)
+    try {
+      const response = await fetch(`/api/admin/item?type=blog&slug=${slug}`, { cache: 'no-store' })
+      if (!response.ok) {
+        throw new Error('No se pudo cargar el artículo')
+      }
+      const data = (await response.json()) as {
+        data?: { title?: string; excerpt?: string; publishedAt?: string; heroImage?: string; tags?: string[] }
+        content?: string
+      }
+      setForm({
+        slug,
+        title: data.data?.title ?? '',
+        excerpt: data.data?.excerpt ?? '',
+        publishedAt: data.data?.publishedAt ?? new Date().toISOString().slice(0, 10),
+        heroImage: data.data?.heroImage ?? '',
+        tags: Array.isArray(data.data?.tags) ? data.data?.tags ?? [] : [],
+        content: data.content ?? '',
+      })
+      setPosts((prev) =>
+        prev.map((item) =>
+          item.slug === slug
+            ? { ...item, title: data.data?.title ?? item.title, publishedAt: data.data?.publishedAt }
+            : item,
+        ),
+      )
+      setSelectedSlug(slug)
+    } catch (error) {
+      console.error('Failed to load blog post', error)
+      setMessage({ type: 'error', message: 'No se pudo cargar el artículo seleccionado.' })
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadList()
+  }, [loadList])
+
+  const resetForm = useCallback(() => {
+    setForm(EMPTY_FORM)
+    setSelectedSlug(null)
+    setMessage(null)
+  }, [])
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      if (!form.slug.trim()) {
+        setMessage({ type: 'error', message: 'El slug es obligatorio.' })
+        return
+      }
+      if (!form.title.trim() || !form.content.trim()) {
+        setMessage({ type: 'error', message: 'Completá título y contenido.' })
+        return
+      }
+
+      setLoading(true)
+      setMessage(null)
+
+      const payload = {
+        data: {
+          title: form.title.trim(),
+          excerpt: form.excerpt.trim(),
+          publishedAt: form.publishedAt,
+          heroImage: form.heroImage?.trim() || undefined,
+          tags: form.tags,
+        },
+        content: form.content,
+      }
+
+      try {
+        const response = await fetch(`/api/admin/item?type=blog&slug=${form.slug.trim()}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+        if (!response.ok) {
+          const errorData = (await response.json().catch(() => null)) as { error?: string } | null
+          throw new Error(errorData?.error ?? 'No se pudo guardar el artículo')
+        }
+        setMessage({ type: 'success', message: 'Artículo guardado correctamente.' })
+        const savedSlug = form.slug.trim()
+        setSelectedSlug(savedSlug)
+        await loadList()
+        setPosts((prev) =>
+          prev.map((item) =>
+            item.slug === savedSlug
+              ? { ...item, title: form.title.trim(), publishedAt: form.publishedAt }
+              : item,
+          ),
+        )
+      } catch (error) {
+        console.error('Failed to save blog post', error)
+        setMessage({ type: 'error', message: error instanceof Error ? error.message : 'No se pudo guardar el artículo.' })
+      } finally {
+        setLoading(false)
+      }
+    },
+    [form, loadList],
+  )
+
+  const handleDelete = useCallback(
+    async (slug: string) => {
+      const confirmed = window.confirm('¿Eliminar este artículo del blog?')
+      if (!confirmed) return
+
+      setLoading(true)
+      setMessage(null)
+      try {
+        const response = await fetch(`/api/admin/item?type=blog&slug=${slug}`, { method: 'DELETE' })
+        if (!response.ok) {
+          throw new Error('No se pudo eliminar el artículo')
+        }
+        await loadList()
+        if (selectedSlug === slug) {
+          resetForm()
+        }
+        setMessage({ type: 'success', message: 'Artículo eliminado.' })
+      } catch (error) {
+        console.error('Failed to delete blog post', error)
+        setMessage({ type: 'error', message: 'No se pudo eliminar el artículo. Intentá nuevamente.' })
+      } finally {
+        setLoading(false)
+      }
+    },
+    [loadList, resetForm, selectedSlug],
+  )
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle>Blog y notas técnicas</CardTitle>
+            <p className="text-sm text-slate-600">
+              Publicá contenido editorial desde el panel. Los artículos se almacenan en <code>.data/blog</code> como JSON +
+              markdown.
+            </p>
+            {message && (
+              <p className={`text-xs ${message.type === 'success' ? 'text-emerald-600' : 'text-red-600'}`}>{message.message}</p>
+            )}
+          </div>
+          <Button type="button" variant="ghost" onClick={resetForm} disabled={loading}>
+            Crear nuevo artículo
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-8 lg:grid-cols-[1.2fr_1fr]">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid gap-2">
+            <Label htmlFor="blog-slug">Slug</Label>
+            <Input
+              id="blog-slug"
+              value={form.slug}
+              onChange={(event) => setForm((prev) => ({ ...prev, slug: event.target.value }))}
+              placeholder="ej: obra-corporativa"
+              required
+              readOnly={isEditing}
+            />
+            {isEditing && <p className="text-xs text-slate-500">El slug no se puede editar una vez creado.</p>}
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="blog-title">Título</Label>
+            <Input
+              id="blog-title"
+              value={form.title}
+              onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+              required
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="blog-excerpt">Resumen</Label>
+            <Textarea
+              id="blog-excerpt"
+              value={form.excerpt}
+              onChange={(event) => setForm((prev) => ({ ...prev, excerpt: event.target.value }))}
+              required
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="blog-published">Fecha de publicación</Label>
+            <Input
+              id="blog-published"
+              type="date"
+              value={form.publishedAt}
+              onChange={(event) => setForm((prev) => ({ ...prev, publishedAt: event.target.value }))}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="blog-hero">Imagen principal (URL opcional)</Label>
+            <Input
+              id="blog-hero"
+              value={form.heroImage ?? ''}
+              onChange={(event) => setForm((prev) => ({ ...prev, heroImage: event.target.value }))}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="blog-tags">Tags (separadas por coma)</Label>
+            <Input
+              id="blog-tags"
+              value={form.tags.join(', ')}
+              onChange={(event) =>
+                setForm((prev) => ({
+                  ...prev,
+                  tags: event.target.value
+                    .split(',')
+                    .map((tag) => tag.trim())
+                    .filter(Boolean),
+                }))
+              }
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="blog-content">Contenido (Markdown simple)</Label>
+            <Textarea
+              id="blog-content"
+              rows={12}
+              value={form.content}
+              onChange={(event) => setForm((prev) => ({ ...prev, content: event.target.value }))}
+              required
+            />
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Button type="submit" disabled={loading}>
+              {isEditing ? 'Actualizar artículo' : 'Publicar artículo'}
+            </Button>
+            {isEditing && (
+              <Button type="button" variant="ghost" onClick={() => handleDelete(form.slug)} disabled={loading}>
+                Eliminar
+              </Button>
+            )}
+          </div>
+        </form>
+
+        <div className="space-y-4">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Artículos existentes</h3>
+          <div className="overflow-hidden rounded-2xl border border-border">
+            <Table>
+              <thead>
+                <TableRow>
+                  <TableHead>Slug</TableHead>
+                  <TableHead>Título</TableHead>
+                  <TableHead className="text-right">Acciones</TableHead>
+                </TableRow>
+              </thead>
+              <tbody>
+                {posts.map((post) => (
+                  <TableRow key={post.slug}>
+                    <TableCell>{post.slug}</TableCell>
+                    <TableCell>{post.title}</TableCell>
+                    <TableCell className="flex justify-end gap-2">
+                      <Button type="button" size="sm" variant="secondary" onClick={() => loadPost(post.slug)} disabled={loading}>
+                        Editar
+                      </Button>
+                      <Button type="button" size="sm" variant="ghost" onClick={() => handleDelete(post.slug)} disabled={loading}>
+                        Eliminar
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </tbody>
+            </Table>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/nerin-electric-site-v3-fixed/app/admin/(dashboard)/BrandManager.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/(dashboard)/BrandManager.tsx
@@ -1,0 +1,216 @@
+
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Table, TableCell, TableHead, TableRow } from '@/components/ui/table'
+
+interface Brand {
+  id: string
+  nombre: string
+  logoUrl?: string | null
+}
+
+interface BrandManagerProps {
+  initialBrands: Brand[]
+}
+
+type MessageState = { type: 'success' | 'error'; message: string } | null
+
+export function BrandManager({ initialBrands }: BrandManagerProps) {
+  const [brands, setBrands] = useState<Brand[]>(initialBrands)
+  const [form, setForm] = useState<{ id: string | null; nombre: string; logoUrl: string }>({
+    id: null,
+    nombre: '',
+    logoUrl: '',
+  })
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState<MessageState>(null)
+
+  const isEditing = useMemo(() => Boolean(form.id), [form.id])
+
+  const loadBrands = useCallback(async () => {
+    try {
+      const response = await fetch('/api/admin/brands', { cache: 'no-store' })
+      if (!response.ok) {
+        throw new Error('No se pudo cargar la lista de marcas')
+      }
+      const data = (await response.json()) as { items: Brand[] }
+      setBrands(data.items)
+    } catch (error) {
+      console.error('Failed to load brands', error)
+      setMessage({ type: 'error', message: 'Error al actualizar la tabla de marcas.' })
+    }
+  }, [])
+
+  const resetForm = useCallback(() => {
+    setForm({ id: null, nombre: '', logoUrl: '' })
+    setMessage(null)
+  }, [])
+
+  const handleEdit = useCallback((brand: Brand) => {
+    setForm({ id: brand.id, nombre: brand.nombre, logoUrl: brand.logoUrl ?? '' })
+    setMessage(null)
+  }, [])
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      const confirmed = window.confirm('¿Eliminar esta marca? Esta acción no se puede deshacer.')
+      if (!confirmed) return
+
+      setLoading(true)
+      setMessage(null)
+      try {
+        const response = await fetch(`/api/admin/brands?id=${id}`, { method: 'DELETE' })
+        if (!response.ok) {
+          throw new Error('No se pudo eliminar la marca')
+        }
+        await loadBrands()
+        if (form.id === id) {
+          resetForm()
+        }
+        setMessage({ type: 'success', message: 'Marca eliminada correctamente.' })
+      } catch (error) {
+        console.error('Failed to delete brand', error)
+        setMessage({ type: 'error', message: 'No se pudo eliminar la marca. Intentá nuevamente.' })
+      } finally {
+        setLoading(false)
+      }
+    },
+    [form.id, loadBrands, resetForm],
+  )
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      setLoading(true)
+      setMessage(null)
+
+      const payload = {
+        id: form.id ?? undefined,
+        nombre: form.nombre.trim(),
+        logoUrl: form.logoUrl.trim() || undefined,
+      }
+
+      try {
+        const response = await fetch('/api/admin/brands', {
+          method: isEditing ? 'PUT' : 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+
+        if (!response.ok) {
+          const errorData = (await response.json().catch(() => null)) as { error?: string } | null
+          throw new Error(errorData?.error ?? 'No se pudo guardar la marca')
+        }
+
+        await loadBrands()
+        setMessage({ type: 'success', message: isEditing ? 'Marca actualizada.' : 'Marca creada.' })
+        setForm((prev) => ({ ...prev, id: prev.id ?? null }))
+        if (!isEditing) {
+          resetForm()
+        }
+      } catch (error) {
+        console.error('Failed to save brand', error)
+        setMessage({ type: 'error', message: error instanceof Error ? error.message : 'No se pudo guardar la marca.' })
+      } finally {
+        setLoading(false)
+      }
+    },
+    [form.id, form.logoUrl, form.nombre, isEditing, loadBrands, resetForm],
+  )
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle>Marcas y partners tecnológicos</CardTitle>
+            <p className="text-sm text-slate-600">
+              Cargá marcas que se muestran en el home y en la página de contacto. Podés incluir la URL del logo hospedado en
+              CDN propio.
+            </p>
+            {message && (
+              <p className={`text-xs ${message.type === 'success' ? 'text-emerald-600' : 'text-red-600'}`}>{message.message}</p>
+            )}
+          </div>
+          {isEditing && (
+            <Button variant="ghost" type="button" onClick={resetForm} disabled={loading}>
+              Crear nueva marca
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form onSubmit={handleSubmit} className="grid gap-4 md:grid-cols-[1fr_1fr_auto] md:items-end">
+          <div className="grid gap-2">
+            <Label htmlFor="brand-name">Nombre</Label>
+            <Input
+              id="brand-name"
+              value={form.nombre}
+              onChange={(event) => setForm((prev) => ({ ...prev, nombre: event.target.value }))}
+              required
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="brand-logo">Logo (URL opcional)</Label>
+            <Input
+              id="brand-logo"
+              value={form.logoUrl}
+              onChange={(event) => setForm((prev) => ({ ...prev, logoUrl: event.target.value }))}
+              placeholder="https://..."
+            />
+          </div>
+          <Button type="submit" disabled={loading}>
+            {isEditing ? 'Actualizar' : 'Agregar'}
+          </Button>
+        </form>
+
+        <div className="overflow-x-auto">
+          <Table>
+            <thead>
+              <TableRow>
+                <TableHead>Nombre</TableHead>
+                <TableHead>Logo</TableHead>
+                <TableHead className="text-right">Acciones</TableHead>
+              </TableRow>
+            </thead>
+            <tbody>
+              {brands.map((brand) => (
+                <TableRow key={brand.id}>
+                  <TableCell>{brand.nombre}</TableCell>
+                  <TableCell className="text-sm text-slate-500">
+                    {brand.logoUrl ? (
+                      <a className="text-accent underline" href={brand.logoUrl} target="_blank" rel="noreferrer">
+                        {brand.logoUrl}
+                      </a>
+                    ) : (
+                      <span className="text-slate-400">Sin logo</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="flex justify-end gap-2">
+                    <Button type="button" variant="secondary" size="sm" onClick={() => handleEdit(brand)} disabled={loading}>
+                      Editar
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDelete(brand.id)}
+                      disabled={loading}
+                    >
+                      Eliminar
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </tbody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/nerin-electric-site-v3-fixed/app/admin/(dashboard)/SiteExperienceDesigner.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/(dashboard)/SiteExperienceDesigner.tsx
@@ -1,0 +1,984 @@
+
+'use client'
+
+import { useMemo, useState } from 'react'
+import type { SiteExperience } from '@/types/site'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+
+interface SiteExperienceDesignerProps {
+  initialData: SiteExperience
+}
+
+type MessageState = { type: 'success' | 'error'; message: string } | null
+
+function parsePairs(value: string): Array<{ label: string; description: string }> {
+  return value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [label, ...rest] = line.split('|')
+      const description = rest.join('|').trim()
+      return { label: label.trim(), description }
+    })
+    .filter((item) => item.label && item.description)
+}
+
+function parseList(value: string): string[] {
+  return value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function formatPairs(items: Array<{ label: string; description: string }>): string {
+  return items.map((item) => `${item.label} | ${item.description}`).join('\n')
+}
+
+function formatList(items: string[]): string {
+  return items.join('\n')
+}
+
+export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerProps) {
+  const [form, setForm] = useState<SiteExperience>(initialData)
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState<MessageState>(null)
+
+  const heroStatsText = useMemo(() => formatPairs(form.hero.stats), [form.hero.stats])
+  const heroHighlightsText = useMemo(() => formatPairs(form.hero.highlights), [form.hero.highlights])
+  const servicesText = useMemo(() => formatPairs(form.services.items), [form.services.items])
+  const faqText = useMemo(
+    () => form.faq.items.map((item) => `${item.question} | ${item.answer}`).join('\n'),
+    [form.faq.items],
+  )
+  const maintenanceCardsText = useMemo(() => formatPairs(form.maintenance.cards), [form.maintenance.cards])
+  const maintenancePageCardsText = useMemo(
+    () => formatPairs(form.maintenancePage.cards),
+    [form.maintenancePage.cards],
+  )
+  const responsiveText = useMemo(() => formatList(form.responsive.bulletPoints), [form.responsive.bulletPoints])
+  const secondaryPhonesText = useMemo(() => form.contact.secondaryPhones.join('\n'), [form.contact.secondaryPhones])
+  const seoKeywordsText = useMemo(() => form.seo.keywords.join(', '), [form.seo.keywords])
+
+  async function handleSave() {
+    setSaving(true)
+    setMessage(null)
+    try {
+      const response = await fetch('/api/admin/site', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      })
+      if (!response.ok) {
+        throw new Error('No se pudo guardar la configuración')
+      }
+      setMessage({ type: 'success', message: 'Configuración guardada correctamente.' })
+    } catch (error) {
+      console.error('Error saving site configuration', error)
+      setMessage({ type: 'error', message: 'Ocurrió un error al guardar. Intentá nuevamente.' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleReset() {
+    setForm(initialData)
+    setMessage(null)
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-xl font-semibold text-foreground">Diseñador de experiencia del sitio</h2>
+        <p className="text-sm text-slate-600">
+          Editá textos, mensajes clave, datos de contacto y contenido destacado del home, blog, obras y mantenimiento.
+          Cada cambio se guarda en <code>.data/site.json</code> y actualiza el sitio completo.
+        </p>
+        {message && (
+          <p
+            className={`text-sm ${message.type === 'success' ? 'text-emerald-600' : 'text-red-600'}`}
+            role="status"
+          >
+            {message.message}
+          </p>
+        )}
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Identidad y contacto</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-2">
+              <Label htmlFor="site-name">Nombre comercial</Label>
+              <Input
+                id="site-name"
+                value={form.name}
+                onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="site-tagline">Tagline</Label>
+              <Textarea
+                id="site-tagline"
+                value={form.tagline}
+                onChange={(event) => setForm((prev) => ({ ...prev, tagline: event.target.value }))}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="site-email">Correo principal</Label>
+              <Input
+                id="site-email"
+                value={form.contact.email}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    contact: { ...prev.contact, email: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="site-phone">Teléfono principal</Label>
+              <Input
+                id="site-phone"
+                value={form.contact.phone}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    contact: { ...prev.contact, phone: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="site-secondary-phones">Teléfonos alternativos (uno por línea)</Label>
+              <Textarea
+                id="site-secondary-phones"
+                value={secondaryPhonesText}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    contact: { ...prev.contact, secondaryPhones: parseList(event.target.value) },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="site-address">Dirección / Oficina técnica</Label>
+              <Input
+                id="site-address"
+                value={form.contact.address}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    contact: { ...prev.contact, address: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="site-schedule">Horarios</Label>
+              <Input
+                id="site-schedule"
+                value={form.contact.schedule}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    contact: { ...prev.contact, schedule: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="site-service-area">Área de cobertura</Label>
+              <Input
+                id="site-service-area"
+                value={form.contact.serviceArea}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    contact: { ...prev.contact, serviceArea: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="site-whatsapp-number">WhatsApp (solo números)</Label>
+              <Input
+                id="site-whatsapp-number"
+                value={form.contact.whatsappNumber}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    contact: { ...prev.contact, whatsappNumber: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="site-whatsapp-message">Mensaje inicial de WhatsApp</Label>
+              <Textarea
+                id="site-whatsapp-message"
+                value={form.contact.whatsappMessage}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    contact: { ...prev.contact, whatsappMessage: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="site-instagram">Instagram</Label>
+              <Input
+                id="site-instagram"
+                value={form.socials.instagram}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    socials: { ...prev.socials, instagram: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="site-linkedin">LinkedIn</Label>
+              <Input
+                id="site-linkedin"
+                value={form.socials.linkedin}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    socials: { ...prev.socials, linkedin: event.target.value },
+                  }))
+                }
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Hero y mensajes clave</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-2">
+              <Label htmlFor="hero-badge">Badge</Label>
+              <Input
+                id="hero-badge"
+                value={form.hero.badge}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    hero: { ...prev.hero, badge: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="hero-title">Título</Label>
+              <Textarea
+                id="hero-title"
+                value={form.hero.title}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    hero: { ...prev.hero, title: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="hero-subtitle">Subtítulo</Label>
+              <Textarea
+                id="hero-subtitle"
+                value={form.hero.subtitle}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    hero: { ...prev.hero, subtitle: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="hero-background">Imagen de fondo (URL)</Label>
+              <Input
+                id="hero-background"
+                value={form.hero.backgroundImage}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    hero: { ...prev.hero, backgroundImage: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="hero-caption">Leyenda de la imagen</Label>
+              <Textarea
+                id="hero-caption"
+                value={form.hero.caption}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    hero: { ...prev.hero, caption: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="hero-primary-label">CTA principal</Label>
+              <Input
+                id="hero-primary-label"
+                value={form.hero.primaryCta.label}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    hero: {
+                      ...prev.hero,
+                      primaryCta: { ...prev.hero.primaryCta, label: event.target.value },
+                    },
+                  }))
+                }
+              />
+              <Input
+                placeholder="/contacto"
+                value={form.hero.primaryCta.href}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    hero: {
+                      ...prev.hero,
+                      primaryCta: { ...prev.hero.primaryCta, href: event.target.value },
+                    },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label>CTA secundario</Label>
+              <Input
+                value={form.hero.secondaryCta.label}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    hero: {
+                      ...prev.hero,
+                      secondaryCta: { ...prev.hero.secondaryCta, label: event.target.value },
+                    },
+                  }))
+                }
+              />
+              <Input
+                placeholder="[whatsapp]"
+                value={form.hero.secondaryCta.href}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    hero: {
+                      ...prev.hero,
+                      secondaryCta: { ...prev.hero.secondaryCta, href: event.target.value },
+                    },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label>CTA terciario</Label>
+              <Input
+                value={form.hero.tertiaryCta.label}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    hero: {
+                      ...prev.hero,
+                      tertiaryCta: { ...prev.hero.tertiaryCta, label: event.target.value },
+                    },
+                  }))
+                }
+              />
+              <Input
+                value={form.hero.tertiaryCta.href}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    hero: {
+                      ...prev.hero,
+                      tertiaryCta: { ...prev.hero.tertiaryCta, href: event.target.value },
+                    },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="hero-highlights">Highlights (Título | Descripción)</Label>
+              <Textarea
+                id="hero-highlights"
+                value={heroHighlightsText}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    hero: { ...prev.hero, highlights: parsePairs(event.target.value) },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="hero-stats">Stats (Título | Descripción)</Label>
+              <Textarea
+                id="hero-stats"
+                value={heroStatsText}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    hero: { ...prev.hero, stats: parsePairs(event.target.value) },
+                  }))
+                }
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Servicios y packs</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-2">
+              <Label htmlFor="services-title">Título de servicios</Label>
+              <Input
+                id="services-title"
+                value={form.services.title}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    services: { ...prev.services, title: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="services-description">Descripción</Label>
+              <Textarea
+                id="services-description"
+                value={form.services.description}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    services: { ...prev.services, description: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="services-items">Servicios (Título | Descripción)</Label>
+              <Textarea
+                id="services-items"
+                value={servicesText}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    services: { ...prev.services, items: parsePairs(event.target.value) },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="packs-title">Título de packs</Label>
+              <Input
+                id="packs-title"
+                value={form.packs.title}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    packs: { ...prev.packs, title: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="packs-description">Descripción packs</Label>
+              <Textarea
+                id="packs-description"
+                value={form.packs.description}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    packs: { ...prev.packs, description: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="packs-cta-label">CTA packs</Label>
+              <Input
+                id="packs-cta-label"
+                value={form.packs.ctaLabel}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    packs: { ...prev.packs, ctaLabel: event.target.value },
+                  }))
+                }
+              />
+              <Input
+                placeholder="/presupuestador"
+                value={form.packs.ctaHref}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    packs: { ...prev.packs, ctaHref: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="packs-note">Nota adicional packs</Label>
+              <Textarea
+                id="packs-note"
+                value={form.packs.note}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    packs: { ...prev.packs, note: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="maintenance-title">Título mantenimiento</Label>
+              <Input
+                id="maintenance-title"
+                value={form.maintenance.title}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    maintenance: { ...prev.maintenance, title: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="maintenance-description">Descripción mantenimiento</Label>
+              <Textarea
+                id="maintenance-description"
+                value={form.maintenance.description}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    maintenance: { ...prev.maintenance, description: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="maintenance-cards">Highlights mantenimiento (Título | Descripción)</Label>
+              <Textarea
+                id="maintenance-cards"
+                value={maintenanceCardsText}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    maintenance: { ...prev.maintenance, cards: parsePairs(event.target.value) },
+                  }))
+                }
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Contenido editorial</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-2">
+              <Label htmlFor="works-title">Título obras</Label>
+              <Input
+                id="works-title"
+                value={form.works.title}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    works: { ...prev.works, title: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="works-description">Descripción obras</Label>
+              <Textarea
+                id="works-description"
+                value={form.works.description}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    works: { ...prev.works, description: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="works-intro-title">Título página obras</Label>
+              <Input
+                id="works-intro-title"
+                value={form.works.introTitle}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    works: { ...prev.works, introTitle: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="works-intro-description">Descripción página obras</Label>
+              <Textarea
+                id="works-intro-description"
+                value={form.works.introDescription}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    works: { ...prev.works, introDescription: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="blog-title">Título blog</Label>
+              <Input
+                id="blog-title"
+                value={form.blog.title}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    blog: { ...prev.blog, title: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="blog-description">Descripción blog</Label>
+              <Textarea
+                id="blog-description"
+                value={form.blog.description}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    blog: { ...prev.blog, description: event.target.value },
+                  }))
+                }
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Preguntas frecuentes y CTA final</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-2">
+              <Label htmlFor="faq-title">Título FAQ</Label>
+              <Input
+                id="faq-title"
+                value={form.faq.title}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    faq: { ...prev.faq, title: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="faq-description">Descripción FAQ</Label>
+              <Textarea
+                id="faq-description"
+                value={form.faq.description}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    faq: { ...prev.faq, description: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="faq-items">Preguntas (Pregunta | Respuesta)</Label>
+              <Textarea
+                id="faq-items"
+                value={faqText}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    faq: {
+                      ...prev.faq,
+                      items: event.target.value
+                        .split('\n')
+                        .map((line) => line.trim())
+                        .filter(Boolean)
+                        .map((line) => {
+                          const [question, ...rest] = line.split('|')
+                          return { question: question.trim(), answer: rest.join('|').trim() }
+                        })
+                        .filter((item) => item.question && item.answer),
+                    },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="closing-title">Título CTA final</Label>
+              <Input
+                id="closing-title"
+                value={form.closingCta.title}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    closingCta: { ...prev.closingCta, title: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="closing-description">Descripción CTA final</Label>
+              <Textarea
+                id="closing-description"
+                value={form.closingCta.description}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    closingCta: { ...prev.closingCta, description: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label>CTA primario</Label>
+              <Input
+                value={form.closingCta.primary.label}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    closingCta: {
+                      ...prev.closingCta,
+                      primary: { ...prev.closingCta.primary, label: event.target.value },
+                    },
+                  }))
+                }
+              />
+              <Input
+                value={form.closingCta.primary.href}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    closingCta: {
+                      ...prev.closingCta,
+                      primary: { ...prev.closingCta.primary, href: event.target.value },
+                    },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label>CTA secundario</Label>
+              <Input
+                value={form.closingCta.secondary.label}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    closingCta: {
+                      ...prev.closingCta,
+                      secondary: { ...prev.closingCta.secondary, label: event.target.value },
+                    },
+                  }))
+                }
+              />
+              <Input
+                value={form.closingCta.secondary.href}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    closingCta: {
+                      ...prev.closingCta,
+                      secondary: { ...prev.closingCta.secondary, href: event.target.value },
+                    },
+                  }))
+                }
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Páginas de contacto y mantenimiento</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-2">
+              <Label htmlFor="contact-intro-title">Título contacto</Label>
+              <Input
+                id="contact-intro-title"
+                value={form.contactPage.introTitle}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    contactPage: { ...prev.contactPage, introTitle: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="contact-intro-description">Descripción contacto</Label>
+              <Textarea
+                id="contact-intro-description"
+                value={form.contactPage.introDescription}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    contactPage: { ...prev.contactPage, introDescription: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="contact-bullets">Diferenciales contacto (uno por línea)</Label>
+              <Textarea
+                id="contact-bullets"
+                value={formatList(form.contactPage.highlightBullets)}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    contactPage: { ...prev.contactPage, highlightBullets: parseList(event.target.value) },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="contact-typeform">Enlace Typeform</Label>
+              <Input
+                id="contact-typeform"
+                value={form.contactPage.typeformUrl}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    contactPage: { ...prev.contactPage, typeformUrl: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="maintenance-page-cards">Sección mantenimiento (Título | Descripción)</Label>
+              <Textarea
+                id="maintenance-page-cards"
+                value={maintenancePageCardsText}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    maintenancePage: { ...prev.maintenancePage, cards: parsePairs(event.target.value) },
+                  }))
+                }
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Responsive y SEO</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-2">
+              <Label htmlFor="responsive-headline">Headline responsive</Label>
+              <Input
+                id="responsive-headline"
+                value={form.responsive.headline}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    responsive: { ...prev.responsive, headline: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="responsive-bullets">Notas responsive (una por línea)</Label>
+              <Textarea
+                id="responsive-bullets"
+                value={responsiveText}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    responsive: { ...prev.responsive, bulletPoints: parseList(event.target.value) },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="seo-title">Título SEO</Label>
+              <Input
+                id="seo-title"
+                value={form.seo.metaTitle}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    seo: { ...prev.seo, metaTitle: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="seo-description">Descripción SEO</Label>
+              <Textarea
+                id="seo-description"
+                value={form.seo.metaDescription}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    seo: { ...prev.seo, metaDescription: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="seo-keywords">Keywords (separadas por coma)</Label>
+              <Textarea
+                id="seo-keywords"
+                value={seoKeywordsText}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    seo: {
+                      ...prev.seo,
+                      keywords: event.target.value
+                        .split(',')
+                        .map((item) => item.trim())
+                        .filter(Boolean),
+                    },
+                  }))
+                }
+              />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? 'Guardando…' : 'Guardar cambios'}
+        </Button>
+        <Button type="button" variant="secondary" onClick={handleReset} disabled={saving}>
+          Revertir cambios
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/nerin-electric-site-v3-fixed/app/admin/(dashboard)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/(dashboard)/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = 'force-dynamic'
 import Link from 'next/link'
 import dynamicImport from 'next/dynamic'
 import { prisma } from '@/lib/db'
+import { getSiteContent } from '@/lib/site-content'
 import { createAdditional, createCertificate } from '../actions'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -12,27 +13,32 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { CaseStudyForm } from './case-study-form'
 import { MaintenanceForm } from './maintenance-form'
+import { SiteExperienceDesigner } from './SiteExperienceDesigner'
+import { BrandManager } from './BrandManager'
+import { BlogManager } from './BlogManager'
 
 const AdminPacks = dynamicImport(() => import('./AdminPacks'), { ssr: false })
 
 export const revalidate = 0
 
 export default async function AdminPage() {
-  const [packs, adicionales, plans, projects] = await Promise.all([
+  const site = getSiteContent()
+  const [packs, adicionales, plans, projects, brands] = await Promise.all([
     prisma.pack.findMany({ orderBy: { createdAt: 'desc' } }),
     prisma.additionalItem.findMany({ orderBy: { createdAt: 'desc' } }),
     prisma.maintenancePlan.findMany({ orderBy: { createdAt: 'desc' } }),
     prisma.project.findMany({ orderBy: { createdAt: 'desc' } }),
+    prisma.brand.findMany({ orderBy: { nombre: 'asc' } }),
   ])
 
   return (
-    <div className="space-y-10">
+    <div className="space-y-12">
       <header className="space-y-2">
         <Badge>Panel administrativo</Badge>
-        <h1>Gestión de contenidos y operaciones</h1>
+        <h1>Control total de contenido y operaciones</h1>
         <p className="text-sm text-slate-600">
-          Administrá packs, adicionales, planes de mantenimiento, casos de éxito y certificados de avance. Todos los
-          cambios impactan en el sitio público y en el portal de clientes.
+          Diseñá la experiencia del sitio, gestioná marcas, blog, packs, planes de mantenimiento y certificados desde un solo
+          lugar. Cada cambio impacta en el sitio público, clientes y SEO.
         </p>
         <div className="flex flex-wrap gap-3 pt-2">
           <Button variant="outline" asChild>
@@ -43,6 +49,13 @@ export default async function AdminPage() {
           </Button>
         </div>
       </header>
+
+      <SiteExperienceDesigner initialData={site} />
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <BrandManager initialBrands={brands} />
+        <BlogManager />
+      </section>
 
       <section className="grid gap-6 lg:grid-cols-2">
         <Card>

--- a/nerin-electric-site-v3-fixed/app/api/admin/brands/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/brands/route.ts
@@ -1,0 +1,75 @@
+
+import { NextResponse } from 'next/server'
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+
+const BrandSchema = z.object({
+  id: z.string().optional(),
+  nombre: z.string().min(2, 'El nombre es obligatorio'),
+  logoUrl: z.string().url().optional().or(z.literal('').transform(() => undefined)),
+})
+
+function sanitizeLogo(logoUrl?: string) {
+  if (!logoUrl) return undefined
+  const trimmed = logoUrl.trim()
+  return trimmed.length ? trimmed : undefined
+}
+
+function revalidateMarketing() {
+  revalidatePath('/')
+  revalidatePath('/contacto')
+}
+
+export async function GET() {
+  await requireAdmin()
+  const items = await prisma.brand.findMany({ orderBy: { nombre: 'asc' } })
+  return NextResponse.json({ items })
+}
+
+export async function POST(request: Request) {
+  await requireAdmin()
+  const json = await request.json()
+  const payload = BrandSchema.parse(json)
+
+  const brand = await prisma.brand.create({
+    data: {
+      nombre: payload.nombre,
+      logoUrl: sanitizeLogo(payload.logoUrl) ?? null,
+    },
+  })
+
+  revalidateMarketing()
+  return NextResponse.json({ item: brand })
+}
+
+export async function PUT(request: Request) {
+  await requireAdmin()
+  const json = await request.json()
+  const payload = BrandSchema.extend({ id: z.string() }).parse(json)
+
+  const brand = await prisma.brand.update({
+    where: { id: payload.id },
+    data: {
+      nombre: payload.nombre,
+      logoUrl: sanitizeLogo(payload.logoUrl) ?? null,
+    },
+  })
+
+  revalidateMarketing()
+  return NextResponse.json({ item: brand })
+}
+
+export async function DELETE(request: Request) {
+  await requireAdmin()
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+  if (!id) {
+    return NextResponse.json({ error: 'Falta id' }, { status: 400 })
+  }
+
+  await prisma.brand.delete({ where: { id } })
+  revalidateMarketing()
+  return NextResponse.json({ ok: true })
+}

--- a/nerin-electric-site-v3-fixed/app/api/admin/site/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/site/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { revalidatePath } from 'next/cache'
 import { readSite, writeSite } from '@/lib/content'
 import { requireAdmin } from '@/lib/auth'
 
@@ -20,5 +21,12 @@ export async function POST(req: Request) {
   await requireAdmin()
   const body = await req.json()
   writeSite(body)
+  revalidatePath('/')
+  revalidatePath('/contacto')
+  revalidatePath('/empresa')
+  revalidatePath('/obras')
+  revalidatePath('/blog')
+  revalidatePath('/packs')
+  revalidatePath('/mantenimiento')
   return NextResponse.json({ ok: true })
 }

--- a/nerin-electric-site-v3-fixed/app/blog/[slug]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation'
 import { Badge } from '@/components/ui/badge'
-import { blogPosts } from '@/content/blogPosts'
+import { getBlogPost } from '@/lib/blog'
+import { getSiteContent } from '@/lib/site-content'
 
 export const revalidate = 3600
 
@@ -9,14 +10,15 @@ interface Props {
 }
 
 export default function BlogPostPage({ params }: Props) {
-  const post = blogPosts.find((item) => item.slug === params.slug)
+  const site = getSiteContent()
+  const post = getBlogPost(params.slug)
   if (!post) {
     notFound()
   }
 
   return (
     <article className="space-y-6">
-      <Badge>Blog</Badge>
+      <Badge>{site.blog.introTitle}</Badge>
       <h1>{post.title}</h1>
       <p className="text-sm text-slate-500">
         {new Date(post.publishedAt).toLocaleDateString('es-AR', {

--- a/nerin-electric-site-v3-fixed/app/blog/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/blog/page.tsx
@@ -1,22 +1,22 @@
 import Link from 'next/link'
 import { Badge } from '@/components/ui/badge'
-import { blogPosts } from '@/content/blogPosts'
+import { getBlogPosts } from '@/lib/blog'
+import { getSiteContent } from '@/lib/site-content'
 
 export const revalidate = 3600
 
 export default function BlogPage() {
+  const site = getSiteContent()
+  const posts = getBlogPosts()
   return (
     <div className="space-y-8">
       <header className="space-y-4">
-        <Badge>Blog</Badge>
-        <h1>Insights eléctricos y buenas prácticas</h1>
-        <p className="text-lg text-slate-600">
-          Consejos prácticos para administradores, desarrolladores y equipos de facilities que buscan instalaciones
-          confiables y auditables.
-        </p>
+        <Badge>{site.blog.introTitle}</Badge>
+        <h1>{site.blog.title}</h1>
+        <p className="text-lg text-slate-600">{site.blog.description}</p>
       </header>
       <div className="grid gap-6 md:grid-cols-2">
-        {blogPosts.map((post) => (
+        {posts.map((post) => (
           <article key={post.slug} className="rounded-3xl border border-border bg-white p-6 shadow-subtle">
             <p className="text-xs uppercase tracking-wide text-slate-400">
               {new Date(post.publishedAt).toLocaleDateString('es-AR', {

--- a/nerin-electric-site-v3-fixed/app/contacto/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/contacto/page.tsx
@@ -6,10 +6,14 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
+import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 
 export const revalidate = 60
 
 export default function ContactoPage({ searchParams }: { searchParams?: { enviado?: string } }) {
+  const site = getSiteContent()
+  const whatsappHref = getWhatsappHref(site)
+
   async function action(formData: FormData) {
     'use server'
     await submitContact(formData)
@@ -20,11 +24,8 @@ export default function ContactoPage({ searchParams }: { searchParams?: { enviad
     <div className="grid gap-16 lg:grid-cols-[1.2fr_1fr]">
       <div className="space-y-8">
         <Badge>Contacto</Badge>
-        <h1>Coordinemos tu obra eléctrica</h1>
-        <p className="text-lg text-slate-600">
-          Completá el formulario y un técnico senior se contactará dentro de las próximas 24 horas hábiles para
-          coordinar visita o reunión virtual.
-        </p>
+        <h1>{site.contactPage.introTitle}</h1>
+        <p className="text-lg text-slate-600">{site.contactPage.introDescription}</p>
         {searchParams?.enviado === '1' && (
           <p className="rounded-2xl border border-accent/30 bg-accent/10 p-4 text-sm text-slate-700">
             ¡Listo! Recibimos tu consulta. Te contactamos por mail dentro de las próximas 24 horas hábiles.
@@ -89,27 +90,45 @@ export default function ContactoPage({ searchParams }: { searchParams?: { enviad
             Enviar consulta
           </Button>
           <p className="text-xs text-slate-500">
-            También podés usar nuestro <Link className="underline" href="https://nerin.typeform.com/to/xxxxx">Typeform</Link>
-            {' '}si preferís completar desde el celular.
+            También podés usar nuestro{' '}
+            <Link className="underline" href={site.contactPage.typeformUrl}>
+              Typeform
+            </Link>{' '}
+            si preferís completar desde el celular.
           </p>
         </form>
       </div>
       <aside className="space-y-6 rounded-3xl border border-border bg-white p-8 shadow-subtle">
         <h2>¿Por qué elegir NERIN?</h2>
         <ul className="space-y-3 text-sm text-slate-600">
-          <li>• Equipo propio con ART y seguros vigentes.</li>
-          <li>• Certificados de avance con pago online vía Mercado Pago.</li>
-          <li>• Reportes fotográficos y checklist digital en cada visita.</li>
-          <li>• Trabajo bajo normativa AEA 90364-7-771 (2006).</li>
-          <li>• Separación transparente entre mano de obra y materiales.</li>
+          {site.contactPage.highlightBullets.map((item) => (
+            <li key={item}>• {item}</li>
+          ))}
         </ul>
         <div className="rounded-2xl bg-muted p-6 text-sm text-slate-600">
           <p className="font-semibold text-foreground">WhatsApp directo</p>
-          <p>+54 9 11 0000 0000</p>
+          <p>{site.contact.whatsappNumber}</p>
           <p className="mt-3 font-semibold text-foreground">Correo</p>
-          <p>hola@nerin.com.ar</p>
+          <p>{site.contact.email}</p>
           <p className="mt-3 font-semibold text-foreground">Oficina técnica</p>
-          <p>Villa Ortúzar · CABA</p>
+          <p>{site.contact.address}</p>
+          <p className="mt-3 font-semibold text-foreground">Horarios</p>
+          <p>{site.contact.schedule}</p>
+          <p className="mt-3 font-semibold text-foreground">Área de cobertura</p>
+          <p>{site.contact.serviceArea}</p>
+          {site.contact.secondaryPhones.length > 0 && (
+            <div className="mt-3">
+              <p className="font-semibold text-foreground">Teléfonos alternativos</p>
+              <ul className="mt-1 space-y-1">
+                {site.contact.secondaryPhones.map((phone) => (
+                  <li key={phone}>{phone}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <Button asChild size="sm" variant="secondary" className="mt-4">
+            <Link href={whatsappHref}>Iniciar conversación</Link>
+          </Button>
         </div>
       </aside>
     </div>

--- a/nerin-electric-site-v3-fixed/app/empresa/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/empresa/page.tsx
@@ -3,53 +3,53 @@ import Image from 'next/image'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { getTechniciansForMarketing } from '@/lib/marketing-data'
+import { getSiteContent } from '@/lib/site-content'
 
 export const revalidate = 60
 
 export default async function EmpresaPage() {
   const technicians = await getTechniciansForMarketing()
+  const site = getSiteContent()
 
   return (
     <div className="space-y-12">
       <header className="space-y-4">
         <Badge>Empresa</Badge>
-        <h1>NERIN: ingeniería eléctrica con protocolos y trazabilidad</h1>
-        <p className="max-w-3xl text-lg text-slate-600">
-          Somos un equipo multidisciplinario con más de 15 años en obras eléctricas para retail, gimnasios,
-          corporativos y viviendas premium. Operamos con mano de obra propia, ART al día y seguros de RC.
-        </p>
+        <h1>{site.company.introTitle}</h1>
+        <p className="max-w-3xl text-lg text-slate-600">{site.company.introDescription}</p>
+        <p className="max-w-2xl text-sm text-slate-500">{site.company.mission}</p>
       </header>
 
       <section className="grid gap-6 md:grid-cols-2">
         <Card>
           <CardHeader>
-            <CardTitle>Protocolos de trabajo</CardTitle>
+            <CardTitle>{site.company.protocolsTitle}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3 text-sm text-slate-600">
             <p>Planificamos cada obra con cronograma, responsables y controles de calidad.</p>
             <ul className="space-y-2">
-              <li>• Ingreso de personal con ART Swiss Medical y certificado de aptitud.</li>
-              <li>• Checklist diario de seguridad y reportes fotográficos.</li>
-              <li>• Entrega de carpeta final con planos, memorias y certificados.</li>
+              {site.company.protocols.map((item) => (
+                <li key={item}>• {item}</li>
+              ))}
             </ul>
           </CardContent>
         </Card>
         <Card>
           <CardHeader>
-            <CardTitle>Compliance y seguros</CardTitle>
+            <CardTitle>{site.company.complianceTitle}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3 text-sm text-slate-600">
             <ul className="space-y-2">
-              <li>• Seguro de RC hasta USD 2M.</li>
-              <li>• Contratos transparentes, pagos escalonados por certificados.</li>
-              <li>• Cumplimiento de normativa AEA 90364-7-771, NFPA 70 y reglamentos locales.</li>
+              {site.company.compliance.map((item) => (
+                <li key={item}>• {item}</li>
+              ))}
             </ul>
           </CardContent>
         </Card>
       </section>
 
       <section className="space-y-4">
-        <h2 className="text-2xl font-semibold text-foreground">Equipo técnico</h2>
+        <h2 className="text-2xl font-semibold text-foreground">{site.company.teamTitle}</h2>
         <div className="grid gap-6 md:grid-cols-3">
           {technicians.map((tech) => (
             <Card key={tech.id} className="space-y-3">

--- a/nerin-electric-site-v3-fixed/app/layout.tsx
+++ b/nerin-electric-site-v3-fixed/app/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css'
 import type { Metadata } from 'next'
 import { Inter, Sora } from 'next/font/google'
-import { siteConfig } from '@/lib/config'
+import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import { Header } from '@/components/Header'
 import { Footer } from '@/components/Footer'
 import { Providers } from '@/components/Providers'
@@ -10,31 +10,34 @@ import { cn } from '@/lib/utils'
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
 const sora = Sora({ subsets: ['latin'], variable: '--font-sora' })
 
+const site = getSiteContent()
+const whatsappHref = getWhatsappHref(site)
+
 export const metadata: Metadata = {
   metadataBase: new URL('https://nerin-electric.render.com'),
   title: {
-    default: siteConfig.name,
-    template: `%s · ${siteConfig.name}`,
+    default: site.seo.metaTitle,
+    template: `%s · ${site.name}`,
   },
-  description: siteConfig.description,
-  keywords: siteConfig.keywords,
+  description: site.seo.metaDescription,
+  keywords: site.seo.keywords,
   alternates: {
     canonical: '/',
   },
   openGraph: {
-    title: siteConfig.name,
-    description: siteConfig.description,
-    url: siteConfig.domain,
+    title: site.seo.metaTitle,
+    description: site.seo.metaDescription,
+    url: 'https://www.nerin.com.ar',
     siteName: 'NERIN Electric',
     locale: 'es_AR',
     type: 'website',
-    images: [{ url: siteConfig.ogImage, width: 1200, height: 630, alt: 'NERIN Electric' }],
+    images: [{ url: '/nerin/og-cover.png', width: 1200, height: 630, alt: 'NERIN Electric' }],
   },
   twitter: {
     card: 'summary_large_image',
-    title: siteConfig.name,
-    description: siteConfig.description,
-    images: [siteConfig.ogImage],
+    title: site.seo.metaTitle,
+    description: site.seo.metaDescription,
+    images: ['/nerin/og-cover.png'],
   },
 }
 
@@ -43,17 +46,22 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="es-AR" className={cn(inter.variable, sora.variable)}>
       <body className="min-h-screen bg-background font-sans text-foreground antialiased">
         <Providers>
-          <Header />
+          <Header
+            contact={{
+              whatsappHref,
+              whatsappLabel: site.hero.secondaryCta.label,
+            }}
+          />
           <main className="container pb-24 pt-16">{children}</main>
-          <Footer />
+          <Footer site={site} />
           <a
             className="fixed bottom-6 right-6 hidden h-14 rounded-full bg-[#25D366] px-6 text-sm font-semibold text-white shadow-xl transition hover:scale-[1.02] focus-visible:ring-2 focus-visible:ring-white/60 md:inline-flex md:items-center"
-            href={`https://wa.me/${siteConfig.whatsapp.number}?text=${encodeURIComponent(siteConfig.whatsapp.message)}`}
+            href={whatsappHref}
             target="_blank"
             rel="noreferrer"
             aria-label="Hablar con NERIN por WhatsApp"
           >
-            Hablar por WhatsApp
+            {site.hero.secondaryCta.label}
           </a>
         </Providers>
       </body>

--- a/nerin-electric-site-v3-fixed/app/layout.tsx
+++ b/nerin-electric-site-v3-fixed/app/layout.tsx
@@ -10,38 +10,42 @@ import { cn } from '@/lib/utils'
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
 const sora = Sora({ subsets: ['latin'], variable: '--font-sora' })
 
-const site = getSiteContent()
-const whatsappHref = getWhatsappHref(site)
+export function generateMetadata(): Metadata {
+  const site = getSiteContent()
 
-export const metadata: Metadata = {
-  metadataBase: new URL('https://nerin-electric.render.com'),
-  title: {
-    default: site.seo.metaTitle,
-    template: `%s · ${site.name}`,
-  },
-  description: site.seo.metaDescription,
-  keywords: site.seo.keywords,
-  alternates: {
-    canonical: '/',
-  },
-  openGraph: {
-    title: site.seo.metaTitle,
+  return {
+    metadataBase: new URL('https://nerin-electric.render.com'),
+    title: {
+      default: site.seo.metaTitle,
+      template: `%s · ${site.name}`,
+    },
     description: site.seo.metaDescription,
-    url: 'https://www.nerin.com.ar',
-    siteName: 'NERIN Electric',
-    locale: 'es_AR',
-    type: 'website',
-    images: [{ url: '/nerin/og-cover.png', width: 1200, height: 630, alt: 'NERIN Electric' }],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: site.seo.metaTitle,
-    description: site.seo.metaDescription,
-    images: ['/nerin/og-cover.png'],
-  },
+    keywords: site.seo.keywords,
+    alternates: {
+      canonical: '/',
+    },
+    openGraph: {
+      title: site.seo.metaTitle,
+      description: site.seo.metaDescription,
+      url: 'https://www.nerin.com.ar',
+      siteName: 'NERIN Electric',
+      locale: 'es_AR',
+      type: 'website',
+      images: [{ url: '/nerin/og-cover.png', width: 1200, height: 630, alt: 'NERIN Electric' }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: site.seo.metaTitle,
+      description: site.seo.metaDescription,
+      images: ['/nerin/og-cover.png'],
+    },
+  }
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const site = getSiteContent()
+  const whatsappHref = getWhatsappHref(site)
+
   return (
     <html lang="es-AR" className={cn(inter.variable, sora.variable)}>
       <body className="min-h-screen bg-background font-sans text-foreground antialiased">

--- a/nerin-electric-site-v3-fixed/app/mantenimiento/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/mantenimiento/page.tsx
@@ -4,21 +4,20 @@ import { getMaintenancePlansForMarketing } from '@/lib/marketing-data'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { getSiteContent } from '@/lib/site-content'
 
 export const revalidate = 60
 
 export default async function MantenimientoPage() {
   const plans = await getMaintenancePlansForMarketing()
+  const site = getSiteContent()
 
   return (
     <div className="space-y-12">
       <header className="space-y-4">
         <Badge>Mantenimiento</Badge>
-        <h1>Planes de mantenimiento eléctrico con respuesta garantizada</h1>
-        <p className="max-w-3xl text-lg text-slate-600">
-          Supervisión programada, chequeos preventivos y atención de emergencias para edificios, oficinas y cadenas
-          comerciales. Cantidades fijas, sin sorpresas ni letra chica.
-        </p>
+        <h1>{site.maintenancePage.introTitle}</h1>
+        <p className="max-w-3xl text-lg text-slate-600">{site.maintenancePage.introDescription}</p>
       </header>
 
       <section className="grid gap-6 md:grid-cols-3">
@@ -56,27 +55,12 @@ export default async function MantenimientoPage() {
       <section className="rounded-3xl border border-border bg-white p-10 shadow-subtle">
         <h2 className="text-2xl font-semibold text-foreground">Alcance operativo</h2>
         <div className="mt-6 grid gap-6 md:grid-cols-3">
-          <div>
-            <h3 className="text-lg font-semibold text-foreground">Visitas preventivas</h3>
-            <p className="text-sm text-slate-600">
-              Revisión de tableros, medición de temperaturas, apriete de borneras, reposición de consumibles y
-              chequeo de iluminación LED (ej.: 10 lámparas incluidas en BASIC).
-            </p>
-          </div>
-          <div>
-            <h3 className="text-lg font-semibold text-foreground">Soporte correctivo</h3>
-            <p className="text-sm text-slate-600">
-              Atención de urgencias dentro de las 24 h hábiles. Priorizamos bombas, tableros generales y sistemas
-              críticos definidos en SLA.
-            </p>
-          </div>
-          <div>
-            <h3 className="text-lg font-semibold text-foreground">Reporte ejecutivo</h3>
-            <p className="text-sm text-slate-600">
-              Informe mensual con hallazgos, fotos geolocalizadas y recomendaciones de inversión para directorios o
-              administraciones.
-            </p>
-          </div>
+          {site.maintenancePage.cards.map((card) => (
+            <div key={card.title}>
+              <h3 className="text-lg font-semibold text-foreground">{card.title}</h3>
+              <p className="text-sm text-slate-600">{card.description}</p>
+            </div>
+          ))}
         </div>
       </section>
     </div>

--- a/nerin-electric-site-v3-fixed/app/obras/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/obras/page.tsx
@@ -3,21 +3,20 @@ import Link from 'next/link'
 import { getCaseStudiesForMarketing } from '@/lib/marketing-data'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { getSiteContent } from '@/lib/site-content'
 
 export const revalidate = 60
 
 export default async function ObrasPage() {
   const caseStudies = await getCaseStudiesForMarketing()
+  const site = getSiteContent()
 
   return (
     <div className="space-y-8">
       <header className="space-y-4">
         <Badge>Obras destacadas</Badge>
-        <h1>Casos de éxito y obras supervisadas</h1>
-        <p className="text-lg text-slate-600">
-          Selección de proyectos donde NERIN lideró la ingeniería eléctrica, montaje y certificaciones. Cada caso
-          documenta desafío, solución y normativa aplicada.
-        </p>
+        <h1>{site.works.introTitle}</h1>
+        <p className="text-lg text-slate-600">{site.works.introDescription}</p>
       </header>
       <section className="grid gap-6 md:grid-cols-2">
         {caseStudies.map((cs) => (

--- a/nerin-electric-site-v3-fixed/app/packs/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/packs/page.tsx
@@ -4,24 +4,24 @@ import { getPacksForMarketing } from '@/lib/marketing-data'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { getSiteContent } from '@/lib/site-content'
 
 export const revalidate = 60
 
 export default async function PacksPage() {
   const packs = await getPacksForMarketing()
+  const site = getSiteContent()
 
   return (
     <div className="space-y-16">
       <header className="space-y-6">
         <Badge>Packs de mano de obra</Badge>
-        <h1>Packs eléctricos para viviendas exigentes</h1>
-        <p className="text-lg text-slate-600">
-          Mano de obra certificada. Materiales no incluidos para que elijas marcas (Schneider, Prysmian, Gimsa,
-          Daisa, Genrock) según tu presupuesto. Proyecto eléctrico se cotiza aparte (base $500.000).
-        </p>
+        <h1>{site.packsPage.introTitle}</h1>
+        <p className="text-lg text-slate-600">{site.packsPage.introDescription}</p>
         <Button asChild size="pill">
           <Link href="/presupuestador">Configurar pack online</Link>
         </Button>
+        <p className="text-sm text-slate-500">{site.packsPage.note}</p>
       </header>
 
       <section className="space-y-8">

--- a/nerin-electric-site-v3-fixed/app/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/page.tsx
@@ -3,7 +3,7 @@ export const dynamic = 'force-dynamic'
 import Image from 'next/image'
 import Link from 'next/link'
 import { getMarketingHomeData } from '@/lib/marketing-data'
-import { siteConfig } from '@/lib/config'
+import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -11,56 +11,10 @@ import { Accordion, AccordionItem } from '@/components/ui/accordion'
 
 export const revalidate = 60
 
-const services = [
-  {
-    title: 'Instalaciones eléctricas completas',
-    description:
-      'Desde el proyecto ejecutivo hasta la puesta en marcha. Tableros, canalizaciones, cableado y medición.',
-  },
-  {
-    title: 'Tableros a medida',
-    description:
-      'Diseño, montaje y ensayos para tableros generales, seccionales y CCM. Certificación de normas vigentes.',
-  },
-  {
-    title: 'Puesta a tierra y descargas atmosféricas',
-    description: 'Mallas, jabalinas, mediciones con informes certificados y adecuaciones AEA 90364-7-771.',
-  },
-  {
-    title: 'Canalizaciones y bandejas portacables',
-    description: 'Tendidos prolijos, registro fotográfico y planimetría actualizada para obras exigentes.',
-  },
-  {
-    title: 'Datos, CCTV y audio profesional',
-    description: 'Redes estructuradas, cámaras, audio distribuido y automatización preparada para futuros upgrades.',
-  },
-  {
-    title: 'Aires acondicionados',
-    description: 'Instalación integral con cañería de cobre, vacío, carga y alimentación eléctrica independiente.',
-  },
-]
-
-const faqs = [
-  {
-    q: '¿Los packs incluyen materiales?',
-    a: 'No. Los packs son solo mano de obra certificada. Los materiales se cotizan aparte según la elección de marcas (Schneider, Prysmian, Gimsa, Daisa, Genrock).',
-  },
-  {
-    q: '¿El proyecto eléctrico está incluido?',
-    a: 'El proyecto eléctrico se cotiza aparte. Tiene un valor base de $500.000 editable desde el panel de administración.',
-  },
-  {
-    q: '¿Trabajan bajo normativa AEA?',
-    a: 'Sí. Nuestras instalaciones cumplen AEA 90364-7-771 (2006) y las reglamentaciones locales. Documentamos cada etapa.',
-  },
-  {
-    q: '¿Cómo se paga el avance de obra?',
-    a: 'Emitimos Certificados de Avance con porcentaje ejecutado. Podés abonarlos online vía Mercado Pago con el link que te enviamos.',
-  },
-]
-
 export default async function HomePage() {
   const { packs, plans, caseStudies, brands } = await getMarketingHomeData()
+  const site = getSiteContent()
+  const whatsappHref = getWhatsappHref(site)
 
   return (
     <div className="space-y-24">
@@ -70,82 +24,57 @@ export default async function HomePage() {
           __html: JSON.stringify({
             '@context': 'https://schema.org',
             '@type': 'Electrician',
-            name: 'NERIN Ingeniería Eléctrica',
+            name: site.name,
             url: 'https://www.nerin.com.ar',
-            telephone: siteConfig.whatsapp.number,
-            areaServed: 'Ciudad Autónoma de Buenos Aires y GBA',
-            serviceType: [
-              'Instalaciones eléctricas',
-              'Tableros',
-              'Puesta a tierra',
-              'Canalizaciones',
-              'Datos y CCTV',
-              'Mantenimiento eléctrico',
-            ],
+            telephone: site.contact.whatsappNumber,
+            areaServed: site.contact.serviceArea,
+            serviceType: site.services.items.map((item) => item.title),
           }),
         }}
       />
       <section className="grid gap-12 md:grid-cols-[1.2fr_1fr]">
         <div className="space-y-6">
-          <Badge>Contratista eléctrico integral en CABA</Badge>
-          <h1>
-            Obras eléctricas premium con trazabilidad total, sin sorpresas y listas para auditorías exigentes.
-          </h1>
-          <p className="max-w-xl text-lg text-slate-600">
-            NERIN acompaña a empresas, consorcios, gimnasios y viviendas de alto nivel desde el anteproyecto
-            hasta la entrega de certificados finales. Mano de obra propia, técnicos habilitados y reportes en
-            tiempo real.
-          </p>
+          <Badge>{site.hero.badge}</Badge>
+          <h1>{site.hero.title}</h1>
+          <p className="max-w-xl text-lg text-slate-600">{site.hero.subtitle}</p>
           <div className="flex flex-wrap gap-4">
             <Button size="pill" asChild>
-              <Link href="/contacto">Pedir presupuesto</Link>
+              <Link href={site.hero.primaryCta.href}>{site.hero.primaryCta.label}</Link>
             </Button>
             <Button size="pill" variant="secondary" asChild>
-              <Link
-                href={`https://wa.me/${siteConfig.whatsapp.number}?text=${encodeURIComponent(siteConfig.whatsapp.message)}`}
-              >
-                Hablar por WhatsApp
+              <Link href={site.hero.secondaryCta.href === '[whatsapp]' ? whatsappHref : site.hero.secondaryCta.href}>
+                {site.hero.secondaryCta.label}
               </Link>
             </Button>
             <Button size="pill" variant="ghost" asChild>
-              <Link href="/packs">Ver packs eléctricos</Link>
+              <Link href={site.hero.tertiaryCta.href}>{site.hero.tertiaryCta.label}</Link>
             </Button>
           </div>
           <div className="flex flex-wrap items-center gap-6 text-sm text-slate-500">
-            <div>
-              <p className="font-semibold text-foreground">+120 obras entregadas</p>
-              <p>Smart Fit, KFC, supermercados DIA, edificios corporativos.</p>
-            </div>
-            <div>
-              <p className="font-semibold text-foreground">Certificaciones y ART al día</p>
-              <p>Equipo propio, cobertura integral y protocolos de ingreso.</p>
-            </div>
+            {site.hero.highlights.map((highlight) => (
+              <div key={highlight.title}>
+                <p className="font-semibold text-foreground">{highlight.title}</p>
+                <p>{highlight.description}</p>
+              </div>
+            ))}
           </div>
         </div>
         <div className="relative hidden overflow-hidden rounded-3xl border border-border bg-gradient-to-br from-slate-100 to-slate-200 shadow-subtle md:block">
-          <Image
-            src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=900&q=80"
-            alt="Tablero eléctrico profesional instalado por NERIN"
-            fill
-            className="object-cover"
-          />
+          <Image src={site.hero.backgroundImage} alt={site.hero.caption} fill className="object-cover" />
           <div className="absolute inset-x-6 bottom-6 rounded-2xl bg-white/85 p-4 text-sm text-slate-600 shadow-subtle">
-            <p className="font-semibold text-slate-800">Tablero general edificio 4.000 m²</p>
-            <p>Montaje, etiquetado y ensayo térmico. Certificado RETIE y AEA 90364-7-771.</p>
+            <p className="font-semibold text-slate-800">{site.hero.caption}</p>
+            <p>{site.contact.serviceArea}</p>
           </div>
         </div>
       </section>
 
       <section className="grid gap-8 lg:grid-cols-3">
         <div className="lg:col-span-1">
-          <h2>Servicios eléctricos de punta a punta</h2>
-          <p>
-            Intervenimos en obra nueva, adecuaciones y expansión. Documentación completa, planos as-built y
-            soporte post entrega.
-          </p>
+          <h2>{site.services.title}</h2>
+          <p>{site.services.description}</p>
         </div>
         <div className="lg:col-span-2 grid gap-6 md:grid-cols-2">
-          {services.map((service) => (
+          {site.services.items.map((service) => (
             <Card key={service.title}>
               <CardHeader>
                 <CardTitle>{service.title}</CardTitle>
@@ -161,11 +90,11 @@ export default async function HomePage() {
       <section className="space-y-12">
         <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div>
-            <h2>Packs eléctricos para viviendas y countries</h2>
-            <p>Packs 100% mano de obra especializada. Materiales a elección del cliente, sin sobreprecios ocultos.</p>
+            <h2>{site.packs.title}</h2>
+            <p>{site.packs.description}</p>
           </div>
           <Button variant="secondary" asChild>
-            <Link href="/presupuestador">Configurar pack</Link>
+            <Link href={site.packs.ctaHref}>{site.packs.ctaLabel}</Link>
           </Button>
         </div>
         <div className="grid gap-6 md:grid-cols-3">
@@ -197,16 +126,14 @@ export default async function HomePage() {
             </Card>
           ))}
         </div>
+        <p className="text-sm text-slate-500">{site.packs.note}</p>
       </section>
 
       <section className="rounded-3xl bg-white p-10 shadow-subtle">
         <div className="grid gap-10 md:grid-cols-2">
           <div className="space-y-4">
-            <h2>Planes de mantenimiento con SLAs reales</h2>
-            <p>
-              Diseñados para oficinas, cadenas de retail y consorcios. Cantidades fijas inalterables, visitas
-              programadas y reportes digitales.
-            </p>
+            <h2>{site.maintenance.title}</h2>
+            <p>{site.maintenance.description}</p>
             <Button asChild>
               <Link href="/mantenimiento">Ver planes completos</Link>
             </Button>
@@ -234,8 +161,8 @@ export default async function HomePage() {
         <section className="space-y-6">
           <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
             <div>
-              <h2>Casos de éxito</h2>
-              <p>Resultados medibles y documentación lista para auditorías de seguros, ART y entes reguladores.</p>
+              <h2>{site.works.title}</h2>
+              <p>{site.works.description}</p>
             </div>
             <Button variant="ghost" asChild>
               <Link href="/obras">Ver todas las obras</Link>
@@ -261,7 +188,7 @@ export default async function HomePage() {
       )}
 
       <section className="rounded-3xl border border-border bg-white/60 p-10 shadow-subtle">
-        <h2 className="mb-6">Marcas que trabajamos todos los días</h2>
+        <h2 className="mb-6">{site.brands.title}</h2>
         <div className="grid grid-cols-2 gap-6 text-sm text-slate-500 md:grid-cols-5">
           {brands.map((brand) => (
             <div
@@ -272,18 +199,17 @@ export default async function HomePage() {
             </div>
           ))}
         </div>
+        <p className="mt-4 text-xs text-slate-500">{site.brands.note}</p>
       </section>
 
       <section className="grid gap-10 md:grid-cols-2">
         <div className="space-y-4">
-          <h2>Preguntas frecuentes</h2>
-          <p>
-            Transparencia total: contratos claros, avances certificados y soporte técnico en menos de 24 h hábil.
-          </p>
+          <h2>{site.faq.title}</h2>
+          <p>{site.faq.description}</p>
         </div>
         <Accordion>
-          {faqs.map((faq) => (
-            <AccordionItem key={faq.q} question={faq.q} answer={<p>{faq.a}</p>} />
+          {site.faq.items.map((faq) => (
+            <AccordionItem key={faq.question} question={faq.question} answer={<p>{faq.answer}</p>} />
           ))}
         </Accordion>
       </section>
@@ -291,18 +217,15 @@ export default async function HomePage() {
       <section className="rounded-3xl bg-gradient-to-br from-slate-900 to-slate-700 p-10 text-white">
         <div className="grid gap-6 md:grid-cols-2 md:items-center">
           <div className="space-y-4">
-            <h2 className="text-white">Listos para ejecutar tu obra eléctrica con excelencia</h2>
-            <p className="text-slate-200">
-              Coordinamos visita técnica, entregamos presupuesto detallado con desglose de mano de obra y
-              materiales sugeridos, y planificamos el cronograma completo.
-            </p>
+            <h2 className="text-white">{site.closingCta.title}</h2>
+            <p className="text-slate-200">{site.closingCta.description}</p>
           </div>
           <div className="flex flex-wrap gap-4 md:justify-end">
             <Button size="pill" asChild>
-              <Link href="/contacto">Solicitar visita técnica</Link>
+              <Link href={site.closingCta.primary.href}>{site.closingCta.primary.label}</Link>
             </Button>
             <Button size="pill" variant="secondary" asChild>
-              <Link href="/presupuestador">Configurar pack online</Link>
+              <Link href={site.closingCta.secondary.href}>{site.closingCta.secondary.label}</Link>
             </Button>
           </div>
         </div>

--- a/nerin-electric-site-v3-fixed/components/Footer.tsx
+++ b/nerin-electric-site-v3-fixed/components/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
-import { siteConfig } from '@/lib/config'
+import type { SiteExperience } from '@/types/site'
+import { getWhatsappHref } from '@/lib/site-content'
 
 const legalLinks = [
   { href: '/terminos', label: 'Términos y condiciones' },
@@ -13,18 +14,23 @@ const quickLinks = [
   { href: '/faq', label: 'Preguntas frecuentes' },
 ] as const
 
-export function Footer() {
+interface FooterProps {
+  site: SiteExperience
+}
+
+export function Footer({ site }: FooterProps) {
+  const whatsappHref = getWhatsappHref(site)
   return (
     <footer className="border-t border-border bg-white">
       <div className="container grid gap-12 py-14 md:grid-cols-4">
         <div className="space-y-3">
           <p className="text-sm uppercase tracking-[0.35em] text-slate-400">NERIN</p>
           <p className="text-sm text-slate-500">
-            Ingeniería eléctrica integral para obras, empresas y viviendas premium en CABA y GBA.
+            {site.tagline}
           </p>
-          <p className="text-sm text-slate-500">CUIT 30-71583698-5 · Lunes a viernes 08 a 18 h</p>
-          <p className="text-sm text-slate-500">{siteConfig.whatsapp.number}</p>
-          <p className="text-sm text-slate-500">{siteConfig.social.linkedin}</p>
+          <p className="text-sm text-slate-500">{site.contact.schedule}</p>
+          <p className="text-sm text-slate-500">{site.contact.phone}</p>
+          <p className="text-sm text-slate-500">{site.socials.linkedin}</p>
         </div>
         <div>
           <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Servicios</h4>
@@ -42,16 +48,13 @@ export function Footer() {
           <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Contacto</h4>
           <ul className="mt-3 space-y-2 text-sm text-slate-600">
             <li>
-              <a
-                href={`https://wa.me/${siteConfig.whatsapp.number}?text=${encodeURIComponent(siteConfig.whatsapp.message)}`}
-                className="hover:text-foreground"
-              >
+              <a href={whatsappHref} className="hover:text-foreground">
                 WhatsApp directo
               </a>
             </li>
             <li>
-              <a href="mailto:hola@nerin.com.ar" className="hover:text-foreground">
-                hola@nerin.com.ar
+              <a href={`mailto:${site.contact.email}`} className="hover:text-foreground">
+                {site.contact.email}
               </a>
             </li>
             <li>

--- a/nerin-electric-site-v3-fixed/components/Header.tsx
+++ b/nerin-electric-site-v3-fixed/components/Header.tsx
@@ -1,10 +1,16 @@
 'use client'
 
 import Link from 'next/link'
-import { siteConfig } from '@/lib/config'
 import { Logo } from './Logo'
 import { Button } from './ui/button'
 import { useSession } from 'next-auth/react'
+
+interface HeaderProps {
+  contact: {
+    whatsappHref: string
+    whatsappLabel: string
+  }
+}
 
 const navigation = [
   { href: '/servicios', label: 'Servicios' },
@@ -19,7 +25,7 @@ const navigation = [
 const adminDashboardRoute = '/admin' as const
 const clientDashboardRoute = '/clientes' as const
 
-export function Header() {
+export function Header({ contact }: HeaderProps) {
   const { data: session } = useSession()
 
   return (
@@ -35,13 +41,8 @@ export function Header() {
         </nav>
         <div className="flex items-center gap-3">
           <Button variant="ghost" size="sm" asChild className="hidden md:inline-flex">
-            <a
-              href={`https://wa.me/${siteConfig.whatsapp.number}?text=${encodeURIComponent(siteConfig.whatsapp.message)}`}
-              aria-label="Hablar por WhatsApp"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              WhatsApp
+            <a href={contact.whatsappHref} aria-label="Hablar por WhatsApp" target="_blank" rel="noopener noreferrer">
+              {contact.whatsappLabel}
             </a>
           </Button>
           <Button size="sm" asChild className="hidden md:inline-flex">

--- a/nerin-electric-site-v3-fixed/lib/blog.ts
+++ b/nerin-electric-site-v3-fixed/lib/blog.ts
@@ -1,0 +1,86 @@
+import { listItems, readMarkdown } from '@/lib/content'
+import { blogPosts as fallbackPosts } from '@/content/blogPosts'
+
+type StoredPost = {
+  data?: {
+    title?: string
+    excerpt?: string
+    publishedAt?: string
+    heroImage?: string
+    tags?: string[]
+  }
+  content?: string
+}
+
+export interface BlogPost {
+  slug: string
+  title: string
+  excerpt: string
+  content: string
+  publishedAt: string
+  heroImage?: string
+  tags?: string[]
+}
+
+function normalizePost(slug: string, raw: StoredPost | null): BlogPost | null {
+  if (!raw || typeof raw !== 'object') {
+    return null
+  }
+
+  const title = raw.data?.title?.trim() ?? ''
+  const excerpt = raw.data?.excerpt?.trim() ?? ''
+  const publishedAt = raw.data?.publishedAt ?? new Date().toISOString().slice(0, 10)
+  const content = raw.content ?? ''
+
+  if (!title || !content) {
+    return null
+  }
+
+  return {
+    slug,
+    title,
+    excerpt,
+    publishedAt,
+    content,
+    heroImage: raw.data?.heroImage?.trim() || undefined,
+    tags: Array.isArray(raw.data?.tags) ? raw.data?.tags : undefined,
+  }
+}
+
+export function getBlogPosts(): BlogPost[] {
+  const slugs = listItems('blog')
+  const posts = slugs
+    .map((slug) => normalizePost(slug, readMarkdown('blog', slug) as StoredPost | null))
+    .filter((post): post is BlogPost => Boolean(post))
+    .sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : -1))
+
+  if (posts.length) {
+    return posts
+  }
+
+  return fallbackPosts.map((post) => ({
+    slug: post.slug,
+    title: post.title,
+    excerpt: post.excerpt,
+    publishedAt: post.publishedAt,
+    content: post.content,
+  }))
+}
+
+export function getBlogPost(slug: string): BlogPost | null {
+  const post = normalizePost(slug, readMarkdown('blog', slug) as StoredPost | null)
+  if (post) {
+    return post
+  }
+
+  const fallback = fallbackPosts.find((item) => item.slug === slug)
+  return fallback
+    ? {
+        slug: fallback.slug,
+        title: fallback.title,
+        excerpt: fallback.excerpt,
+        publishedAt: fallback.publishedAt,
+        content: fallback.content,
+      }
+    : null
+}

--- a/nerin-electric-site-v3-fixed/lib/content.ts
+++ b/nerin-electric-site-v3-fixed/lib/content.ts
@@ -1,62 +1,306 @@
 import fs from 'fs'
 import path from 'path'
+import type { SiteExperience } from '@/types/site'
 
-export function getStorageDir(){
-  const p = process.env.STORAGE_DIR || path.join(process.cwd(), '.data')
-  if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true })
-  return p
+export function getStorageDir() {
+  const storagePath = process.env.STORAGE_DIR || path.join(process.cwd(), '.data')
+  if (!fs.existsSync(storagePath)) {
+    fs.mkdirSync(storagePath, { recursive: true })
+  }
+  return storagePath
 }
 
 const SITE_FILE = 'site.json'
 
-function getTypeDir(type: string){
+export const SITE_DEFAULTS: SiteExperience = {
+  name: 'NERIN · Ingeniería Eléctrica',
+  tagline: 'Instalaciones de alta performance con trazabilidad completa.',
+  accent: '#f59e0b',
+  socials: {
+    instagram: 'https://www.instagram.com/nerin.electric',
+    linkedin: 'https://www.linkedin.com/company/nerin-electric',
+  },
+  contact: {
+    email: 'hola@nerin.com.ar',
+    phone: '+54 11 0000 0000',
+    secondaryPhones: ['+54 11 5555 5555'],
+    address: 'Villa Ortúzar · CABA, Argentina',
+    schedule: 'Lunes a viernes de 08:00 a 18:00',
+    serviceArea: 'Ciudad Autónoma de Buenos Aires y GBA',
+    whatsappNumber: '5491100000000',
+    whatsappMessage: 'Hola, soy [Nombre]. Quiero cotizar un servicio eléctrico con NERIN.',
+  },
+  hero: {
+    badge: 'Contratista eléctrico integral en CABA',
+    title: 'Obras eléctricas premium con trazabilidad total, sin sorpresas y listas para auditorías exigentes.',
+    subtitle:
+      'NERIN acompaña a empresas, consorcios, gimnasios y viviendas de alto nivel desde el anteproyecto hasta la entrega de certificados finales. Mano de obra propia, técnicos habilitados y reportes en tiempo real.',
+    backgroundImage:
+      'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=900&q=80',
+    caption: 'Tablero general edificio 4.000 m² · Ensayos y certificaciones completas.',
+    primaryCta: { label: 'Pedir presupuesto', href: '/contacto' },
+    secondaryCta: { label: 'Hablar por WhatsApp', href: '[whatsapp]' },
+    tertiaryCta: { label: 'Ver packs eléctricos', href: '/packs' },
+    highlights: [
+      {
+        title: '+120 obras entregadas',
+        description: 'Smart Fit, KFC, supermercados DIA, edificios corporativos.',
+      },
+      {
+        title: 'Certificaciones y ART al día',
+        description: 'Equipo propio, cobertura integral y protocolos de ingreso.',
+      },
+    ],
+    stats: [
+      {
+        label: 'Documentación completa',
+        description: 'Planos, memorias, checklist digital y certificados de avance.',
+      },
+      {
+        label: 'Normativa AEA 90364-7-771',
+        description: 'Cumplimiento y auditoría permanente en cada etapa de obra.',
+      },
+    ],
+  },
+  services: {
+    title: 'Servicios eléctricos de punta a punta',
+    description:
+      'Intervenimos en obra nueva, adecuaciones y expansión. Documentación completa, planos as-built y soporte post entrega.',
+    items: [
+      {
+        title: 'Instalaciones eléctricas completas',
+        description: 'Proyecto ejecutivo, tableros, canalizaciones y puesta en marcha.',
+      },
+      {
+        title: 'Tableros a medida',
+        description: 'Montaje, ensayo y certificación de tableros generales, seccionales y CCM.',
+      },
+      {
+        title: 'Puesta a tierra y descargas atmosféricas',
+        description: 'Mallas, jabalinas, mediciones con informes certificados y adecuaciones AEA.',
+      },
+      {
+        title: 'Canalizaciones y bandejas portacables',
+        description: 'Tendidos prolijos, registro fotográfico y planimetría actualizada.',
+      },
+      {
+        title: 'Datos, CCTV y audio profesional',
+        description: 'Redes estructuradas, cámaras, audio distribuido y automatización lista para upgrades.',
+      },
+      {
+        title: 'Aires acondicionados',
+        description: 'Instalación integral con cañería de cobre, vacío, carga y alimentación eléctrica.',
+      },
+    ],
+  },
+  packs: {
+    title: 'Packs eléctricos para viviendas y countries',
+    description:
+      'Packs 100% mano de obra especializada. Materiales a elección del cliente, sin sobreprecios ocultos.',
+    ctaLabel: 'Configurar pack',
+    ctaHref: '/presupuestador',
+    note: 'Proyecto eléctrico se cotiza aparte (base $500.000).',
+  },
+  maintenance: {
+    title: 'Planes de mantenimiento con SLAs reales',
+    description:
+      'Diseñados para oficinas, cadenas de retail y consorcios. Cantidades fijas inalterables, visitas programadas y reportes digitales.',
+    cards: [
+      {
+        title: 'Visitas preventivas',
+        description:
+          'Revisión de tableros, medición de temperaturas, apriete de borneras y reposición de consumibles.',
+      },
+      {
+        title: 'Soporte correctivo',
+        description:
+          'Atención de urgencias dentro de las 24 h hábiles. Priorizamos sistemas críticos definidos en SLA.',
+      },
+      {
+        title: 'Reporte ejecutivo',
+        description:
+          'Informe mensual con hallazgos, fotos geolocalizadas y recomendaciones de inversión.',
+      },
+    ],
+  },
+  works: {
+    title: 'Casos de éxito',
+    description:
+      'Resultados medibles y documentación lista para auditorías de seguros, ART y entes reguladores.',
+    introTitle: 'Obras destacadas',
+    introDescription:
+      'Selección de proyectos donde NERIN lideró ingeniería eléctrica, montaje y certificaciones.',
+  },
+  blog: {
+    title: 'Insights eléctricos y buenas prácticas',
+    description:
+      'Consejos prácticos para administradores, desarrolladores y equipos de facilities.',
+    introTitle: 'Blog',
+    introDescription:
+      'Contenido editorial para acompañar decisiones técnicas y de gestión eléctrica.',
+  },
+  brands: {
+    title: 'Marcas que trabajamos todos los días',
+    note: 'Coordinamos materiales con Schneider Electric, Prysmian, Gimsa, Daisa, Genrock y más.',
+  },
+  faq: {
+    title: 'Preguntas frecuentes',
+    description:
+      'Transparencia total: contratos claros, avances certificados y soporte técnico en menos de 24 h hábil.',
+    items: [
+      {
+        question: '¿Los packs incluyen materiales?',
+        answer:
+          'No. Los packs son solo mano de obra certificada. Los materiales se cotizan aparte según elección de marcas.',
+      },
+      {
+        question: '¿El proyecto eléctrico está incluido?',
+        answer:
+          'El proyecto eléctrico se cotiza aparte. Tiene un valor base configurable desde este panel.',
+      },
+      {
+        question: '¿Trabajan bajo normativa AEA?',
+        answer:
+          'Sí. Las instalaciones cumplen AEA 90364-7-771 (2006) y reglamentaciones locales. Documentamos cada etapa.',
+      },
+      {
+        question: '¿Cómo se paga el avance de obra?',
+        answer:
+          'Emitimos Certificados de Avance con porcentaje ejecutado. Podés abonarlos online vía Mercado Pago.',
+      },
+    ],
+  },
+  closingCta: {
+    title: 'Listos para ejecutar tu obra eléctrica con excelencia',
+    description:
+      'Coordinamos visita técnica, entregamos presupuesto detallado y planificamos el cronograma completo.',
+    primary: { label: 'Solicitar visita técnica', href: '/contacto' },
+    secondary: { label: 'Configurar pack online', href: '/presupuestador' },
+  },
+  company: {
+    introTitle: 'NERIN: ingeniería eléctrica con protocolos y trazabilidad',
+    introDescription:
+      'Equipo multidisciplinario con más de 15 años en obras eléctricas para retail, gimnasios, corporativos y viviendas premium.',
+    protocolsTitle: 'Protocolos de trabajo',
+    protocols: [
+      'Ingreso de personal con ART Swiss Medical y certificado de aptitud.',
+      'Checklist diario de seguridad y reportes fotográficos.',
+      'Entrega de carpeta final con planos, memorias y certificados.',
+    ],
+    complianceTitle: 'Compliance y seguros',
+    compliance: [
+      'Seguro de RC hasta USD 2M.',
+      'Contratos transparentes con pagos escalonados por certificados.',
+      'Cumplimiento de normativa AEA 90364-7-771, NFPA 70 y reglamentos locales.',
+    ],
+    mission: 'Hacer que cada instalación eléctrica sea auditada, segura y preparada para crecer.',
+    teamTitle: 'Equipo técnico',
+  },
+  contactPage: {
+    introTitle: 'Coordinemos tu obra eléctrica',
+    introDescription:
+      'Completá el formulario y un técnico senior se contactará dentro de las próximas 24 horas hábiles.',
+    highlightBullets: [
+      'Equipo propio con ART y seguros vigentes.',
+      'Certificados de avance con pago online vía Mercado Pago.',
+      'Reportes fotográficos y checklist digital en cada visita.',
+      'Trabajo bajo normativa AEA 90364-7-771 (2006).',
+      'Separación transparente entre mano de obra y materiales.',
+    ],
+    typeformUrl: 'https://nerin.typeform.com/to/xxxxx',
+  },
+  packsPage: {
+    introTitle: 'Packs eléctricos para viviendas exigentes',
+    introDescription:
+      'Mano de obra certificada. Materiales no incluidos para que elijas marcas según tu presupuesto.',
+    note: 'Proyecto eléctrico se cotiza aparte (base $500.000).',
+  },
+  maintenancePage: {
+    introTitle: 'Planes de mantenimiento eléctrico con respuesta garantizada',
+    introDescription:
+      'Supervisión programada, chequeos preventivos y atención de emergencias para edificios, oficinas y cadenas comerciales.',
+    cards: [
+      {
+        title: 'Visitas preventivas',
+        description:
+          'Revisión de tableros, medición de temperaturas, apriete de borneras y reposición de consumibles.',
+      },
+      {
+        title: 'Soporte correctivo',
+        description:
+          'Atención de urgencias dentro de las 24 h hábiles. Priorizamos bombas, tableros generales y sistemas críticos.',
+      },
+      {
+        title: 'Reporte ejecutivo',
+        description:
+          'Informe mensual con hallazgos, fotos geolocalizadas y recomendaciones de inversión.',
+      },
+    ],
+  },
+  responsive: {
+    headline: 'Experiencia optimizada para escritorio, iPad y iPhone',
+    bulletPoints: [
+      'Componentes responsive con breakpoints específicos para obra en campo.',
+      'Formularios con teclado numérico y máscaras en móviles.',
+      'Accesibilidad AA garantizada en contraste y navegación.',
+    ],
+  },
+  seo: {
+    metaTitle: 'NERIN · Ingeniería eléctrica certificada en CABA y GBA',
+    metaDescription:
+      'Instalaciones eléctricas premium, tableros, mantenimiento y proyectos llave en mano con documentación completa.',
+    keywords: [
+      'instalaciones eléctricas',
+      'contratista eléctrico',
+      'tableros eléctricos',
+      'puesta a tierra',
+      'consorcios',
+      'obras eléctricas CABA',
+    ],
+  },
+}
+
+function getTypeDir(type: string) {
   const dir = path.join(getStorageDir(), type)
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
   return dir
 }
 
-function getItemFile(type: string, slug: string){
+function getItemFile(type: string, slug: string) {
   return path.join(getTypeDir(type), `${slug}.json`)
 }
 
-export function readSite(){
+export function readSite() {
   const dir = getStorageDir()
   const file = path.join(dir, SITE_FILE)
-  if (!fs.existsSync(file)){
-    const defaults = {
-      name: 'NERIN',
-      accent: '#f59e0b',
-      email: 'hola@nerin.com.ar',
-      phone: '+54 11 1234-5678',
-      address: 'CABA',
-      socials: { instagram: '', linkedin: '' }
-    }
-    fs.writeFileSync(file, JSON.stringify(defaults, null, 2))
-    return defaults
+  if (!fs.existsSync(file)) {
+    fs.writeFileSync(file, JSON.stringify(SITE_DEFAULTS, null, 2))
+    return SITE_DEFAULTS
   }
-  try{
+  try {
     return JSON.parse(fs.readFileSync(file, 'utf-8'))
-  }catch{
-    return { name: 'NERIN', accent: '#f59e0b' }
+  } catch {
+    return SITE_DEFAULTS
   }
 }
 
-export function writeSite(data: any){
+export function writeSite(data: unknown) {
   const dir = getStorageDir()
   const file = path.join(dir, SITE_FILE)
   fs.writeFileSync(file, JSON.stringify(data, null, 2))
   return true
 }
 
-export function listItems(type: string){
+export function listItems(type: string) {
   const dir = getTypeDir(type)
-  return fs.readdirSync(dir)
-    .filter(f => f.endsWith('.json'))
-    .map(f => f.replace(/\.json$/, ''))
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.replace(/\.json$/, ''))
     .sort()
 }
 
-export function readMarkdown(type: string, slug: string){
+export function readMarkdown(type: string, slug: string) {
   const file = getItemFile(type, slug)
   if (!fs.existsSync(file)) return null
   try {
@@ -66,14 +310,14 @@ export function readMarkdown(type: string, slug: string){
   }
 }
 
-export function writeMarkdown(type: string, slug: string, data: any, content: string){
+export function writeMarkdown(type: string, slug: string, data: unknown, content: string) {
   const file = getItemFile(type, slug)
   const payload = { data: data ?? {}, content: content ?? '' }
   fs.writeFileSync(file, JSON.stringify(payload, null, 2))
   return payload
 }
 
-export function deleteMarkdown(type: string, slug: string){
+export function deleteMarkdown(type: string, slug: string) {
   const file = getItemFile(type, slug)
   if (fs.existsSync(file)) fs.unlinkSync(file)
 }

--- a/nerin-electric-site-v3-fixed/lib/site-content.ts
+++ b/nerin-electric-site-v3-fixed/lib/site-content.ts
@@ -1,0 +1,58 @@
+import { SITE_DEFAULTS, readSite, writeSite } from '@/lib/content'
+import type { SiteExperience } from '@/types/site'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function cloneDefaults(defaults: SiteExperience): SiteExperience {
+  return JSON.parse(JSON.stringify(defaults))
+}
+
+function mergeSite(defaults: SiteExperience, incoming: unknown): SiteExperience {
+  const target = cloneDefaults(defaults)
+
+  if (!isRecord(incoming)) {
+    return target
+  }
+
+  const merge = (base: any, patch: any): any => {
+    if (Array.isArray(base)) {
+      if (Array.isArray(patch)) {
+        return patch
+      }
+      return base
+    }
+
+    if (isRecord(base)) {
+      const result: Record<string, unknown> = { ...base }
+      if (isRecord(patch)) {
+        for (const [key, value] of Object.entries(patch)) {
+          if (key in base) {
+            result[key] = merge((base as Record<string, unknown>)[key], value)
+          } else {
+            result[key] = value
+          }
+        }
+      }
+      return result
+    }
+
+    return patch ?? base
+  }
+
+  return merge(target, incoming) as SiteExperience
+}
+
+export function getSiteContent(): SiteExperience {
+  const raw = readSite()
+  return mergeSite(SITE_DEFAULTS, raw)
+}
+
+export function saveSiteContent(payload: SiteExperience) {
+  writeSite(payload)
+}
+
+export function getWhatsappHref(site: SiteExperience): string {
+  return `https://wa.me/${site.contact.whatsappNumber}?text=${encodeURIComponent(site.contact.whatsappMessage)}`
+}

--- a/nerin-electric-site-v3-fixed/types/site.ts
+++ b/nerin-electric-site-v3-fixed/types/site.ts
@@ -1,0 +1,110 @@
+export interface SiteExperience {
+  name: string
+  tagline: string
+  accent: string
+  socials: {
+    instagram: string
+    linkedin: string
+  }
+  contact: {
+    email: string
+    phone: string
+    secondaryPhones: string[]
+    address: string
+    schedule: string
+    serviceArea: string
+    whatsappNumber: string
+    whatsappMessage: string
+  }
+  hero: {
+    badge: string
+    title: string
+    subtitle: string
+    backgroundImage: string
+    caption: string
+    primaryCta: { label: string; href: string }
+    secondaryCta: { label: string; href: string }
+    tertiaryCta: { label: string; href: string }
+    highlights: Array<{ title: string; description: string }>
+    stats: Array<{ label: string; description: string }>
+  }
+  services: {
+    title: string
+    description: string
+    items: Array<{ title: string; description: string }>
+  }
+  packs: {
+    title: string
+    description: string
+    ctaLabel: string
+    ctaHref: string
+    note: string
+  }
+  maintenance: {
+    title: string
+    description: string
+    cards: Array<{ title: string; description: string }>
+  }
+  works: {
+    title: string
+    description: string
+    introTitle: string
+    introDescription: string
+  }
+  blog: {
+    title: string
+    description: string
+    introTitle: string
+    introDescription: string
+  }
+  brands: {
+    title: string
+    note: string
+  }
+  faq: {
+    title: string
+    description: string
+    items: Array<{ question: string; answer: string }>
+  }
+  closingCta: {
+    title: string
+    description: string
+    primary: { label: string; href: string }
+    secondary: { label: string; href: string }
+  }
+  company: {
+    introTitle: string
+    introDescription: string
+    protocolsTitle: string
+    protocols: string[]
+    complianceTitle: string
+    compliance: string[]
+    mission: string
+    teamTitle: string
+  }
+  contactPage: {
+    introTitle: string
+    introDescription: string
+    highlightBullets: string[]
+    typeformUrl: string
+  }
+  packsPage: {
+    introTitle: string
+    introDescription: string
+    note: string
+  }
+  maintenancePage: {
+    introTitle: string
+    introDescription: string
+    cards: Array<{ title: string; description: string }>
+  }
+  responsive: {
+    headline: string
+    bulletPoints: string[]
+  }
+  seo: {
+    metaTitle: string
+    metaDescription: string
+    keywords: string[]
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the admin dashboard to centralize packs, maintenance, case studies, brands, and blog management
- persist marketing copy via `.data/site.json` with a rich client designer and hydrate public pages from the new schema
- expose authenticated CRUD APIs for brands and blog content, plus ignore local build artifacts in git

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_6909f752456c833189f76f35f2f1228f