### PR TITLE
Force dynamic rendering for public site/settings routes

### DIFF
--- a/nerin-electric-site-v3-fixed/app/api/public/settings/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/public/settings/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server'
 import { getSettings } from '@/lib/siteSettings'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET() {
   const settings = await getSettings()
   return NextResponse.json({

--- a/nerin-electric-site-v3-fixed/app/api/public/site/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/public/site/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server'
 import { getSettings } from '@/lib/siteSettings'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET() {
   const settings = await getSettings()
   return NextResponse.json(settings.siteExperience)


### PR DESCRIPTION
### Motivation
- Prevent stale CMS data from being served by ensuring the public API handlers always load fresh settings instead of returning cached/static responses.

### Description
- Added `export const dynamic = 'force-dynamic'` to `app/api/public/site/route.ts` and `app/api/public/settings/route.ts` so Next.js treats those route handlers as dynamic and does not serve cached content.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a06158d8c8331a1929333ab5ca6ec)