### PR TITLE
Guardar settings en memoria cuando falta la tabla SiteSetting

### DIFF
--- a/nerin-electric-site-v3-fixed/lib/content-store.ts
+++ b/nerin-electric-site-v3-fixed/lib/content-store.ts
@@ -356,7 +356,8 @@ function buildPrismaStore(): ContentStore {
         }
         await prisma.siteSetting.create({ data })
       } catch (error) {
-        if (handleMissingTable(error, 'SiteSetting', 'skipping save')) {
+        if (handleMissingTable(error, 'SiteSetting', 'saving to memory store')) {
+          await memoryStore.saveSettings(settings)
           return
         }
         throw error


### PR DESCRIPTION
### Motivation
- Cuando la tabla `SiteSetting` no existe los cambios hechos desde el panel admin se descartaban al intentar guardar; es necesario conservar los textos en memoria para que el admin pueda seguir guardando durante la sesión aunque no haya almacenamiento persistente.

### Description
- En `lib/content-store.ts` (implementación Prisma) se cambió el `catch` de `saveSettings` para que si `handleMissingTable(error, 'SiteSetting', ...)` se cumple se ejecute `await memoryStore.saveSettings(settings)` en lugar de simplemente omitir el guardado.

### Testing
- No se ejecutaron tests automatizados para este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978ffc5c58083319b07aee8e85139db)