### PR TITLE
Avoid DB access during build; add CAC/IVA certificates, photo uploads and operativo admin

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/(dashboard)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/(dashboard)/page.tsx
@@ -63,6 +63,9 @@ export default async function AdminPage() {
           <Button variant="outline" asChild>
             <Link href="/admin/ops">Admin operativo</Link>
           </Button>
+          <Button variant="outline" asChild>
+            <Link href="/admin/operativo">Admin operativo (CAC/IVA)</Link>
+          </Button>
         </div>
       </header>
 
@@ -159,10 +162,14 @@ export default async function AdminPage() {
                   <Input id="porcentaje" name="porcentaje" type="number" required />
                 </div>
                 <div>
-                  <Label htmlFor="monto">Monto</Label>
-                  <Input id="monto" name="monto" type="number" required />
+                  <Label htmlFor="cacActual">CAC actual</Label>
+                  <Input id="cacActual" name="cacActual" type="number" step="0.01" required />
                 </div>
               </div>
+              <label className="flex items-center gap-2 text-sm text-slate-600">
+                <input type="checkbox" name="aplicaIVA" defaultChecked />
+                Aplicar IVA
+              </label>
               <Button type="submit">Crear certificado</Button>
             </form>
             <p className="text-xs text-slate-500">

--- a/nerin-electric-site-v3-fixed/app/admin/operativo/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/operativo/page.tsx
@@ -1,0 +1,229 @@
+export const dynamic = 'force-dynamic'
+
+import Link from 'next/link'
+import { prisma } from '@/lib/db'
+import { DB_ENABLED } from '@/lib/dbMode'
+import { isMissingTableError } from '@/lib/prisma-errors'
+import { createCertificate, markCertificatePaid } from '../actions'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Table, TableCell, TableHead, TableRow } from '@/components/ui/table'
+
+const formatCurrency = (value: number) =>
+  value.toLocaleString('es-AR', {
+    style: 'currency',
+    currency: 'ARS',
+    maximumFractionDigits: 2,
+  })
+
+export default async function AdminOperativoPage() {
+  if (!DB_ENABLED) {
+    return (
+      <div className="space-y-4">
+        <Badge>Admin operativo</Badge>
+        <h1>Admin operativo no configurado</h1>
+        <p className="text-sm text-slate-600">La base de datos está deshabilitada.</p>
+      </div>
+    )
+  }
+
+  let projects: Awaited<ReturnType<typeof prisma.project.findMany>> = []
+
+  try {
+    projects = await prisma.project.findMany({
+      include: {
+        client: { include: { user: true } },
+        progressCertificates: { orderBy: { createdAt: 'desc' } },
+        photos: { orderBy: { createdAt: 'desc' } },
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+  } catch (error) {
+    if (isMissingTableError(error)) {
+      return (
+        <div className="space-y-4">
+          <Badge>Admin operativo</Badge>
+          <h1>DB no inicializada</h1>
+          <p className="text-sm text-slate-600">La base de datos todavía no está lista. Inicializala y recargá.</p>
+          <Button variant="secondary" asChild>
+            <Link href="/admin">Volver al panel</Link>
+          </Button>
+        </div>
+      )
+    }
+    throw error
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <Badge>Admin operativo</Badge>
+        <h1>Obras en ejecución</h1>
+        <p className="text-sm text-slate-600">Seguimiento de certificados, CAC, IVA y pagos en un solo tablero.</p>
+      </header>
+
+      {!projects.length ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Sin obras registradas</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-slate-600">
+            <p>Cuando cargues proyectos para clientes vas a poder emitir certificados desde aquí.</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-10">
+          {projects.map((project) => {
+            const clientName = project.client?.user?.name || project.client?.user?.email || 'Cliente'
+            return (
+              <Card key={project.id} className="space-y-4">
+                <CardHeader>
+                  <CardTitle>{project.nombre}</CardTitle>
+                  <p className="text-sm text-slate-500">
+                    Cliente: {clientName} · Base obra {formatCurrency(Number(project.valorObraBase))}
+                  </p>
+                  <p className="text-sm text-slate-500">
+                    Avance certificado: {project.avanceCertificado}% · Avance pagado: {project.avancePagado}%
+                  </p>
+                </CardHeader>
+                <CardContent className="space-y-8">
+                  <section className="grid gap-4 md:grid-cols-[1.1fr_1fr]">
+                    <div className="space-y-4">
+                      <h3 className="text-base font-semibold text-foreground">Emitir certificado</h3>
+                      <form action={createCertificate} className="grid gap-4">
+                        <input type="hidden" name="projectId" value={project.id} />
+                        <div className="grid gap-2">
+                          <Label htmlFor={`porcentaje-${project.id}`}>Porcentaje (%)</Label>
+                          <Input
+                            id={`porcentaje-${project.id}`}
+                            name="porcentaje"
+                            type="number"
+                            min="1"
+                            max="100"
+                            required
+                          />
+                        </div>
+                        <div className="grid gap-2">
+                          <Label htmlFor={`cacActual-${project.id}`}>CAC actual</Label>
+                          <Input
+                            id={`cacActual-${project.id}`}
+                            name="cacActual"
+                            type="number"
+                            step="0.01"
+                            required
+                          />
+                        </div>
+                        <label className="flex items-center gap-2 text-sm text-slate-600">
+                          <input type="checkbox" name="aplicaIVA" defaultChecked />
+                          Aplicar IVA ({project.ivaPorcentaje}%)
+                        </label>
+                        <Button type="submit">Crear certificado</Button>
+                      </form>
+                    </div>
+
+                    <div className="space-y-4">
+                      <h3 className="text-base font-semibold text-foreground">Fotos de obra</h3>
+                      <form
+                        action="/api/upload/project-photo"
+                        method="post"
+                        encType="multipart/form-data"
+                        className="grid gap-3"
+                      >
+                        <input type="hidden" name="projectId" value={project.id} />
+                        <div className="grid gap-2">
+                          <Label htmlFor={`photo-title-${project.id}`}>Título</Label>
+                          <Input id={`photo-title-${project.id}`} name="title" placeholder="Ingreso de materiales" />
+                        </div>
+                        <div className="grid gap-2">
+                          <Label htmlFor={`photo-file-${project.id}`}>Archivo</Label>
+                          <Input id={`photo-file-${project.id}`} name="file" type="file" accept="image/*" required />
+                        </div>
+                        <Button type="submit" variant="secondary">
+                          Subir foto
+                        </Button>
+                      </form>
+                      {project.photos.length ? (
+                        <div className="grid grid-cols-2 gap-3">
+                          {project.photos.map((photo) => (
+                            <figure key={photo.id} className="space-y-2">
+                              <img
+                                src={`/uploads/${photo.storedPath}`}
+                                alt={photo.title ?? 'Foto de obra'}
+                                className="h-32 w-full rounded-lg object-cover"
+                                loading="lazy"
+                              />
+                              <figcaption className="text-xs text-slate-500">{photo.title ?? photo.filename}</figcaption>
+                            </figure>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-xs text-slate-500">Todavía no hay fotos cargadas.</p>
+                      )}
+                    </div>
+                  </section>
+
+                  <section className="space-y-3">
+                    <h3 className="text-base font-semibold text-foreground">Certificados emitidos</h3>
+                    <Table>
+                      <thead>
+                        <TableRow>
+                          <TableHead>Fecha</TableHead>
+                          <TableHead>Porcentaje</TableHead>
+                          <TableHead>CAC</TableHead>
+                          <TableHead>Subtotal</TableHead>
+                          <TableHead>IVA</TableHead>
+                          <TableHead>Total</TableHead>
+                          <TableHead>Estado</TableHead>
+                          <TableHead></TableHead>
+                        </TableRow>
+                      </thead>
+                      <tbody>
+                        {project.progressCertificates.length ? (
+                          project.progressCertificates.map((certificate) => (
+                            <TableRow key={certificate.id}>
+                              <TableCell>{new Date(certificate.createdAt).toLocaleDateString('es-AR')}</TableCell>
+                              <TableCell>{certificate.porcentaje}%</TableCell>
+                              <TableCell>
+                                {Number(certificate.cacAnterior).toLocaleString('es-AR')} →{' '}
+                                {Number(certificate.cacActual).toLocaleString('es-AR')}
+                              </TableCell>
+                              <TableCell>{formatCurrency(Number(certificate.subtotalSinIVA))}</TableCell>
+                              <TableCell>{formatCurrency(Number(certificate.ivaMonto))}</TableCell>
+                              <TableCell>{formatCurrency(Number(certificate.totalConIVA))}</TableCell>
+                              <TableCell className="capitalize">{certificate.estado}</TableCell>
+                              <TableCell>
+                                {certificate.estado !== 'pagado' ? (
+                                  <form action={markCertificatePaid}>
+                                    <input type="hidden" name="certificateId" value={certificate.id} />
+                                    <Button size="sm" variant="outline">
+                                      Marcar pagado
+                                    </Button>
+                                  </form>
+                                ) : (
+                                  <span className="text-xs text-slate-500">Pagado</span>
+                                )}
+                              </TableCell>
+                            </TableRow>
+                          ))
+                        ) : (
+                          <TableRow>
+                            <TableCell colSpan={8} className="text-center text-sm text-slate-500">
+                              No hay certificados cargados.
+                            </TableCell>
+                          </TableRow>
+                        )}
+                      </tbody>
+                    </Table>
+                  </section>
+                </CardContent>
+              </Card>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/nerin-electric-site-v3-fixed/app/api/upload/project-photo/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/upload/project-photo/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import { prisma } from '@/lib/db'
+import { DB_ENABLED } from '@/lib/dbMode'
+import { getStorageDir } from '@/lib/content'
+import { requireAdmin } from '@/lib/auth'
+
+export async function POST(req: Request) {
+  await requireAdmin()
+
+  if (!DB_ENABLED) {
+    return NextResponse.json({ error: 'DB_DISABLED' }, { status: 400 })
+  }
+
+  const form = await req.formData()
+  const projectId = form.get('projectId')?.toString() ?? ''
+  const title = form.get('title')?.toString() ?? null
+  const file = form.get('file') as File | null
+
+  if (!projectId || !file) {
+    return NextResponse.json({ error: 'Missing projectId or file' }, { status: 400 })
+  }
+
+  const project = await prisma.project.findUnique({ where: { id: projectId } })
+  if (!project) {
+    return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+  }
+
+  const safeName = (file.name || 'upload').replace(/[^a-zA-Z0-9._-]/g, '_')
+  const storageDir = getStorageDir()
+  const uploadsDir = path.join(storageDir, 'uploads', 'projects', projectId)
+  await fs.mkdir(uploadsDir, { recursive: true })
+
+  const arrayBuffer = await file.arrayBuffer()
+  const buffer = Buffer.from(arrayBuffer)
+  const outputPath = path.join(uploadsDir, safeName)
+  await fs.writeFile(outputPath, buffer)
+
+  const storedPath = path.posix.join('projects', projectId, safeName)
+
+  const photo = await prisma.projectPhoto.create({
+    data: {
+      projectId,
+      title,
+      filename: safeName,
+      mimeType: file.type || 'application/octet-stream',
+      size: buffer.length,
+      storedPath,
+    },
+  })
+
+  return NextResponse.json({
+    ok: true,
+    id: photo.id,
+    url: `/uploads/${storedPath}`,
+  })
+}

--- a/nerin-electric-site-v3-fixed/app/uploads/[...path]/route.ts
+++ b/nerin-electric-site-v3-fixed/app/uploads/[...path]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import { getStorageDir } from '@/lib/content'
+
+const contentTypes: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+}
+
+export async function GET(_req: Request, { params }: { params: { path: string[] } }) {
+  const storageDir = getStorageDir()
+  const baseDir = path.resolve(storageDir, 'uploads')
+  const relativePath = params.path.join('/')
+  const filePath = path.resolve(baseDir, relativePath)
+
+  if (!filePath.startsWith(baseDir)) {
+    return new NextResponse('Invalid path', { status: 400 })
+  }
+
+  try {
+    const file = await fs.readFile(filePath)
+    const ext = path.extname(filePath).toLowerCase()
+    const contentType = contentTypes[ext] || 'application/octet-stream'
+    return new NextResponse(file, {
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      },
+    })
+  } catch {
+    return new NextResponse('Not found', { status: 404 })
+  }
+}

--- a/nerin-electric-site-v3-fixed/lib/blog.ts
+++ b/nerin-electric-site-v3-fixed/lib/blog.ts
@@ -33,19 +33,24 @@ export async function getBlogPosts(): Promise<BlogPost[]> {
       }))
       .sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : -1))
   } catch (error) {
-    const store = getContentStore()
-    const posts = await store.listPosts()
-    return posts
-      .filter((post) => post.publishedAt)
-      .map((post) => ({
-        slug: post.slug,
-        title: post.title,
-        excerpt: post.excerpt,
-        publishedAt: post.publishedAt ?? new Date().toISOString(),
-        content: post.content,
-        heroImage: post.coverImage ?? undefined,
-      }))
-      .sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : -1))
+    try {
+      const store = getContentStore()
+      const posts = await store.listPosts()
+      return posts
+        .filter((post) => post.publishedAt)
+        .map((post) => ({
+          slug: post.slug,
+          title: post.title,
+          excerpt: post.excerpt,
+          publishedAt: post.publishedAt ?? new Date().toISOString(),
+          content: post.content,
+          heroImage: post.coverImage ?? undefined,
+        }))
+        .sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : -1))
+    } catch (storeError) {
+      console.warn('[BLOG] Unable to list posts, returning empty list.', storeError)
+      return []
+    }
   }
 }
 

--- a/nerin-electric-site-v3-fixed/lib/content-store.ts
+++ b/nerin-electric-site-v3-fixed/lib/content-store.ts
@@ -577,6 +577,9 @@ function buildPrismaStore(): ContentStore {
       }
     },
     listPosts: async () => {
+      if (!DB_ENABLED) {
+        return []
+      }
       try {
         const posts = await prisma.blogPost.findMany({ orderBy: { createdAt: 'desc' } })
         return posts.map((post) => ({
@@ -594,7 +597,8 @@ function buildPrismaStore(): ContentStore {
         if (handleMissingTable(error, 'BlogPost', 'returning empty list')) {
           return []
         }
-        throw error
+        console.warn('[CONTENT] Failed to list posts from Prisma, returning empty list.', error)
+        return []
       }
     },
     getPost: async (slug: string) => {

--- a/nerin-electric-site-v3-fixed/package.json
+++ b/nerin-electric-site-v3-fixed/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "next dev -p 3000",
-    "build": "export STORAGE_DIR=${STORAGE_DIR:-/var/data} && export DATABASE_URL=${DATABASE_URL:-$( [ -d \"$STORAGE_DIR\" ] && echo file:$STORAGE_DIR/nerin.db || echo file:/tmp/nerin.db )} && prisma generate && prisma db push && next build",
+    "build": "DB_ENABLED=false prisma generate && next build",
     "start": "export STORAGE_DIR=${STORAGE_DIR:-/var/data} && export DATABASE_URL=${DATABASE_URL:-$( [ -d \"$STORAGE_DIR\" ] && echo file:$STORAGE_DIR/nerin.db || echo file:/tmp/nerin.db )} && prisma db push && next start -p $PORT",
     "lint": "next lint",
     "format": "prettier --write .",

--- a/nerin-electric-site-v3-fixed/prisma/schema.prisma
+++ b/nerin-electric-site-v3-fixed/prisma/schema.prisma
@@ -93,6 +93,12 @@ model Project {
   normativasAplicadas  String   @default("[]")
   fechaInicio          DateTime?
   fechaFinEstimada     DateTime?
+  valorObraBase        Decimal  @default(0)
+  ivaPorcentaje        Int      @default(21)
+  cacInicial           Decimal  @default(0)
+  cacUltimo            Decimal  @default(0)
+  avanceCertificado    Int      @default(0)
+  avancePagado         Int      @default(0)
   createdAt            DateTime        @default(now())
   updatedAt            DateTime        @updatedAt
   client               Client          @relation(fields: [clientId], references: [id], onDelete: Cascade)
@@ -101,6 +107,7 @@ model Project {
   progressCertificates ProgressCertificate[]
   invoices             Invoice[]
   tickets              Ticket[]
+  photos               ProjectPhoto[]
 }
 
 model Pack {
@@ -239,10 +246,31 @@ model ProgressCertificate {
   estado          String   @default("pendiente")
   mpPreferenceId  String?
   mpInitPointUrl  String?
+  cacAnterior     Decimal  @default(0)
+  cacActual       Decimal  @default(0)
+  factorCAC       Decimal  @default(1)
+  montoBase       Decimal  @default(0)
+  ajusteCAC       Decimal  @default(0)
+  subtotalSinIVA  Decimal  @default(0)
+  ivaMonto        Decimal  @default(0)
+  totalConIVA     Decimal  @default(0)
+  pagadoAt        DateTime?
   paidAt          DateTime?
   createdAt       DateTime       @default(now())
   updatedAt       DateTime       @updatedAt
   project         Project        @relation(fields: [projectId], references: [id], onDelete: Cascade)
+}
+
+model ProjectPhoto {
+  id         String   @id @default(cuid())
+  projectId  String
+  title      String?
+  filename   String
+  mimeType   String
+  size       Int
+  storedPath String
+  createdAt  DateTime @default(now())
+  project    Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
 }
 
 model Invoice {


### PR DESCRIPTION
### Motivation
- Ensure Next.js `build` does not touch the DB/disk on Render by disabling DB access during build time. 
- Support operational admin flows: issue certificates with CAC/IVA breakdown, track paid progress and upload project photos.
- Make content/blog fallbacks resilient so prerender/build won't fail when Prisma/tables are unavailable.

### Description
- Change `build` script in `package.json` to run with DB disabled at build time: `"build": "DB_ENABLED=false prisma generate && next build"`.
- Make content code resilient: wrap fallback store access in `lib/blog.ts` and avoid Prisma queries in `lib/content-store.ts` when `DB_ENABLED` is false, returning safe empty lists and logging errors instead of throwing. 
- Extend Prisma schema (`prisma/schema.prisma`) adding project financial fields (`valorObraBase`, `ivaPorcentaje`, `cacInicial`, `cacUltimo`, `avanceCertificado`, `avancePagado`), detailed fields in `ProgressCertificate` (CAC/IVA/monto breakdown and `pagadoAt`) and a new `ProjectPhoto` model for uploads.
- Implement certificate logic and payment marking in `app/admin/actions.ts` with `createCertificate` and `markCertificatePaid` that compute factor/CAC adjustments using `Prisma.Decimal`, store detailed breakdown (`montoBase`, `ajusteCAC`, `subtotalSinIVA`, `ivaMonto`, `totalConIVA`), update `project.cacUltimo`, and recalc `avanceCertificado`/`avancePagado`.
- Add a new admin UI page `app/admin/operativo/page.tsx` that shows a DB-disabled message when `DB_ENABLED=false`, lists projects, provides a certificate form (porcentaje + CAC + IVA checkbox), displays certificates with breakdown and a button to mark paid, and a project photos section with file input.
- Add real upload route `app/api/upload/project-photo/route.ts` to accept `multipart/form-data`, save files under `STORAGE_DIR/uploads/projects/{projectId}`, create `ProjectPhoto` DB row and return a public URL; and add `app/uploads/[...path]/route.ts` to serve files safely (path-traversal protected).

### Testing
- Ran `DATABASE_URL=file:/tmp/nerin.db npx prisma db push` which completed successfully and generated the Prisma client against a temporary SQLite DB. (Succeeded)
- Started the dev server with `DATABASE_URL=file:/tmp/nerin.db DB_ENABLED=true npm run dev` and Next.js booted and served locally. (Succeeded)
- Attempted a Playwright-based smoke screenshot of `/admin/operativo`, but the headless browser crashed with a SIGSEGV during the run, so UI screenshot validation did not complete. (Failed)
- No automated unit/integration tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69775b77c0608331b4aac23ac6ce3348)