### PR TITLE
Fix createCertificate server action return type

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/actions.ts
+++ b/nerin-electric-site-v3-fixed/app/admin/actions.ts
@@ -181,7 +181,7 @@ const CertificateSchema = z.object({
   aplicaIVA: z.coerce.boolean().optional(),
 })
 
-export async function createCertificate(formData: FormData) {
+export async function createCertificate(formData: FormData): Promise<void> {
   if (!DB_ENABLED) {
     throw new Error('DB_DISABLED')
   }
@@ -215,7 +215,7 @@ export async function createCertificate(formData: FormData) {
     : new Prisma.Decimal(0)
   const total = subtotal.plus(ivaMonto)
 
-  const [certificate, percentSum] = await prisma.$transaction([
+  const [, percentSum] = await prisma.$transaction([
     prisma.progressCertificate.create({
       data: {
         projectId: payload.projectId,
@@ -252,7 +252,6 @@ export async function createCertificate(formData: FormData) {
   revalidatePath('/admin/operativo')
   revalidatePath(`/admin/operativo`)
 
-  return certificate
 }
 
 const MarkPaidSchema = z.object({


### PR DESCRIPTION
### Motivation
- Asegurar que la server action usada en `form action={createCertificate}` cumpla la firma `Promise<void>` y no retorne el objeto Prisma, para resolver el error de TypeScript en la página administrativa.

### Description
- Cambié la firma a `export async function createCertificate(formData: FormData): Promise<void>`, evité retornar el resultado de `prisma.progressCertificate.create(...)` reemplazando el valor retornado por `await` (ignorando el primer elemento del `$transaction`) y mantuve las llamadas a `revalidatePath(...)` sin tocar la UI ni el esquema.

### Testing
- Ejecuté `npx prisma generate` (exitoso) y `npx next build` (falló con errores de tipos no relacionados en `app/admin/operativo/page.tsx` sobre propiedades de `project`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697776877b2c833188a68c9af7c3585e)