### PR TITLE
Ensure Prisma schema before Next build when DB is enabled

### DIFF
--- a/nerin-electric-site-v3-fixed/.env.example
+++ b/nerin-electric-site-v3-fixed/.env.example
@@ -1,6 +1,11 @@
 # Base de datos
 # Por defecto usamos SQLite para simplificar el despliegue.
+DB_ENABLED="true"
 DATABASE_URL="file:/var/data/nerin.db"
+# Preview UI sin pago (SQLite temporal)
+# DATABASE_URL="file:/tmp/nerin.db"
+# Producción con Render Disk montado en /var/data
+# DATABASE_URL="file:/var/data/nerin.db"
 # En desarrollo podés seguir usando SQLite local con DATABASE_URL="file:./dev.db".
 # Si preferís PostgreSQL, cambiá el provider en prisma/schema.prisma y establecé DIRECT_URL/DATABASE_URL acorde.
 # DIRECT_URL="postgresql://nerin:password@127.0.0.1:5432/nerin"

--- a/nerin-electric-site-v3-fixed/package.json
+++ b/nerin-electric-site-v3-fixed/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "next dev -p 3000",
-    "build": "prisma generate && next build",
+    "build": "node scripts/prisma-push-if-enabled.mjs && prisma generate && next build",
     "start": "export DATABASE_URL=\"${DATABASE_URL:-file:/var/data/nerin.db}\" && prisma db push && next start",
     "lint": "next lint",
     "format": "prettier --write .",

--- a/nerin-electric-site-v3-fixed/scripts/prisma-push-if-enabled.mjs
+++ b/nerin-electric-site-v3-fixed/scripts/prisma-push-if-enabled.mjs
@@ -1,0 +1,21 @@
+import { spawnSync } from "node:child_process";
+
+const enabled = (process.env.DB_ENABLED || "").toLowerCase() === "true";
+const url = (process.env.DATABASE_URL || "").trim();
+
+if (!enabled) {
+  console.log("[build] DB disabled; skipping prisma db push");
+  process.exit(0);
+}
+if (!url) {
+  console.warn(
+    "[build] DB_ENABLED=true but DATABASE_URL missing; skipping prisma db push"
+  );
+  process.exit(0);
+}
+
+const result = spawnSync("npx", ["prisma", "db", "push"], {
+  stdio: "inherit",
+  shell: true,
+});
+process.exit(result.status ?? 1);


### PR DESCRIPTION
### Motivation
- Prevent prerender/build failures (Prisma P2021 "table does not exist") by ensuring the Prisma schema is pushed before `next build` when the database is enabled.
- Support both a free preview mode (temporary SQLite at `/tmp`) and a production mode (persistent SQLite on Render disk at `/var/data`) while leaving behavior unchanged when the DB is disabled.

### Description
- Add `scripts/prisma-push-if-enabled.mjs` which checks `DB_ENABLED` and `DATABASE_URL` and runs `npx prisma db push` only when appropriate.
- Update the `build` script in `package.json` to run `node scripts/prisma-push-if-enabled.mjs` before `prisma generate` and `next build`.
- Document `DB_ENABLED` plus preview/production SQLite `DATABASE_URL` examples in `.env.example`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972d35512388331a3d24595a46b0fdc)