### PR TITLE
Fix quote API to use `SiteExperience` contact fields

### DIFF
--- a/nerin-electric-site-v3-fixed/app/api/quote/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/quote/route.ts
@@ -36,10 +36,9 @@ export async function POST(req: Request){
 <body style="font-family:Arial, sans-serif; color:#0a0a0a;">
   <div style="max-width:900px;margin:40px auto;">
     <div style="display:flex;align-items:center;gap:16px;margin-bottom:16px;">
-      <img src="${site.logo || '/logo-placeholder.svg'}" alt="logo" style="height:48px"/>
       <div>
-        <div style="font-size:22px;font-weight:800;">${site.siteName || 'NERIN Ingeniería Eléctrica'}</div>
-        <div style="font-size:12px;color:#555;">${site.primaryEmail || ''} · ${site.primaryPhone || ''} · ${site.address || ''}</div>
+        <div style="font-size:22px;font-weight:800;">${site.name || 'NERIN Ingeniería Eléctrica'}</div>
+        <div style="font-size:12px;color:#555;">${site.contact.email || ''} · ${site.contact.phone || ''} · ${site.contact.address || ''}</div>
       </div>
     </div>
     <h1 style="font-size:26px;margin:16px 0;">Presupuesto</h1>


### PR DESCRIPTION
### Motivation
- The production build failed with a TypeScript error because the quote route referenced legacy/unavailable properties such as `logo` and `siteName` on the site object.
- The site content shape was migrated to the `SiteExperience` interface which exposes `name` and `contact` fields instead of the legacy top-level properties. 
- The quote HTML header needed to be updated so email/HTML generation compiles and deploys on Render. 

### Description
- Updated `app/api/quote/route.ts` to remove the non-existent `site.logo` and legacy header fields. 
- Replaced `site.siteName` with `site.name` and replaced `site.primaryEmail`, `site.primaryPhone`, and `site.address` with `site.contact.email`, `site.contact.phone`, and `site.contact.address` respectively. 
- Removed the `<img>` tag that referenced `site.logo` to avoid accessing absent properties in server-side generation. 

### Testing
- A Next.js production build previously failed with a TypeScript error: `Property 'logo' does not exist on type 'SiteExperience'`. 
- No automated tests or builds were run after applying the fix. 
- Manual commit was created with the change and the file `app/api/quote/route.ts` was updated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696282ea62f88331b1e8f72895a90758)