### PR TITLE
Add admin shell form constants for dashboard forms

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/constants.ts
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/constants.ts
@@ -1,0 +1,17 @@
+export type MaintenanceFormState = {
+  success: boolean
+  error?: string
+}
+
+export const initialMaintenanceFormState: MaintenanceFormState = {
+  success: false,
+}
+
+export type CaseStudyFormState = {
+  success: boolean
+  error?: string
+}
+
+export const initialCaseStudyState: CaseStudyFormState = {
+  success: false,
+}


### PR DESCRIPTION
### Motivation
- Fix unresolved import errors in the admin dashboard forms by providing the missing `../constants` module that the forms expect.

### Description
- Add `app/(admin)/admin/(shell)/constants.ts` exporting `MaintenanceFormState` and `CaseStudyFormState` types and their defaults `initialMaintenanceFormState` and `initialCaseStudyState` so the dashboard forms can import `../constants`.

### Testing
- Ran `npm run build`, which executed but ultimately failed with a TypeScript error in `components/admin/AdminSidebar.tsx:31:21` (`Type 'string' is not assignable to type 'UrlObject | RouteImpl<string>'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69789f576aec8331b63fd60e4828d664)