### PR TITLE
Fix logo display fallback and sizing

### DIFF
--- a/nerin-electric-site-v3-fixed/components/Logo.tsx
+++ b/nerin-electric-site-v3-fixed/components/Logo.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useState } from 'react'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 
@@ -9,13 +12,21 @@ type LogoProps = {
 }
 
 export function Logo({ className, imageUrl, subtitle, title }: LogoProps) {
+  const [imageFailed, setImageFailed] = useState(false)
+  const showImage = Boolean(imageUrl) && !imageFailed
+
   return (
     <Link href="/" className={cn('no-underline flex items-center gap-3 font-display text-lg', className)}>
-      <span className="inline-flex h-10 w-10 items-center justify-center rounded-[var(--radius)] border border-border bg-white">
-        {imageUrl ? (
-          <img src={imageUrl} alt={`${title} ${subtitle}`.trim()} className="h-7 w-7 object-contain" />
+      <span className="inline-flex h-10 w-10 items-center justify-center overflow-hidden rounded-[var(--radius)] border border-border bg-white p-1">
+        {showImage ? (
+          <img
+            src={imageUrl ?? undefined}
+            alt={`${title} ${subtitle}`.trim()}
+            className="h-full w-full object-contain"
+            onError={() => setImageFailed(true)}
+          />
         ) : (
-          <svg aria-hidden viewBox="0 0 64 64" className="h-7 w-7">
+          <svg aria-hidden viewBox="0 0 64 64" className="h-full w-full">
             <rect x="6" y="6" width="52" height="52" rx="6" fill="#0B0F14" stroke="#FBBF24" strokeWidth="2" />
             <path d="M35 10L20 36h14l-8 18 18-28H30l5-16z" fill="#FBBF24" />
           </svg>


### PR DESCRIPTION
### Motivation
- Logo images hosted externally could fail to load or render stretched, producing broken or mis-sized badges, so the component needs a client-side fallback and consistent sizing behavior.

### Description
- Convert `Logo` to a client component and add `useState` to track load failures, exposing a `showImage` boolean to conditionally render the image or fallback SVG.
- Add an `onError` handler on the `img` element to switch to the SVG when loading fails and use `src={imageUrl ?? undefined}` to avoid passing falsy values.
- Update wrapper and image classes to `overflow-hidden p-1` and `h-full w-full object-contain` so logos scale to the badge without distortion and the SVG fallback also fills the container.

### Testing
- Started the dev server with `npm run dev` and Next compiled successfully (app served locally). 
- Ran a Playwright script to visit the homepage and capture a screenshot (`artifacts/logo-fix.png`), which completed and shows the updated rendering. 
- The Next image optimizer reported network `ENETUNREACH` errors for some external images (500 responses) during requests, which are environment/network issues and unrelated to the component logic changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a5eb8a0288331bbb3284471e464a0)