### PR TITLE
Persist site settings and add configurable logo (header + admin)

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/SiteExperienceDesigner.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/SiteExperienceDesigner.tsx
@@ -140,9 +140,49 @@ export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerPr
       <div className="grid gap-6 lg:grid-cols-2">
         <Card>
           <CardHeader>
-            <CardTitle>Identidad y contacto</CardTitle>
+          <CardTitle>Identidad y contacto</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
+            <div className="grid gap-2">
+              <Label htmlFor="site-logo-title">Texto principal del logo</Label>
+              <Input
+                id="site-logo-title"
+                value={form.logo.title}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    logo: { ...prev.logo, title: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="site-logo-subtitle">Texto secundario del logo</Label>
+              <Input
+                id="site-logo-subtitle"
+                value={form.logo.subtitle}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    logo: { ...prev.logo, subtitle: event.target.value },
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="site-logo-url">Logo (URL)</Label>
+              <Input
+                id="site-logo-url"
+                value={form.logo.imageUrl}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    logo: { ...prev.logo, imageUrl: event.target.value },
+                  }))
+                }
+                placeholder="https://..."
+              />
+            </div>
             <div className="grid gap-2">
               <Label htmlFor="site-name">Nombre comercial</Label>
               <Input

--- a/nerin-electric-site-v3-fixed/app/(site)/layout.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/layout.tsx
@@ -115,6 +115,11 @@ export default async function SiteLayout({ children }: { children: ReactNode }) 
           whatsappHref,
           whatsappLabel: site.contact.whatsappCtaLabel,
         }}
+        logo={{
+          title: site.logo.title,
+          subtitle: site.logo.subtitle,
+          imageUrl: site.logo.imageUrl,
+        }}
       />
       <main className="container pb-24 pt-14">{children}</main>
       <Footer site={site} />

--- a/nerin-electric-site-v3-fixed/components/Header.tsx
+++ b/nerin-electric-site-v3-fixed/components/Header.tsx
@@ -10,6 +10,11 @@ interface HeaderProps {
     whatsappHref: string
     whatsappLabel: string
   }
