### PR TITLE
Validate logo upload response URL before updating state

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/SiteExperienceDesigner.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/SiteExperienceDesigner.tsx
@@ -144,12 +144,13 @@ export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerPr
         throw new Error('No se pudo subir el logo')
       }
       const payload = (await response.json()) as { ok?: boolean; url?: string }
-      if (!payload.url) {
+      const url = payload.url
+      if (typeof url !== 'string' || url.trim().length === 0) {
         throw new Error('Respuesta inválida al subir el logo')
       }
       setForm((prev) => ({
         ...prev,
-        logo: { ...prev.logo, imageUrl: payload.url },
+        logo: { ...prev.logo, imageUrl: url },
       }))
     } catch (error) {
       console.error('Error uploading logo', error)


### PR DESCRIPTION
### Motivation
- Fix a TypeScript error where `payload.url` (inferred as `string | undefined`) could be assigned to `SiteExperience.logo.imageUrl` which must remain a strict `string`, and ensure the state is only updated with a valid string URL.

### Description
- In `app/(admin)/admin/(shell)/(dashboard)/SiteExperienceDesigner.tsx` cast the response payload to `{ ok?: boolean; url?: string }`, extract `const url = payload.url`, validate `typeof url === 'string' && url.trim().length > 0`, throw an error on invalid responses, and assign `imageUrl: url` when valid.

### Testing
- Ran `npm run build` which completed successfully and TypeScript checks passed, with unrelated warnings about `<img>` usage and missing DB tables during static generation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a59f7070c83319266e8292d2d685a)