### PR TITLE
Fix typed routes for admin nav

### DIFF
--- a/nerin-electric-site-v3-fixed/components/admin/nav.ts
+++ b/nerin-electric-site-v3-fixed/components/admin/nav.ts
@@ -1,6 +1,8 @@
+import type { Route } from 'next'
+
 export type AdminNavItem = {
   title: string
-  href: string
+  href: Route
 }
 
 export type AdminNavSection = {
@@ -12,36 +14,36 @@ export const adminNav: AdminNavSection[] = [
   {
     label: 'Dashboard',
     items: [
-      { title: 'Dashboard', href: '/admin' },
-      { title: 'Leads', href: '/admin/leads' },
+      { title: 'Dashboard', href: '/admin' as Route },
+      { title: 'Leads', href: '/admin/leads' as Route },
     ],
   },
   {
     label: 'Operaciones (Ops)',
     items: [
-      { title: 'Panel Ops', href: '/admin/ops' },
-      { title: 'Proyectos', href: '/admin/ops/projects' },
-      { title: 'Certificados', href: '/admin/ops/certificates' },
-      { title: 'Adicionales', href: '/admin/ops/projects?tab=adicionales' },
-      { title: 'Clientes', href: '/admin/ops/clients' },
+      { title: 'Panel Ops', href: '/admin/ops' as Route },
+      { title: 'Proyectos', href: '/admin/ops/projects' as Route },
+      { title: 'Certificados', href: '/admin/ops/certificates' as Route },
+      { title: 'Adicionales', href: '/admin/ops/projects?tab=adicionales' as Route },
+      { title: 'Clientes', href: '/admin/ops/clients' as Route },
     ],
   },
   {
     label: 'Packs',
-    items: [{ title: 'Packs comerciales', href: '/admin/packs' }],
+    items: [{ title: 'Packs comerciales', href: '/admin/packs' as Route }],
   },
   {
     label: 'Contenido',
     items: [
-      { title: 'Textos del sitio', href: '/admin' },
-      { title: 'Noticias', href: '/admin/noticias' },
+      { title: 'Textos del sitio', href: '/admin' as Route },
+      { title: 'Noticias', href: '/admin/noticias' as Route },
     ],
   },
   {
     label: 'Ajustes',
     items: [
-      { title: 'Config general', href: '/admin/ajustes' },
-      { title: 'CAC/IVA operativo', href: '/admin/operativo' },
+      { title: 'Config general', href: '/admin/ajustes' as Route },
+      { title: 'CAC/IVA operativo', href: '/admin/operativo' as Route },
     ],
   },
 ]


### PR DESCRIPTION
### Motivation
- Fix a TypeScript error where `Link` calls in the admin sidebar failed because `href` was a `string` instead of a typed `Route` under Next.js `typedRoutes`.
- Keep `typedRoutes` enabled and avoid using `any` or disabling the feature while making nav links compatible with Next.js types.

### Description
- Import `Route` from `next` and change `AdminNavItem.href` to type `Route` in `components/admin/nav.ts`.
- Cast all admin path literals to `Route` (e.g. `'/admin/...' as Route`) for each nav entry to satisfy the typed route requirement.
- Left `findAdminNavMatch` logic intact so route matching continues to work with the typed `href` values.

### Testing
- Ran `npm run build` in the project root and the Next.js build completed successfully with type checking and compilation passing.
- The build produced runtime warnings about missing Prisma tables and missing auth env vars in this environment, but the production build finished with exit code 0.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978adfa48fc8331a2110cbb4f1be208)