### PR TITLE
Initialize SQLite DB and handle missing-table (Prisma P2021) errors

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/error.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/error.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function AdminError({ error }: { error: Error & { digest?: string } }) {
+  useEffect(() => {
+    console.error('[Admin] Unhandled error', error)
+  }, [error])
+
+  return (
+    <div className="space-y-3 rounded-3xl border border-border bg-white p-6 text-sm text-slate-600">
+      <h1 className="text-lg font-semibold text-foreground">Algo salió mal en el admin</h1>
+      <p>Ocurrió un error en el servidor. Revisá los logs para más detalles.</p>
+      {error.message ? <p className="text-xs text-slate-500">Mensaje: {error.message}</p> : null}
+      {error.digest ? <p className="text-xs text-slate-500">Digest: {error.digest}</p> : null}
+      <p className="text-xs text-slate-500">Si el problema persiste, verificá la base de datos y volvé a intentar.</p>
+      <p className="text-xs text-slate-500">Ver logs.</p>
+    </div>
+  )
+}

--- a/nerin-electric-site-v3-fixed/app/blog/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/blog/page.tsx
@@ -15,24 +15,30 @@ export default async function BlogPage() {
         <h1>{site.blog.title}</h1>
         <p className="text-lg text-slate-600">{site.blog.description}</p>
       </header>
-      <div className="grid gap-6 md:grid-cols-2">
-        {posts.map((post) => (
-          <article key={post.slug} className="rounded-3xl border border-border bg-white p-6 shadow-subtle">
-            <p className="text-xs uppercase tracking-wide text-slate-400">
-              {new Date(post.publishedAt).toLocaleDateString('es-AR', {
-                day: '2-digit',
-                month: 'short',
-                year: 'numeric',
-              })}
-            </p>
-            <h2 className="mt-3 text-2xl font-semibold text-foreground">{post.title}</h2>
-            <p className="mt-2 text-sm text-slate-600">{post.excerpt}</p>
-            <Link className="mt-4 inline-flex text-accent" href={`/blog/${post.slug}`}>
-              Leer más →
-            </Link>
-          </article>
-        ))}
-      </div>
+      {posts.length === 0 ? (
+        <div className="rounded-3xl border border-dashed border-border bg-white p-8 text-center text-sm text-slate-500">
+          Todavía no hay publicaciones disponibles. Volvé a visitar esta sección en unas horas.
+        </div>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2">
+          {posts.map((post) => (
+            <article key={post.slug} className="rounded-3xl border border-border bg-white p-6 shadow-subtle">
+              <p className="text-xs uppercase tracking-wide text-slate-400">
+                {new Date(post.publishedAt).toLocaleDateString('es-AR', {
+                  day: '2-digit',
+                  month: 'short',
+                  year: 'numeric',
+                })}
+              </p>
+              <h2 className="mt-3 text-2xl font-semibold text-foreground">{post.title}</h2>
+              <p className="mt-2 text-sm text-slate-600">{post.excerpt}</p>
+              <Link className="mt-4 inline-flex text-accent" href={`/blog/${post.slug}`}>
+                Leer más →
+              </Link>
+            </article>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/nerin-electric-site-v3-fixed/lib/db.ts
+++ b/nerin-electric-site-v3-fixed/lib/db.ts
@@ -4,17 +4,22 @@ import { existsSync } from 'node:fs'
 import { PrismaClient } from '@prisma/client'
 
 const VAR_DATA_DB_URL = 'file:/var/data/nerin.db'
+const TMP_DB_URL = 'file:/tmp/nerin.db'
 const DEV_DB_URL = 'file:./dev.db'
 
 const isDatabaseUrlMissing =
   !process.env.DATABASE_URL || process.env.DATABASE_URL.trim().length === 0
 
-if (isDatabaseUrlMissing && existsSync('/var/data')) {
-  process.env.DATABASE_URL = VAR_DATA_DB_URL
+if (isDatabaseUrlMissing) {
+  if (existsSync('/var/data')) {
+    process.env.DATABASE_URL = VAR_DATA_DB_URL
+  } else {
+    process.env.DATABASE_URL = process.env.NODE_ENV === 'development' ? DEV_DB_URL : TMP_DB_URL
+  }
 }
 
 const databaseUrl = process.env.DATABASE_URL?.trim()
-const resolvedDatabaseUrl = databaseUrl && databaseUrl.length > 0 ? databaseUrl : DEV_DB_URL
+const resolvedDatabaseUrl = databaseUrl && databaseUrl.length > 0 ? databaseUrl : TMP_DB_URL
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined

--- a/nerin-electric-site-v3-fixed/lib/prisma-errors.ts
+++ b/nerin-electric-site-v3-fixed/lib/prisma-errors.ts
@@ -1,0 +1,11 @@
+import { Prisma } from '@prisma/client'
+
+export function isMissingTableError(error: unknown): boolean {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    return error.code === 'P2021'
+  }
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    return (error as { code?: string }).code === 'P2021'
+  }
+  return false
+}

--- a/nerin-electric-site-v3-fixed/package.json
+++ b/nerin-electric-site-v3-fixed/package.json
@@ -4,8 +4,8 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "next dev -p 3000",
-    "build": "node scripts/prisma-push-if-enabled.mjs && prisma generate && next build",
-    "start": "export DATABASE_URL=\"${DATABASE_URL:-file:/var/data/nerin.db}\" && prisma db push && next start",
+    "build": "export DATABASE_URL=${DATABASE_URL:-$( [ -d /var/data ] && echo file:/var/data/nerin.db || echo file:/tmp/nerin.db )} && prisma generate && prisma db push && next build",
+    "start": "export DATABASE_URL=${DATABASE_URL:-$( [ -d /var/data ] && echo file:/var/data/nerin.db || echo file:/tmp/nerin.db )} && prisma db push && next start -p $PORT",
     "lint": "next lint",
     "format": "prettier --write .",
     "test": "vitest run",


### PR DESCRIPTION
### Motivation
- Fix build and runtime failures caused by missing Prisma tables (P2021) and the admin area throwing server exceptions. 
- Ensure the app can run in a DEMO (ephemeral `/tmp`) mode and a DISK mode (`/var/data`) and that pages querying Prisma do not crash before the DB is initialized. 

### Description
- Update `package.json` scripts so build/start run a DB initialization step and autodetect the data path by default, using `/var/data/nerin.db` when available and `file:/tmp/nerin.db` as the demo fallback (scripts use `prisma generate && prisma db push` and set `DATABASE_URL` accordingly). 
- Add `lib/db.ts` logic to set a resolved `DATABASE_URL` when missing and prefer `/var/data` when present, otherwise fallback to `/tmp` (dev uses `./dev.db`). 
- Add `lib/prisma-errors.ts` with `isMissingTableError` helper to detect Prisma `P2021` errors. 
- Harden `lib/content-store.ts` (Prisma store) by wrapping all Prisma queries in `try/catch`, using a `handleMissingTable` helper to `console.warn` and return safe fallbacks (`[]`, `null`, default in-memory values, or draft objects) instead of throwing on missing tables. 
- Make `/blog` show a friendly empty state when there are no posts or the table is missing (avoid rendering errors). 
- Make the Admin "Admin operativo" dashboard resilient by catching missing-table errors and rendering a friendly "DB no inicializada" notice instead of a 500, and add `app/admin/error.tsx` to surface admin errors inside the admin UI. 

### Testing
- Ran `npm run build` and the build completed successfully with Prisma creating or syncing the SQLite DB when needed (success). 
- Started the app with `PORT=3005 DATABASE_URL=file:/tmp/nerin.db npm run start` and validated `/blog` returned the site (success). 
- Created `/var/data` and started with `PORT=3006 DATABASE_URL=file:/var/data/nerin.db npm run start` to validate disk mode and Prisma DB creation (success). 
- Performed an HTTP smoke-check with `curl` against `/blog` and captured a Playwright screenshot of the empty blog state to confirm the UI fallback (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697405c696d88331a64d9c9e10bc34fc)