+  logo: {
+    title: string
+    subtitle: string
+    imageUrl?: string | null
+  }
 }
 
 const navigation = [
@@ -23,13 +28,13 @@ const navigation = [
 
 const clientDashboardRoute = '/clientes' as const
 
-export function Header({ contact }: HeaderProps) {
+export function Header({ contact, logo }: HeaderProps) {
   const { data: session } = useSession()
 
   return (
     <header className="sticky top-0 z-50 border-b border-border/80 bg-white/95 backdrop-blur">
       <div className="container flex items-center justify-between gap-6 py-3">
-        <Logo />
+        <Logo title={logo.title} subtitle={logo.subtitle} imageUrl={logo.imageUrl} />
         <nav className="hidden items-center gap-6 text-sm font-medium text-muted-foreground lg:flex">
           {navigation.map((item) => (
             <Link key={item.href} href={item.href} className="hover:text-foreground">

--- a/nerin-electric-site-v3-fixed/components/Logo.tsx
+++ b/nerin-electric-site-v3-fixed/components/Logo.tsx
@@ -1,21 +1,29 @@
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 
-export function Logo({ className }: { className?: string }) {
+type LogoProps = {
+  title: string
+  subtitle: string
+  imageUrl?: string | null
+  className?: string
+}
+
+export function Logo({ className, imageUrl, subtitle, title }: LogoProps) {
   return (
     <Link href="/" className={cn('no-underline flex items-center gap-3 font-display text-lg', className)}>
       <span className="inline-flex h-10 w-10 items-center justify-center rounded-[var(--radius)] border border-border bg-white">
-        <svg aria-hidden viewBox="0 0 64 64" className="h-7 w-7">
-          <rect x="6" y="6" width="52" height="52" rx="6" fill="#0B0F14" stroke="#FBBF24" strokeWidth="2" />
-          <path
-            d="M35 10L20 36h14l-8 18 18-28H30l5-16z"
-            fill="#FBBF24"
-          />
-        </svg>
+        {imageUrl ? (
+          <img src={imageUrl} alt={`${title} ${subtitle}`.trim()} className="h-7 w-7 object-contain" />
+        ) : (
+          <svg aria-hidden viewBox="0 0 64 64" className="h-7 w-7">
+            <rect x="6" y="6" width="52" height="52" rx="6" fill="#0B0F14" stroke="#FBBF24" strokeWidth="2" />
+            <path d="M35 10L20 36h14l-8 18 18-28H30l5-16z" fill="#FBBF24" />
+          </svg>
+        )}
       </span>
       <div className="flex flex-col leading-tight">
-        <span className="text-base font-semibold uppercase tracking-[0.2em] text-foreground">NERIN</span>
-        <span className="text-xs text-muted-foreground">Ingeniería Eléctrica</span>
+        <span className="text-base font-semibold uppercase tracking-[0.2em] text-foreground">{title}</span>
+        <span className="text-xs text-muted-foreground">{subtitle}</span>
       </div>
     </Link>
   )

--- a/nerin-electric-site-v3-fixed/lib/content.ts
+++ b/nerin-electric-site-v3-fixed/lib/content.ts
@@ -15,6 +15,11 @@ const SITE_FILE = 'site.json'
 export const SITE_DEFAULTS: SiteExperience = {
   name: 'NERIN · Ingeniería Eléctrica',
   tagline: 'Instalaciones de alta performance con trazabilidad completa.',
+  logo: {
+    title: 'NERIN',
+    subtitle: 'Ingeniería Eléctrica',
+    imageUrl: '',
+  },
   accent: '#f59e0b',
   socials: {
     instagram: 'https://www.instagram.com/nerin.electric',

--- a/nerin-electric-site-v3-fixed/lib/siteSettings.ts
+++ b/nerin-electric-site-v3-fixed/lib/siteSettings.ts
@@ -1,8 +1,6 @@
 import type { SiteExperience } from '@/types/site'
 import { SITE_DEFAULTS } from '@/lib/content'
-import { DB_ENABLED } from '@/lib/dbMode'
-import { prisma } from '@/lib/db'
-import { parseJson } from '@/lib/serialization'
+import { getContentStore } from '@/lib/content-store'
 
 export type SiteSetting = {
   id?: string
@@ -32,34 +30,9 @@ export const DEFAULT_SETTINGS: SiteSetting = {
 }
 
 export async function getSettings(): Promise<SiteSetting> {
-  if (!DB_ENABLED) {
-    return DEFAULT_SETTINGS
-  }
-
   try {
-    const record = await prisma.siteSetting.findFirst()
-    if (!record) {
-      return DEFAULT_SETTINGS
-    }
-
-    const siteExperience =
-      parseJson<SiteExperience>(record.siteExperience) ?? DEFAULT_SETTINGS.siteExperience
-    const metrics =
-      parseJson<Array<{ label: string; value: string }>>(record.metrics) ?? DEFAULT_SETTINGS.metrics
-
-    return {
-      id: record.id,
-      companyName: record.companyName,
-      industry: record.industry,
-      whatsappNumber: record.whatsappNumber,
-      whatsappMessage: record.whatsappMessage,
-      emailContacto: record.emailContacto,
-      zone: record.zone,
-      schedule: record.schedule,
-      primaryCopy: record.primaryCopy,
-      metrics,
-      siteExperience,
-    }
+    const store = getContentStore()
+    return await store.getSettings()
   } catch (error) {
     return DEFAULT_SETTINGS
   }

--- a/nerin-electric-site-v3-fixed/types/site.ts
+++ b/nerin-electric-site-v3-fixed/types/site.ts
@@ -1,6 +1,11 @@
 export interface SiteExperience {
   name: string
   tagline: string
+  logo: {
+    title: string
+    subtitle: string
+    imageUrl: string
+  }
   accent: string
   socials: {
     instagram: string


### PR DESCRIPTION
### Motivation
- Hacer que los cambios hechos desde el panel de administración se persistan y se reflejen en el sitio público, y permitir configurar el logo (texto y URL) desde el CMS.

### Description
- Cambié la lectura de settings para usar el store compartido reemplazando la consulta directa a Prisma por `getContentStore().getSettings()` en `lib/siteSettings.ts` para que las actualizaciones del admin no se pierdan ante defaults.
- Añadí el campo `logo` al `SiteExperience` (`types/site.ts`) y al `SITE_DEFAULTS` en `lib/content.ts` con `title`, `subtitle` e `imageUrl` para exponer la configuración del logo.
- Extendí el editor en `app/(admin)/admin/(shell)/(dashboard)/SiteExperienceDesigner.tsx` para incluir inputs de `logo.title`, `logo.subtitle` y `logo.imageUrl` y que formen parte del payload guardado por `POST /api/admin/site`.
- Actualicé `components/Logo.tsx` para soportar una imagen remota opcional y mostrar `title`/`subtitle`, y conecté `components/Header.tsx` y `app/(site)/layout.tsx` para usar los valores configurados.

### Testing
- Ejecuté el servidor de desarrollo con `npm run dev` y la app compiló y arrancó (Next dev ready). 
- Generé una captura de la homepage con Playwright y se produjo el artefacto `artifacts/logo-header.png` (screenshot del header configurado).
- Observé avisos en el entorno de desarrollo sobre tablas faltantes en la BD (causando fallback a store en disco/memoria) y errores de fetch externos (`ENETUNREACH`) al optimizar imágenes, pero la lectura/escritura en el content store funcionó en este entorno.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978f7e04e708331888fc7595ae35953)