### PR TITLE
Fix footer legal link tracking typecheck

### DIFF
--- a/nerin-electric-site-v3-fixed/components/Footer.tsx
+++ b/nerin-electric-site-v3-fixed/components/Footer.tsx
@@ -67,7 +67,7 @@ export function Footer({ site }: FooterProps) {
           <ul className="mt-3 space-y-2 text-sm text-foreground">
             {legalLinks.map((item) => (
               <li key={item.href}>
-                <Link className="hover:text-foreground" href={item.href} data-track={item.href === "/presupuesto" ? "lead" : undefined} data-content-name={item.href === "/presupuesto" ? "Pedir presupuesto footer" : undefined}>
+                <Link className="hover:text-foreground" href={item.href} data-track="legal" data-content-name={item.label}>
                   {item.label}
                 </Link>
               </li>


### PR DESCRIPTION
### Motivation
- The `Footer` component compared `item.href` in the `legalLinks` array against `"/presupuesto"`, which is impossible given the `legalLinks` literal types and caused a TypeScript error during `next build`.

### Description
- Remove the unreachable conditional attributes in the `legalLinks.map(...)` iteration inside `components/Footer.tsx` and replace them with static attributes for legal links.
- Set `data-track="legal"` and `data-content-name={item.label}` on each legal `Link` to provide consistent tracking metadata.
- Leave the `Servicios` / `quickLinks` logic unchanged so the `/presupuesto` lead tracking remains intact.
- File modified: `components/Footer.tsx`.

### Testing
- Ran `npm run build` which completed successfully and generated the Prisma client, compiled the Next.js app, and emitted the static pages without TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69727004d05c8331a53c04ff8f61863e)