### PR TITLE
Improve admin site saving feedback and UI refresh

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/SiteExperienceDesigner.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/SiteExperienceDesigner.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import type { SiteExperience } from '@/types/site'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
@@ -73,6 +74,7 @@ function formatList(items: string[]): string {
 }
 
 export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerProps) {
+  const router = useRouter()
   const [form, setForm] = useState<SiteExperience>(initialData)
   const [saving, setSaving] = useState(false)
   const [message, setMessage] = useState<MessageState>(null)
@@ -105,7 +107,12 @@ export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerPr
       if (!response.ok) {
         throw new Error('No se pudo guardar la configuración')
       }
+      const payload = (await response.json()) as { ok: boolean; site?: SiteExperience }
+      if (payload.site) {
+        setForm(payload.site)
+      }
       setMessage({ type: 'success', message: 'Configuración guardada correctamente.' })
+      router.refresh()
     } catch (error) {
       console.error('Error saving site configuration', error)
       setMessage({ type: 'error', message: 'Ocurrió un error al guardar. Intentá nuevamente.' })

--- a/nerin-electric-site-v3-fixed/app/api/admin/site/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/site/route.ts
@@ -22,6 +22,7 @@ export async function POST(req: Request) {
   await requireAdmin()
   const body = await req.json()
   await saveSiteContent(body)
+  revalidatePath('/admin')
   revalidatePath('/')
   revalidatePath('/contacto')
   revalidatePath('/empresa')
@@ -29,5 +30,5 @@ export async function POST(req: Request) {
   revalidatePath('/blog')
   revalidatePath('/packs')
   revalidatePath('/mantenimiento')
-  return NextResponse.json({ ok: true })
+  return NextResponse.json({ ok: true, site: body })
 }


### PR DESCRIPTION
### Motivation
- Admin site edits were not immediately reflected in the admin UI after saving, which made it unclear whether changes persisted and required a manual refresh to sync state.

### Description
- Update the admin save endpoint to revalidate the admin route and return the saved payload by changing the POST handler in `app/api/admin/site/route.ts` to call `revalidatePath('/admin')` and return `{ ok: true, site: body }`.
- Update the editor component in `app/(admin)/admin/(shell)/(dashboard)/SiteExperienceDesigner.tsx` to import `useRouter`, parse the JSON response, synchronize `form` state with the returned `site`, and call `router.refresh()` after a successful save.
- Preserve existing revalidation of public pages and existing success/error feedback in the UI.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697904219ddc8331bf121683580a481f)