### PR TITLE
Migrate ops monetary fields to BigInt and handle BigInt in actions/UI

### DIFF
--- a/nerin-electric-site-v3-fixed/app/admin/ops/certificates/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/ops/certificates/page.tsx
@@ -142,7 +142,7 @@ export default async function AdminOpsCertificatesPage({
                   <TableCell>
                     +{certificate.percentToAdd}% → {certificate.percentAfter}%
                   </TableCell>
-                  <TableCell>${(certificate.amount / 100).toLocaleString('es-AR')}</TableCell>
+                  <TableCell>${(Number(certificate.amount) / 100).toLocaleString('es-AR')}</TableCell>
                   <TableCell>
                     <Badge className="bg-slate-100 text-slate-600">{certificate.status}</Badge>
                   </TableCell>

--- a/nerin-electric-site-v3-fixed/app/admin/ops/projects/[id]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/admin/ops/projects/[id]/page.tsx
@@ -195,7 +195,7 @@ export default async function AdminOpsProjectDetail({
                     <TableCell>
                       +{certificate.percentToAdd}% → {certificate.percentAfter}%
                     </TableCell>
-                    <TableCell>${(certificate.amount / 100).toLocaleString('es-AR')}</TableCell>
+                    <TableCell>${(Number(certificate.amount) / 100).toLocaleString('es-AR')}</TableCell>
                     <TableCell>
                       <Badge className="bg-slate-100 text-slate-600">{certificate.status}</Badge>
                     </TableCell>
@@ -264,7 +264,7 @@ export default async function AdminOpsProjectDetail({
                     <TableCell>
                       {additional.quantity} {additional.unit}
                     </TableCell>
-                    <TableCell>${(additional.unitPrice / 100).toLocaleString('es-AR')}</TableCell>
+                    <TableCell>${(Number(additional.unitPrice) / 100).toLocaleString('es-AR')}</TableCell>
                     <TableCell>
                       <Badge className="bg-slate-100 text-slate-600">{additional.status}</Badge>
                     </TableCell>

--- a/nerin-electric-site-v3-fixed/app/clientes/obra/[id]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/clientes/obra/[id]/page.tsx
@@ -50,12 +50,12 @@ export default async function ClienteObraPage({ params }: { params: { id: string
     ...project.certificates.map((item) => ({
       type: 'Certificado',
       date: item.createdAt,
-      label: `+${item.percentToAdd}% · $${(item.amount / 100).toLocaleString('es-AR')} · ${item.status}`,
+      label: `+${item.percentToAdd}% · $${(Number(item.amount) / 100).toLocaleString('es-AR')} · ${item.status}`,
     })),
     ...project.additionals.map((item) => ({
       type: 'Adicional',
       date: item.createdAt,
-      label: `${item.name} · ${item.quantity} ${item.unit} · $${(item.unitPrice / 100).toLocaleString('es-AR')}`,
+      label: `${item.name} · ${item.quantity} ${item.unit} · $${(Number(item.unitPrice) / 100).toLocaleString('es-AR')}`,
     })),
   ].sort((a, b) => b.date.getTime() - a.date.getTime())
 
@@ -93,7 +93,7 @@ export default async function ClienteObraPage({ params }: { params: { id: string
                   <TableRow key={certificate.id}>
                     <TableCell>{new Date(certificate.createdAt).toLocaleDateString('es-AR')}</TableCell>
                     <TableCell>+{certificate.percentToAdd}%</TableCell>
-                    <TableCell>${(certificate.amount / 100).toLocaleString('es-AR')}</TableCell>
+                    <TableCell>${(Number(certificate.amount) / 100).toLocaleString('es-AR')}</TableCell>
                     <TableCell>
                       <Badge className="bg-slate-100 text-slate-600">{certificate.status}</Badge>
                     </TableCell>
@@ -135,7 +135,7 @@ export default async function ClienteObraPage({ params }: { params: { id: string
                     <TableCell>{additional.name}</TableCell>
                     <TableCell>
                       {additional.quantity} {additional.unit} · $
-                      {(additional.unitPrice / 100).toLocaleString('es-AR')}
+                      {(Number(additional.unitPrice) / 100).toLocaleString('es-AR')}
                     </TableCell>
                     <TableCell>
                       <Badge className="bg-slate-100 text-slate-600">{additional.status}</Badge>

--- a/nerin-electric-site-v3-fixed/prisma/schema.prisma
+++ b/nerin-electric-site-v3-fixed/prisma/schema.prisma
@@ -447,7 +447,7 @@ model OpsProgressCertificate {
   projectId                String
   percentToAdd             Int
   percentAfter             Int
-  amount                   Int
+  amount                   BigInt
   currency                 String               @default("ARS")
   description              String?
   status                   String               @default("DRAFT")
@@ -464,7 +464,7 @@ model AdditionalCatalogItem {
   name           String
   description    String?
   unit           String
-  laborUnitPrice Int
+  laborUnitPrice BigInt
   active         Boolean                  @default(true)
   projectItems   OpsProjectAdditionalItem[]
 }
@@ -476,7 +476,7 @@ model OpsProjectAdditionalItem {
   name                     String
   description              String?
   unit                     String
-  unitPrice                Int
+  unitPrice                BigInt
   quantity                 Float
   status                   String             @default("QUOTED")
   mercadoPagoPreferenceId  String?

--- a/nerin-electric-site-v3-fixed/prisma/seed.ts
+++ b/nerin-electric-site-v3-fixed/prisma/seed.ts
@@ -390,7 +390,7 @@ async function main() {
         name: 'Bocas adicionales',
         description: 'Instalación de bocas adicionales por ambiente.',
         unit: 'unidad',
-        laborUnitPrice: 18000,
+        laborUnitPrice: 18000n,
         active: true,
       },
     })
@@ -400,7 +400,7 @@ async function main() {
         projectId: opsProject.id,
         percentToAdd: 15,
         percentAfter: 40,
-        amount: 42000000,
+        amount: 42000000n,
         status: 'DRAFT',
         description: 'Certificado parcial de avance.',
       },


### PR DESCRIPTION
### Motivation
- Prevent Prisma P2023 (integer overflow) on ops monetary fields by using `BigInt` for large cent values. 
- Ensure Mercado Pago integrations receive numeric amounts while storing precise cent values as `BigInt` in the DB. 

### Description
- Updated Prisma types: `OpsProgressCertificate.amount`, `AdditionalCatalogItem.laborUnitPrice` and `OpsProjectAdditionalItem.unitPrice` are now `BigInt` in `prisma/schema.prisma`. 
- Added `toCentsBigInt()` helper and switched ops flows to use `bigint` cent values in `app/admin/ops/actions.ts`, including validation (`<= 0n`) and saving `BigInt` cents to the DB. 
- Convert `BigInt` cent values to numbers for Mercado Pago preferences by using `Number(...) / 100` (e.g. `const mpAmount = Number(amountCents) / 100`) before calling `createPreference`. 
- Updated UI formatting to avoid direct `BigInt` arithmetic in JSX by casting with `Number(...)` in `app/admin/ops/certificates/page.tsx`, `app/admin/ops/projects/[id]/page.tsx` and `app/clientes/obra/[id]/page.tsx`. 
- Updated seed data to use `bigint` literals (e.g. `18000n`, `42000000n`). 

### Testing
- Ran Prisma client generation as part of `npm run build` via `prisma generate`, which completed successfully. 
- Ran `npm run build` (Next.js build), which compiled successfully; build output included warnings about missing DB tables during static generation and a Next.js lint suggestion but no type/build errors. 
- No automated API runtime tests were executed beyond the build; database table absence caused expected runtime warnings during static generation but did not fail the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697819e6228c83319ed0f771e01e9e84)