### PR TITLE
Fix SiteExperience designer pair formatting and external links

### DIFF
--- a/nerin-electric-site-v3-fixed/app/contacto/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/contacto/page.tsx
@@ -1,5 +1,4 @@
 import { redirect } from 'next/navigation'
-import Link from 'next/link'
 import { submitContact } from './actions'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -91,9 +90,14 @@ export default function ContactoPage({ searchParams }: { searchParams?: { enviad
           </Button>
           <p className="text-xs text-slate-500">
             También podés usar nuestro{' '}
-            <Link className="underline" href={site.contactPage.typeformUrl}>
+            <a
+              className="underline"
+              href={site.contactPage.typeformUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
               Typeform
-            </Link>{' '}
+            </a>{' '}
             si preferís completar desde el celular.
           </p>
         </form>
@@ -127,7 +131,9 @@ export default function ContactoPage({ searchParams }: { searchParams?: { enviad
             </div>
           )}
           <Button asChild size="sm" variant="secondary" className="mt-4">
-            <Link href={whatsappHref}>Iniciar conversación</Link>
+            <a href={whatsappHref} target="_blank" rel="noreferrer">
+              Iniciar conversación
+            </a>
           </Button>
         </div>
       </aside>

--- a/nerin-electric-site-v3-fixed/app/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/page.tsx
@@ -39,15 +39,15 @@ export default async function HomePage() {
           <p className="max-w-xl text-lg text-slate-600">{site.hero.subtitle}</p>
           <div className="flex flex-wrap gap-4">
             <Button size="pill" asChild>
-              <Link href={site.hero.primaryCta.href}>{site.hero.primaryCta.label}</Link>
+              <a href={site.hero.primaryCta.href}>{site.hero.primaryCta.label}</a>
             </Button>
             <Button size="pill" variant="secondary" asChild>
-              <Link href={site.hero.secondaryCta.href === '[whatsapp]' ? whatsappHref : site.hero.secondaryCta.href}>
+              <a href={site.hero.secondaryCta.href === '[whatsapp]' ? whatsappHref : site.hero.secondaryCta.href}>
                 {site.hero.secondaryCta.label}
-              </Link>
+              </a>
             </Button>
             <Button size="pill" variant="ghost" asChild>
-              <Link href={site.hero.tertiaryCta.href}>{site.hero.tertiaryCta.label}</Link>
+              <a href={site.hero.tertiaryCta.href}>{site.hero.tertiaryCta.label}</a>
             </Button>
           </div>
           <div className="flex flex-wrap items-center gap-6 text-sm text-slate-500">
@@ -94,7 +94,7 @@ export default async function HomePage() {
             <p>{site.packs.description}</p>
           </div>
           <Button variant="secondary" asChild>
-            <Link href={site.packs.ctaHref}>{site.packs.ctaLabel}</Link>
+            <a href={site.packs.ctaHref}>{site.packs.ctaLabel}</a>
           </Button>
         </div>
         <div className="grid gap-6 md:grid-cols-3">
@@ -120,7 +120,7 @@ export default async function HomePage() {
                   ))}
                 </ul>
                 <Button variant="ghost" asChild>
-                  <Link href={`/packs#${pack.slug}`}>Ver alcance completo</Link>
+                  <a href={`/packs#${pack.slug}`}>Ver alcance completo</a>
                 </Button>
               </CardContent>
             </Card>
@@ -178,7 +178,7 @@ export default async function HomePage() {
                   <p className="text-sm text-slate-500">{cs.resumen}</p>
                   <p className="text-sm text-slate-600">{cs.contenido.slice(0, 180)}...</p>
                   <Button variant="ghost" asChild>
-                    <Link href={`/obras/${cs.slug}`}>Ver detalle</Link>
+                    <a href={`/obras/${cs.slug}`}>Ver detalle</a>
                   </Button>
                 </CardContent>
               </Card>
@@ -222,10 +222,10 @@ export default async function HomePage() {
           </div>
           <div className="flex flex-wrap gap-4 md:justify-end">
             <Button size="pill" asChild>
-              <Link href={site.closingCta.primary.href}>{site.closingCta.primary.label}</Link>
+              <a href={site.closingCta.primary.href}>{site.closingCta.primary.label}</a>
             </Button>
             <Button size="pill" variant="secondary" asChild>
-              <Link href={site.closingCta.secondary.href}>{site.closingCta.secondary.label}</Link>
+              <a href={site.closingCta.secondary.href}>{site.closingCta.secondary.label}</a>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- allow the SiteExperience designer to format and parse title-based key/value pairs correctly alongside label-based pairs
- adjust contact CTA links to use standard anchors for external Typeform and WhatsApp destinations
- replace dynamic Next.js Link usages on the home page with anchors so typedRoutes validation no longer fails during builds

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_690a5cab45f8833180ffaa4e309d3080