### PR TITLE
Add @types/bcryptjs to fix TypeScript build error

### DIFF
--- a/nerin-electric-site-v3-fixed/package-lock.json
+++ b/nerin-electric-site-v3-fixed/package-lock.json
@@ -42,6 +42,7 @@
         "@playwright/test": "1.48.0",
         "@testing-library/jest-dom": "6.5.0",
         "@testing-library/react": "16.0.0",
+        "@types/bcryptjs": "^2.4.6",
         "@types/node": "20.16.5",
         "@types/pdfkit": "0.13.6",
         "@types/react": "18.3.11",
@@ -2224,6 +2225,13 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/nerin-electric-site-v3-fixed/package.json
+++ b/nerin-electric-site-v3-fixed/package.json
@@ -54,6 +54,7 @@
     "@playwright/test": "1.48.0",
     "@testing-library/jest-dom": "6.5.0",
     "@testing-library/react": "16.0.0",
+    "@types/bcryptjs": "^2.4.6",
     "@types/node": "20.16.5",
     "@types/pdfkit": "0.13.6",
     "@types/react": "18.3.11",


### PR DESCRIPTION
### Motivation
- The Next.js TypeScript build failed with an error complaining that module `bcryptjs` had no declaration file and was implicitly `any` during `next build`.
- Providing type definitions for `bcryptjs` resolves the TypeScript compiler error so the production build can complete.
- The lockfile was updated to reflect the newly added dev dependency.

### Description
- Add `@types/bcryptjs` to `devDependencies` in `package.json`.
- Update `package-lock.json` to include the installed `@types/bcryptjs` package metadata.
- Commit the updated `package.json` and `package-lock.json` to the repository.

### Testing
- No automated tests were executed after this dependency update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69628dcb1e688331b179bc1447d0b4a2)