### PR TITLE
Unificar motor de presupuesto y añadir flujo de aprobación para adicionales

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/ops/projects/[id]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/ops/projects/[id]/page.tsx
@@ -185,6 +185,7 @@ export default async function AdminOpsProjectDetail({
                   <TableHead>Porcentaje</TableHead>
                   <TableHead>Monto</TableHead>
                   <TableHead>Estado</TableHead>
+                  <TableHead>Aprobación</TableHead>
                   <TableHead>Pago</TableHead>
                 </TableRow>
               </thead>
@@ -254,6 +255,7 @@ export default async function AdminOpsProjectDetail({
                   <TableHead>Cantidad</TableHead>
                   <TableHead>Precio</TableHead>
                   <TableHead>Estado</TableHead>
+                  <TableHead>Aprobación</TableHead>
                   <TableHead>Pago</TableHead>
                 </TableRow>
               </thead>
@@ -268,6 +270,7 @@ export default async function AdminOpsProjectDetail({
                     <TableCell>
                       <Badge className="bg-slate-100 text-slate-600">{additional.status}</Badge>
                     </TableCell>
+                    <TableCell>{additional.approvalStatus}</TableCell>
                     <TableCell>
                       {additional.mercadoPagoInitPoint ? (
                         <a className="text-accent" href={additional.mercadoPagoInitPoint} target="_blank" rel="noreferrer">
@@ -328,6 +331,14 @@ export default async function AdminOpsProjectDetail({
               <div className="grid gap-2">
                 <Label htmlFor="additional-price">Precio unitario (ARS)</Label>
                 <Input id="additional-price" name="unitPrice" type="number" step="0.01" />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="additional-requested-by">Cargado por</Label>
+                <Input id="additional-requested-by" name="requestedBy" placeholder="Técnico / coordinador" />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="additional-evidence">URL evidencia/foto (opcional)</Label>
+                <Input id="additional-evidence" name="evidenceUrl" placeholder="https://..." />
               </div>
               <label className="flex items-center gap-2 text-sm text-slate-600">
                 <input type="checkbox" name="generatePayment" />

--- a/nerin-electric-site-v3-fixed/app/(site)/clientes/obra/[id]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/clientes/obra/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Table, TableCell, TableHead, TableRow } from '@/components/ui/table'
+import { approveOpsAdditionalByClient } from '@/app/(admin)/admin/(shell)/ops/actions'
 
 export default async function ClienteObraPage({ params }: { params: { id: string } }) {
   if (!DB_ENABLED) {
@@ -85,6 +86,7 @@ export default async function ClienteObraPage({ params }: { params: { id: string
                   <TableHead>Porcentaje</TableHead>
                   <TableHead>Monto</TableHead>
                   <TableHead>Estado</TableHead>
+                  <TableHead>Aprobación</TableHead>
                   <TableHead></TableHead>
                 </TableRow>
               </thead>
@@ -126,6 +128,7 @@ export default async function ClienteObraPage({ params }: { params: { id: string
                   <TableHead>Adicional</TableHead>
                   <TableHead>Detalle</TableHead>
                   <TableHead>Estado</TableHead>
+                  <TableHead>Aprobación</TableHead>
                   <TableHead></TableHead>
                 </TableRow>
               </thead>
@@ -141,7 +144,16 @@ export default async function ClienteObraPage({ params }: { params: { id: string
                       <Badge className="bg-slate-100 text-slate-600">{additional.status}</Badge>
                     </TableCell>
                     <TableCell>
-                      {additional.status !== 'PAID' && additional.mercadoPagoInitPoint ? (
+                      <span className="text-xs text-slate-500">{additional.approvalStatus}</span>
+                    </TableCell>
+                    <TableCell>
+                      {additional.approvalStatus === 'PENDING' ? (
+                        <form action={approveOpsAdditionalByClient} className="space-y-2">
+                          <input type="hidden" name="additionalId" value={additional.id} />
+                          <input type="hidden" name="returnTo" value={`/clientes/obra/${project.id}`} />
+                          <Button size="sm" type="submit">Aprobar</Button>
+                        </form>
+                      ) : additional.status !== 'PAID' && additional.mercadoPagoInitPoint ? (
                         <Button size="sm" variant="secondary" asChild>
                           <a href={additional.mercadoPagoInitPoint} target="_blank" rel="noreferrer">
                             Pagar

--- a/nerin-electric-site-v3-fixed/app/(site)/tecnico/obra/[id]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/tecnico/obra/[id]/page.tsx
@@ -1,0 +1,67 @@
+export const dynamic = 'force-dynamic'
+
+import { redirect, notFound } from 'next/navigation'
+import { prisma } from '@/lib/db'
+import { getSession } from '@/lib/auth'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { createOpsAdditional } from '@/app/(admin)/admin/(shell)/ops/actions'
+
+export default async function TecnicoObraPage({ params }: { params: { id: string } }) {
+  const session = await getSession()
+  if (!session?.user || !['admin', 'tecnico'].includes(session.user.role ?? '')) {
+    redirect('/clientes/login')
+  }
+
+  const project = await prisma.opsProject.findUnique({
+    where: { id: params.id },
+    include: { additionals: { orderBy: { createdAt: 'desc' } } },
+  })
+
+  if (!project) notFound()
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <Badge>Flujo técnico móvil</Badge>
+        <h1 className="text-2xl font-semibold">{project.title}</h1>
+        <p className="text-sm text-slate-600">Cargá adicionales con trazabilidad y aprobación previa del cliente.</p>
+      </header>
+
+      <Card>
+        <CardHeader><CardTitle>Registrar adicional en obra</CardTitle></CardHeader>
+        <CardContent>
+          <form action={createOpsAdditional} className="grid gap-3">
+            <input type="hidden" name="projectId" value={project.id} />
+            <input type="hidden" name="returnTo" value={`/tecnico/obra/${project.id}`} />
+            <input type="hidden" name="requestedBy" value={session.user.name ?? session.user.email ?? 'tecnico'} />
+            <div className="grid gap-2"><Label>Tipo de adicional</Label><Input name="name" required /></div>
+            <div className="grid gap-2"><Label>Cantidad</Label><Input type="number" name="quantity" defaultValue={1} min={0.1} step={0.1} required /></div>
+            <div className="grid gap-2"><Label>Unidad</Label><Input name="unit" defaultValue="unidad" required /></div>
+            <div className="grid gap-2"><Label>Precio unitario</Label><Input type="number" name="unitPrice" min={1} step={0.01} required /></div>
+            <div className="grid gap-2"><Label>Nota técnica</Label><Textarea name="description" /></div>
+            <div className="grid gap-2"><Label>Foto/evidencia URL (opcional)</Label><Input name="evidenceUrl" /></div>
+            <Button type="submit">Guardar para aprobación del cliente</Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader><CardTitle>Adicionales registrados</CardTitle></CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          {project.additionals.map((item) => (
+            <div key={item.id} className="rounded-xl border p-3">
+              <p className="font-semibold">{item.name}</p>
+              <p>{item.quantity} {item.unit} · ${((Number(item.unitPrice) * item.quantity) / 100).toLocaleString('es-AR')}</p>
+              <p className="text-xs text-slate-500">Estado: {item.status} · Aprobación: {item.approvalStatus}</p>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/nerin-electric-site-v3-fixed/components/configurator/ConfiguratorWizard.tsx
+++ b/nerin-electric-site-v3-fixed/components/configurator/ConfiguratorWizard.tsx
@@ -1,18 +1,18 @@
 'use client'
 
 import { useMemo, useState, useTransition } from 'react'
-import Link from 'next/link'
 import { calculateTotals } from './calculations'
+import { professionalCatalog, quoteServices } from './catalog'
 import { WizardAdditional, WizardPack, WizardSummary } from './types'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { Progress } from '@/components/ui/progress'
+import { Textarea } from '@/components/ui/textarea'
 import { createConfiguratorQuote } from './actions'
 
-const steps = ['Pack base', 'Ambientes y bocas', 'Adicionales', 'Resumen']
+const steps = ['Modo y servicio', 'Definición técnica', 'Ajustes comerciales', 'Resumen']
 
 interface Props {
   packs: WizardPack[]
@@ -23,274 +23,169 @@ interface Props {
 export function ConfiguratorWizard({ packs, adicionales, defaultPackId }: Props) {
   const [step, setStep] = useState(0)
   const [summary, setSummary] = useState<WizardSummary>({
-    packId: defaultPackId && packs.some((pack) => pack.id === defaultPackId)
-      ? defaultPackId
-      : packs[0]?.id ?? '',
+    mode: 'EXPRESS',
+    serviceId: quoteServices[0].id,
+    zoneTier: 'PRIORITY',
+    urgencyMultiplier: 1,
+    difficultyMultiplier: 1,
+    packId: defaultPackId && packs.some((pack) => pack.id === defaultPackId) ? defaultPackId : packs[0]?.id ?? '',
     ambientes: 4,
     bocasExtra: 0,
     adicionales: [],
+    professionalItems: professionalCatalog
+      .filter((item) => item.suggestedQty)
+      .map((item) => ({ id: item.id, cantidad: item.suggestedQty ?? 0 })),
     comentarios: '',
   })
   const [contacto, setContacto] = useState({ nombre: '', email: '' })
   const [pdfUrl, setPdfUrl] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
-  const selectedPack = useMemo(() => packs.find((pack) => pack.id === summary.packId) ?? packs[0], [
-    packs,
-    summary.packId,
-  ])
 
-  const totals = useMemo(() => {
-    if (!selectedPack) {
-      return null
-    }
-    return calculateTotals({ pack: selectedPack, adicionales, summary })
-  }, [selectedPack, adicionales, summary])
-
-  if (!selectedPack || !totals) {
-    return <p className="text-sm text-slate-500">No hay packs configurados. Cargalos desde el panel de admin.</p>
-  }
-
-  const additionalWithQty = new Map(summary.adicionales.map((item) => [item.id, item.cantidad]))
+  const selectedPack = useMemo(() => packs.find((pack) => pack.id === summary.packId) ?? packs[0] ?? null, [packs, summary.packId])
+  const totals = useMemo(() => calculateTotals({ pack: selectedPack, adicionales, summary, services: quoteServices, catalog: professionalCatalog }), [selectedPack, adicionales, summary])
 
   const next = () => setStep((prev) => Math.min(prev + 1, steps.length - 1))
   const back = () => setStep((prev) => Math.max(prev - 1, 0))
 
-  const handleAdicionalChange = (id: string, cantidad: number) => {
+  const updateItems = (id: string, cantidad: number, key: 'adicionales' | 'professionalItems') => {
     setSummary((prev) => {
-      const filtered = prev.adicionales.filter((item) => item.id !== id)
-      if (cantidad <= 0) {
-        return { ...prev, adicionales: filtered }
-      }
-      return { ...prev, adicionales: [...filtered, { id, cantidad }] }
+      const filtered = prev[key].filter((item) => item.id !== id)
+      if (cantidad <= 0) return { ...prev, [key]: filtered }
+      return { ...prev, [key]: [...filtered, { id, cantidad }] }
     })
   }
 
   const handleSubmit = () => {
     startTransition(async () => {
-      const result = await createConfiguratorQuote({
-        ...summary,
-        nombre: contacto.nombre || undefined,
-        email: contacto.email || undefined,
-      })
+      const result = await createConfiguratorQuote({ ...summary, nombre: contacto.nombre || undefined, email: contacto.email || undefined })
       setPdfUrl(result.pdfUrl)
       setStep(3)
     })
   }
 
+  const service = quoteServices.find((item) => item.id === summary.serviceId)
+
   return (
-    <div className="space-y-10">
+    <div className="space-y-8">
       <div>
-        <div className="flex items-center justify-between">
-          <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">
-            Paso {step + 1} de {steps.length}
-          </p>
-          <p className="text-sm text-slate-500">{steps[step]}</p>
+        <div className="flex items-center justify-between text-sm text-slate-500">
+          <span>Paso {step + 1} de {steps.length}</span>
+          <span>{steps[step]}</span>
         </div>
         <Progress value={((step + 1) / steps.length) * 100} />
       </div>
 
       {step === 0 && (
-        <section className="grid gap-6 md:grid-cols-2">
-          {packs.map((pack) => (
-            <Card
-              key={pack.id}
-              className={`cursor-pointer transition ${
-                pack.id === selectedPack.id ? 'border-accent ring-2 ring-accent/40' : ''
-              }`}
-              onClick={() => setSummary((prev) => ({ ...prev, packId: pack.id }))}
-              role="button"
-              aria-pressed={pack.id === selectedPack.id}
-            >
-              <CardHeader>
-                <CardTitle>{pack.name}</CardTitle>
-                <p className="text-sm text-slate-500">{pack.description}</p>
-              </CardHeader>
-              <CardContent className="space-y-3 text-sm text-slate-600">
-                <p>{pack.scope || 'Definí el alcance en el panel de admin.'}</p>
-                <p>Mano de obra base ${Number(pack.basePrice).toLocaleString('es-AR')}</p>
-                {pack.advancePrice > 0 && (
-                  <p>Anticipo sugerido ${Number(pack.advancePrice).toLocaleString('es-AR')}</p>
-                )}
-                <ul className="space-y-1">
-                  {pack.features.slice(0, 4).map((item) => (
-                    <li key={item}>• {item}</li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          ))}
+        <section className="grid gap-6 lg:grid-cols-2">
+          <Card>
+            <CardHeader><CardTitle>Modo de presupuesto</CardTitle></CardHeader>
+            <CardContent className="space-y-4">
+              {['EXPRESS', 'ASSISTED', 'PROFESSIONAL'].map((mode) => (
+                <label key={mode} className="flex items-center gap-3 rounded-xl border p-3">
+                  <input type="radio" name="mode" checked={summary.mode === mode} onChange={() => setSummary((prev) => ({ ...prev, mode: mode as WizardSummary['mode'] }))} />
+                  <span>{mode === 'EXPRESS' ? 'Modo Express' : mode === 'ASSISTED' ? 'Modo Asistido' : 'Modo Profesional'}</span>
+                </label>
+              ))}
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader><CardTitle>Servicio</CardTitle></CardHeader>
+            <CardContent className="space-y-3">
+              <select className="h-11 w-full rounded-xl border border-border bg-white px-4 text-sm" value={summary.serviceId} onChange={(event) => setSummary((prev) => ({ ...prev, serviceId: event.target.value }))}>
+                {quoteServices.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}
+              </select>
+              <p className="text-sm text-slate-600">{service?.description}</p>
+              <p className="text-sm">Flujo: <b>{service?.flow === 'ONLINE' ? 'Contratable online' : 'Requiere relevamiento'}</b></p>
+            </CardContent>
+          </Card>
         </section>
       )}
 
-      {step === 1 && (
-        <section className="grid gap-6 md:grid-cols-2">
+      {step === 1 && summary.mode !== 'PROFESSIONAL' && (
+        <section className="grid gap-6 lg:grid-cols-2">
           <Card>
-            <CardHeader>
-              <CardTitle>Ambientes y bocas</CardTitle>
-            </CardHeader>
+            <CardHeader><CardTitle>{summary.mode === 'EXPRESS' ? 'Alcance Express' : 'Supuestos asistidos editables'}</CardTitle></CardHeader>
             <CardContent className="space-y-4">
-              <div>
-                <Label htmlFor="ambientes">Cantidad de ambientes</Label>
-                <Input
-                  id="ambientes"
-                  type="number"
-                  min={1}
-                  max={30}
-                  value={summary.ambientes}
-                  onChange={(event) =>
-                    setSummary((prev) => ({ ...prev, ambientes: Number(event.target.value) || 0 }))
-                  }
-                />
-              </div>
-              <div>
-                <Label htmlFor="bocasExtra">Bocas adicionales estimadas</Label>
-                <Input
-                  id="bocasExtra"
-                  type="number"
-                  min={0}
-                  max={500}
-                  value={summary.bocasExtra}
-                  onChange={(event) =>
-                    setSummary((prev) => ({ ...prev, bocasExtra: Number(event.target.value) || 0 }))
-                  }
-                />
-              </div>
-              <div>
-                <Label htmlFor="comentarios">Comentarios o ambientes especiales</Label>
-                <Textarea
-                  id="comentarios"
-                  value={summary.comentarios}
-                  onChange={(event) =>
-                    setSummary((prev) => ({ ...prev, comentarios: event.target.value }))
-                  }
-                  placeholder="Ej: agregar circuito exclusivo para sala de servidores."
-                />
-              </div>
+              <div><Label>Ambientes</Label><Input type="number" value={summary.ambientes} onChange={(e) => setSummary((p) => ({ ...p, ambientes: Number(e.target.value) || 0 }))} /></div>
+              <div><Label>Bocas extra</Label><Input type="number" value={summary.bocasExtra} onChange={(e) => setSummary((p) => ({ ...p, bocasExtra: Number(e.target.value) || 0 }))} /></div>
+              <div><Label>Comentarios</Label><Textarea value={summary.comentarios} onChange={(e) => setSummary((p) => ({ ...p, comentarios: e.target.value }))} /></div>
             </CardContent>
           </Card>
-          <Card className="bg-muted">
-            <CardHeader>
-              <CardTitle>Resumen parcial</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-slate-600">
-              <p>Pack seleccionado: {selectedPack.name}</p>
-              <p>Alcance recomendado: {selectedPack.scope}</p>
-              <p>Bocas adicionales estimadas: {summary.bocasExtra}</p>
-              <p>Ambientes estimados: {summary.ambientes}</p>
+          <Card>
+            <CardHeader><CardTitle>Ítems ajustables</CardTitle></CardHeader>
+            <CardContent className="space-y-3">
+              {adicionales.slice(0, 8).map((item) => (
+                <div key={item.id} className="grid grid-cols-[1fr_90px] items-center gap-3">
+                  <span className="text-sm">{item.nombre}</span>
+                  <Input type="number" min={0} value={summary.adicionales.find((it) => it.id === item.id)?.cantidad ?? 0} onChange={(e) => updateItems(item.id, Number(e.target.value) || 0, 'adicionales')} />
+                </div>
+              ))}
             </CardContent>
           </Card>
         </section>
+      )}
+
+      {step === 1 && summary.mode === 'PROFESSIONAL' && (
+        <Card>
+          <CardHeader><CardTitle>Carga profesional por rubro e ítem</CardTitle></CardHeader>
+          <CardContent className="grid gap-3 md:grid-cols-2">
+            {professionalCatalog.map((item) => (
+              <div key={item.id} className="grid grid-cols-[1fr_88px] items-center gap-3">
+                <span className="text-sm">{item.name}</span>
+                <Input type="number" min={0} value={summary.professionalItems.find((it) => it.id === item.id)?.cantidad ?? 0} onChange={(e) => updateItems(item.id, Number(e.target.value) || 0, 'professionalItems')} />
+              </div>
+            ))}
+          </CardContent>
+        </Card>
       )}
 
       {step === 2 && (
-        <section className="grid gap-6 md:grid-cols-2">
-          {adicionales.map((adicional) => (
-            <Card key={adicional.id}>
-              <CardHeader>
-                <CardTitle>{adicional.nombre}</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3 text-sm text-slate-600">
-                <p>{adicional.descripcion}</p>
-                <p>
-                  Valor unitario ${Number(adicional.precioUnitarioManoObra).toLocaleString('es-AR')} / {adicional.unidad}
-                </p>
-                <Input
-                  type="number"
-                  min={0}
-                  max={50}
-                  value={additionalWithQty.get(adicional.id) ?? 0}
-                  onChange={(event) => handleAdicionalChange(adicional.id, Number(event.target.value) || 0)}
-                  aria-label={`Cantidad para ${adicional.nombre}`}
-                />
-              </CardContent>
-            </Card>
-          ))}
+        <section className="grid gap-6 lg:grid-cols-2">
+          <Card>
+            <CardHeader><CardTitle>Zona y recargos</CardTitle></CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <Label>Zona</Label>
+                <select className="h-11 w-full rounded-xl border border-border bg-white px-4 text-sm" value={summary.zoneTier} onChange={(e) => setSummary((p) => ({ ...p, zoneTier: e.target.value as WizardSummary['zoneTier'] }))}>
+                  <option value="PRIORITY">Prioritaria</option>
+                  <option value="SECONDARY">Secundaria</option>
+                  <option value="REVIEW">Revisión manual</option>
+                </select>
+              </div>
+              <div><Label>Recargo urgencia</Label><Input type="number" min={1} step={0.05} value={summary.urgencyMultiplier} onChange={(e) => setSummary((p) => ({ ...p, urgencyMultiplier: Number(e.target.value) || 1 }))} /></div>
+              <div><Label>Recargo dificultad</Label><Input type="number" min={1} step={0.05} value={summary.difficultyMultiplier} onChange={(e) => setSummary((p) => ({ ...p, difficultyMultiplier: Number(e.target.value) || 1 }))} /></div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader><CardTitle>Contacto</CardTitle></CardHeader>
+            <CardContent className="space-y-4">
+              <Input placeholder="Nombre" value={contacto.nombre} onChange={(e) => setContacto((p) => ({ ...p, nombre: e.target.value }))} />
+              <Input placeholder="Email" type="email" value={contacto.email} onChange={(e) => setContacto((p) => ({ ...p, email: e.target.value }))} />
+            </CardContent>
+          </Card>
         </section>
       )}
 
       {step === 3 && (
-        <section className="grid gap-6 md:grid-cols-[1.3fr_1fr]">
-          <Card>
-            <CardHeader>
-              <CardTitle>Resumen de cotización</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-slate-600">
-              <p>Pack base: {selectedPack.name}</p>
-              <p>Alcance: {selectedPack.scope}</p>
-              {selectedPack.advancePrice > 0 && (
-                <p>
-                  Anticipo sugerido: ${Number(selectedPack.advancePrice).toLocaleString('es-AR')}
-                </p>
-              )}
-              <p>Mano de obra base: ${totals.subtotalPack.toLocaleString('es-AR')}</p>
-              <ul className="space-y-2">
-                {totals.adicionales.map((item) => (
-                  <li key={item.id}>
-                    {item.nombre} · {item.cantidad} × ${item.precioUnitario.toLocaleString('es-AR')} = $
-                    {item.subtotal.toLocaleString('es-AR')}
-                  </li>
-                ))}
-              </ul>
-              <p className="text-lg font-semibold text-foreground">
-                Total mano de obra: ${totals.totalManoObra.toLocaleString('es-AR')}
-              </p>
-              <p>Proyecto eléctrico se cobra aparte: $500.000</p>
-              <p className="text-xs text-slate-500">
-                Los materiales no están incluidos. Podés elegir marcas como Schneider, Prysmian, Gimsa, Daisa o Genrock y las
-                compramos con tu aprobación.
-              </p>
-              {pdfUrl ? (
-                <Button asChild>
-                  <a href={pdfUrl} target="_blank" rel="noopener noreferrer">
-                    Descargar PDF de cotización
-                  </a>
-                </Button>
-              ) : (
-                <Button onClick={handleSubmit} disabled={isPending}>
-                  {isPending ? 'Generando PDF...' : 'Guardar cotización y generar PDF'}
-                </Button>
-              )}
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader>
-              <CardTitle>Datos de contacto</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4 text-sm text-slate-600">
-              <div>
-                <Label htmlFor="nombre">Nombre y empresa</Label>
-                <Input
-                  id="nombre"
-                  value={contacto.nombre}
-                  onChange={(event) => setContacto((prev) => ({ ...prev, nombre: event.target.value }))}
-                  placeholder="Ej: Ana Torres · Consorcio San Telmo"
-                />
-              </div>
-              <div>
-                <Label htmlFor="email">Email</Label>
-                <Input
-                  id="email"
-                  type="email"
-                  value={contacto.email}
-                  onChange={(event) => setContacto((prev) => ({ ...prev, email: event.target.value }))}
-                  placeholder="correo@empresa.com"
-                />
-              </div>
-              <p className="text-xs text-slate-500">
-                Te enviaremos la cotización y un enlace para solicitar la visita técnica o pagar la seña de obra vía Mercado Pago.
-              </p>
-            </CardContent>
-          </Card>
-        </section>
+        <Card>
+          <CardHeader><CardTitle>Resumen</CardTitle></CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <p>Servicio: <b>{service?.name}</b></p>
+            <p>Flujo: <b>{totals.requiresSurvey ? 'Relevamiento / presupuesto' : 'Express con contratación online'}</b></p>
+            <p>Subtotal base: ${totals.subtotalBase.toLocaleString('es-AR')}</p>
+            <p>Recargo zona: ${totals.recargoZona.toLocaleString('es-AR')}</p>
+            <p>Recargo urgencia: ${totals.recargoUrgencia.toLocaleString('es-AR')}</p>
+            <p>Recargo dificultad: ${totals.recargoDificultad.toLocaleString('es-AR')}</p>
+            <p className="text-lg font-semibold">Total estimado: ${totals.totalManoObra.toLocaleString('es-AR')}</p>
+            {totals.warning && <p className="text-amber-600">{totals.warning}</p>}
+            {!pdfUrl ? <Button onClick={handleSubmit} disabled={isPending}>{isPending ? 'Guardando...' : 'Guardar cotización'}</Button> : <a className="text-accent" href={pdfUrl} target="_blank">Descargar PDF</a>}
+          </CardContent>
+        </Card>
       )}
 
-      <div className="flex items-center justify-between">
-        <Button variant="ghost" onClick={back} disabled={step === 0}>
-          Volver
-        </Button>
-        {step < steps.length - 1 && (
-          <Button onClick={next}>Continuar</Button>
-        )}
+      <div className="flex justify-between">
+        <Button variant="ghost" onClick={back} disabled={step === 0}>Volver</Button>
+        {step < steps.length - 1 && <Button onClick={next}>Continuar</Button>}
       </div>
     </div>
   )

--- a/nerin-electric-site-v3-fixed/components/configurator/actions.ts
+++ b/nerin-electric-site-v3-fixed/components/configurator/actions.ts
@@ -5,12 +5,20 @@ import { z } from 'zod'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/db'
 import { serializeJson } from '@/lib/serialization'
+import { calculateTotals } from './calculations'
+import { professionalCatalog, quoteServices } from './catalog'
 
 const QuoteSchema = z.object({
+  mode: z.enum(['EXPRESS', 'ASSISTED', 'PROFESSIONAL']),
+  serviceId: z.string(),
+  zoneTier: z.enum(['PRIORITY', 'SECONDARY', 'REVIEW']),
+  urgencyMultiplier: z.number().min(1).max(2),
+  difficultyMultiplier: z.number().min(1).max(2),
   packId: z.string(),
-  ambientes: z.number().min(1).max(30),
+  ambientes: z.number().min(0).max(40),
   bocasExtra: z.number().min(0).max(500),
-  adicionales: z.array(z.object({ id: z.string(), cantidad: z.number().min(1).max(100) })),
+  adicionales: z.array(z.object({ id: z.string(), cantidad: z.number().min(1).max(300) })),
+  professionalItems: z.array(z.object({ id: z.string(), cantidad: z.number().min(1).max(500) })),
   comentarios: z.string().optional(),
   email: z.string().email().optional(),
   nombre: z.string().optional(),
@@ -20,48 +28,54 @@ export async function createConfiguratorQuote(data: z.infer<typeof QuoteSchema>)
   const payload = QuoteSchema.parse(data)
 
   const pack = await prisma.pack.findUnique({ where: { id: payload.packId } })
-  if (!pack) {
-    throw new Error('Pack no encontrado')
-  }
-
   const adicionales = await prisma.additionalItem.findMany({
     where: { id: { in: payload.adicionales.map((item) => item.id) } },
   })
 
-  const totalAdicionales = payload.adicionales.reduce((acc, item) => {
-    const adicional = adicionales.find((a) => a.id === item.id)
-    if (!adicional) return acc
-    return acc + Number(adicional.precioUnitarioManoObra) * item.cantidad
-  }, 0)
-
-  const totalManoObra = Number(pack.basePrice) + totalAdicionales
+  const totals = calculateTotals({
+    pack: pack
+      ? {
+          id: pack.id,
+          slug: pack.slug,
+          name: pack.name,
+          description: pack.description,
+          scope: pack.scope,
+          features: [],
+          basePrice: Number(pack.basePrice),
+          advancePrice: Number(pack.advancePrice),
+        }
+      : null,
+    adicionales: adicionales.map((item) => ({
+      id: item.id,
+      nombre: item.nombre,
+      descripcion: item.descripcion,
+      unidad: item.unidad,
+      precioUnitarioManoObra: Number(item.precioUnitarioManoObra),
+      reglasCompatibilidad: null,
+      packId: item.packId,
+    })),
+    summary: payload,
+    services: quoteServices,
+    catalog: professionalCatalog,
+  })
 
   const quote = await prisma.configuratorQuote.create({
     data: {
-      packId: pack.id,
+      packId: pack?.id ?? (await prisma.pack.findFirstOrThrow()).id,
       itemsSeleccionados: serializeJson(payload),
-      totalManoObra: new Prisma.Decimal(totalManoObra),
+      totalManoObra: new Prisma.Decimal(totals.totalManoObra),
+      aclaracionesMateriales: totals.requiresSurvey
+        ? 'Requiere visita técnica para validar cantidades finales y materiales.'
+        : 'Servicio contratable online. Materiales se confirman antes de ejecutar.',
       proyectoElectricoAparte: new Prisma.Decimal(500000),
       configuratorQuoteItems: {
-        create: [
-          {
-            descripcion: `Pack base ${pack.name}`,
-            cantidad: 1,
-            precioUnitario: pack.basePrice,
-            subtotal: pack.basePrice,
-          },
-          ...payload.adicionales.map((item) => {
-            const adicional = adicionales.find((a) => a.id === item.id)
-            const precio = adicional ? Number(adicional.precioUnitarioManoObra) : 0
-            return {
-              additionalItemId: item.id,
-              descripcion: adicional?.nombre ?? 'Adicional',
-              cantidad: item.cantidad,
-              precioUnitario: new Prisma.Decimal(precio),
-              subtotal: new Prisma.Decimal(precio * item.cantidad),
-            }
-          }),
-        ],
+        create: totals.adicionales.map((item) => ({
+          additionalItemId: payload.mode === 'PROFESSIONAL' ? null : item.id,
+          descripcion: item.nombre,
+          cantidad: item.cantidad,
+          precioUnitario: new Prisma.Decimal(item.precioUnitario),
+          subtotal: new Prisma.Decimal(item.subtotal),
+        })),
       },
     },
   })

--- a/nerin-electric-site-v3-fixed/components/configurator/calculations.ts
+++ b/nerin-electric-site-v3-fixed/components/configurator/calculations.ts
@@ -1,7 +1,23 @@
-import { WizardAdditional, WizardPack, WizardSummary } from './types'
+import {
+  QuoteCatalogItem,
+  QuoteService,
+  WizardAdditional,
+  WizardPack,
+  WizardSummary,
+  ZoneTier,
+} from './types'
+
+const zoneMultipliers: Record<ZoneTier, number> = {
+  PRIORITY: 1,
+  SECONDARY: 1.12,
+  REVIEW: 1.25,
+}
 
 export interface QuoteTotals {
-  subtotalPack: number
+  mode: WizardSummary['mode']
+  service: QuoteService | null
+  requiresSurvey: boolean
+  subtotalBase: number
   adicionales: Array<{
     id: string
     nombre: string
@@ -9,42 +25,86 @@ export interface QuoteTotals {
     precioUnitario: number
     subtotal: number
   }>
+  recargoZona: number
+  recargoUrgencia: number
+  recargoDificultad: number
   totalManoObra: number
-  recomendado?: WizardPack
+  warning?: string
+}
+
+function buildSelectedItems({
+  summary,
+  adicionales,
+  catalog,
+}: {
+  summary: WizardSummary
+  adicionales: WizardAdditional[]
+  catalog: QuoteCatalogItem[]
+}) {
+  const selected = summary.mode === 'PROFESSIONAL' ? summary.professionalItems : summary.adicionales
+  const source = summary.mode === 'PROFESSIONAL'
+    ? catalog.map((item) => ({
+      id: item.id,
+      nombre: item.name,
+      precioUnitarioManoObra: item.baseUnitPrice,
+    }))
+    : adicionales
+
+  return selected
+    .map((item) => {
+      const match = source.find((entry) => entry.id === item.id)
+      if (!match || item.cantidad <= 0) return null
+      const precio = Number(match.precioUnitarioManoObra)
+      return {
+        id: item.id,
+        nombre: match.nombre,
+        cantidad: item.cantidad,
+        precioUnitario: precio,
+        subtotal: precio * item.cantidad,
+      }
+    })
+    .filter(Boolean) as QuoteTotals['adicionales']
 }
 
 export function calculateTotals({
   pack,
   adicionales,
   summary,
+  services,
+  catalog,
 }: {
-  pack: WizardPack
+  pack: WizardPack | null
   adicionales: WizardAdditional[]
   summary: WizardSummary
+  services: QuoteService[]
+  catalog: QuoteCatalogItem[]
 }): QuoteTotals {
-  const subtotalPack = Number(pack.basePrice)
-  const adicionalesCalculados = summary.adicionales
-    .map((item) => {
-      const adicional = adicionales.find((a) => a.id === item.id)
-      if (!adicional) return null
-      const precio = Number(adicional.precioUnitarioManoObra)
-      const subtotal = precio * item.cantidad
-      return {
-        id: adicional.id,
-        nombre: adicional.nombre,
-        cantidad: item.cantidad,
-        precioUnitario: precio,
-        subtotal,
-      }
-    })
-    .filter(Boolean) as QuoteTotals['adicionales']
+  const service = services.find((item) => item.id === summary.serviceId) ?? null
+  const selectedItems = buildSelectedItems({ summary, adicionales, catalog })
+  const itemsSubtotal = selectedItems.reduce((acc, item) => acc + item.subtotal, 0)
+  const packSubtotal = pack ? Number(pack.basePrice) : 0
 
-  const totalAdicionales = adicionalesCalculados.reduce((acc, item) => acc + item.subtotal, 0)
-  const totalManoObra = subtotalPack + totalAdicionales
+  const subtotalBase = Math.max(
+    service?.basePrice ?? 0,
+    summary.mode === 'EXPRESS' ? service?.minPrice ?? 0 : packSubtotal + itemsSubtotal,
+  )
+
+  const zoneMultiplier = zoneMultipliers[summary.zoneTier] ?? 1
+  const recargoZona = subtotalBase * (zoneMultiplier - 1)
+  const recargoUrgencia = subtotalBase * (Math.max(summary.urgencyMultiplier, 1) - 1)
+  const recargoDificultad = subtotalBase * (Math.max(summary.difficultyMultiplier, 1) - 1)
+  const totalManoObra = subtotalBase + recargoZona + recargoUrgencia + recargoDificultad
 
   return {
-    subtotalPack,
-    adicionales: adicionalesCalculados,
+    mode: summary.mode,
+    service,
+    requiresSurvey: service?.flow === 'SURVEY',
+    subtotalBase,
+    adicionales: selectedItems,
+    recargoZona,
+    recargoUrgencia,
+    recargoDificultad,
     totalManoObra,
+    warning: summary.zoneTier === 'REVIEW' ? 'Zona fuera de cobertura inmediata. Revisión comercial manual.' : undefined,
   }
 }

--- a/nerin-electric-site-v3-fixed/components/configurator/catalog.ts
+++ b/nerin-electric-site-v3-fixed/components/configurator/catalog.ts
@@ -1,0 +1,63 @@
+import { QuoteCatalogItem, QuoteService } from './types'
+
+export const quoteServices: QuoteService[] = [
+  {
+    id: 'diagnostico-premium',
+    name: 'Diagnóstico eléctrico premium',
+    description: 'Inspección técnica, mediciones y plan de acción priorizado.',
+    flow: 'ONLINE',
+    basePrice: 95000,
+    minPrice: 95000,
+    includes: ['Relevamiento visual', 'Medición básica de protecciones', 'Informe digital'],
+    excludes: ['Materiales', 'Reparaciones no incluidas en el diagnóstico'],
+  },
+  {
+    id: 'colocacion-artefactos',
+    name: 'Colocación de artefactos',
+    description: 'Instalación de artefactos simples y especiales con matriz por complejidad.',
+    flow: 'ONLINE',
+    basePrice: 75000,
+    minPrice: 75000,
+    includes: ['Montaje', 'Conexionado', 'Prueba funcional'],
+    excludes: ['Artefactos provistos por NERIN', 'Obras civiles'],
+  },
+  {
+    id: 'circuito-dedicado-aa',
+    name: 'Circuito dedicado para aire acondicionado',
+    description: 'Línea independiente y protecciones según carga.',
+    flow: 'ONLINE',
+    basePrice: 180000,
+    minPrice: 180000,
+    includes: ['Circuito dedicado', 'Protecciones', 'Puesta en marcha'],
+    excludes: ['Equipo de AA', 'Canalizaciones extra especiales'],
+  },
+  {
+    id: 'reforma-parcial',
+    name: 'Reformas parciales',
+    description: 'Trabajo por etapas con definición técnica asistida.',
+    flow: 'SURVEY',
+    basePrice: 320000,
+    includes: ['Presupuesto preliminar', 'Visita técnica', 'Definición de alcance'],
+    excludes: ['Ejecución sin validación'],
+  },
+]
+
+export const professionalCatalog: QuoteCatalogItem[] = [
+  { id: 'boca-iluminacion', name: 'Bocas de iluminación', unit: 'boca', baseUnitPrice: 26000, kind: 'PER_POINT', suggestedQty: 12 },
+  { id: 'tomacorriente', name: 'Tomacorrientes', unit: 'boca', baseUnitPrice: 30000, kind: 'PER_POINT', suggestedQty: 10 },
+  { id: 'boca-especial', name: 'Bocas especiales', unit: 'boca', baseUnitPrice: 42000, kind: 'PER_POINT', suggestedQty: 4 },
+  { id: 'boca-datos', name: 'Bocas de datos', unit: 'boca', baseUnitPrice: 31000, kind: 'PER_POINT', suggestedQty: 4 },
+  { id: 'boca-tv', name: 'Bocas de TV', unit: 'boca', baseUnitPrice: 24000, kind: 'PER_POINT', suggestedQty: 2 },
+  { id: 'boca-aa', name: 'Bocas de aire acondicionado', unit: 'boca', baseUnitPrice: 49000, kind: 'PER_POINT', suggestedQty: 3 },
+  { id: 'tablero', name: 'Tableros', unit: 'unidad', baseUnitPrice: 280000, kind: 'UNIT', suggestedQty: 1 },
+  { id: 'puesta-tierra', name: 'Puesta a tierra', unit: 'unidad', baseUnitPrice: 180000, kind: 'UNIT', suggestedQty: 1 },
+  { id: 'canalizacion', name: 'Canalizaciones', unit: 'ml', baseUnitPrice: 22000, kind: 'UNIT', suggestedQty: 40 },
+  { id: 'alimentacion', name: 'Alimentaciones', unit: 'tramo', baseUnitPrice: 92000, kind: 'UNIT', suggestedQty: 2 },
+  { id: 'artefacto-simple', name: 'Artefacto simple', unit: 'unidad', baseUnitPrice: 16000, kind: 'UNIT', suggestedQty: 8 },
+  { id: 'artefacto-mediano', name: 'Artefacto decorativo mediano', unit: 'unidad', baseUnitPrice: 26000, kind: 'UNIT', suggestedQty: 4 },
+  { id: 'artefacto-pesado', name: 'Artefacto pesado/especial', unit: 'unidad', baseUnitPrice: 48000, kind: 'UNIT', suggestedQty: 2 },
+  { id: 'artefacto-exterior', name: 'Artefacto exterior', unit: 'unidad', baseUnitPrice: 30000, kind: 'UNIT', suggestedQty: 4 },
+  { id: 'lineal-led', name: 'Lineal / perfil LED', unit: 'metro', baseUnitPrice: 18000, kind: 'UNIT', suggestedQty: 12 },
+  { id: 'altura-especial', name: 'Altura especial', unit: 'unidad', baseUnitPrice: 25000, kind: 'UNIT', suggestedQty: 1 },
+  { id: 'dos-operarios', name: 'Necesidad de dos operarios', unit: 'jornada', baseUnitPrice: 85000, kind: 'UNIT', suggestedQty: 1 },
+]

--- a/nerin-electric-site-v3-fixed/components/configurator/types.ts
+++ b/nerin-electric-site-v3-fixed/components/configurator/types.ts
@@ -1,3 +1,8 @@
+export type QuoteMode = 'EXPRESS' | 'ASSISTED' | 'PROFESSIONAL'
+export type ServiceFlow = 'ONLINE' | 'SURVEY'
+export type ZoneTier = 'PRIORITY' | 'SECONDARY' | 'REVIEW'
+export type PriceKind = 'UNIT' | 'PER_POINT' | 'FIXED'
+
 export interface WizardPack {
   id: string
   slug: string
@@ -19,11 +24,40 @@ export interface WizardAdditional {
   packId?: string | null
 }
 
+export interface QuoteService {
+  id: string
+  name: string
+  description: string
+  flow: ServiceFlow
+  basePrice: number
+  minPrice?: number
+  includes: string[]
+  excludes: string[]
+}
+
+export interface QuoteCatalogItem {
+  id: string
+  name: string
+  unit: string
+  baseUnitPrice: number
+  kind: PriceKind
+  suggestedQty?: number
+}
+
 export interface WizardSummary {
+  mode: QuoteMode
+  serviceId: string
+  zoneTier: ZoneTier
+  urgencyMultiplier: number
+  difficultyMultiplier: number
   packId: string
   ambientes: number
   bocasExtra: number
   adicionales: Array<{
+    id: string
+    cantidad: number
+  }>
+  professionalItems: Array<{
     id: string
     cantidad: number
   }>

--- a/nerin-electric-site-v3-fixed/prisma/schema.prisma
+++ b/nerin-electric-site-v3-fixed/prisma/schema.prisma
@@ -478,7 +478,12 @@ model OpsProjectAdditionalItem {
   unit                     String
   unitPrice                BigInt
   quantity                 Float
-  status                   String             @default("QUOTED")
+  status                   String             @default("PENDING_CLIENT_APPROVAL")
+  approvalStatus           String             @default("PENDING")
+  approvalNote             String?
+  requestedBy              String?
+  approvedByClientAt       DateTime?
+  evidenceUrl              String?
   mercadoPagoPreferenceId  String?
   mercadoPagoInitPoint     String?
   createdAt                DateTime           @default(now())

--- a/nerin-electric-site-v3-fixed/tests/unit/configurator.test.ts
+++ b/nerin-electric-site-v3-fixed/tests/unit/configurator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { calculateTotals } from '@/components/configurator/calculations'
+import { professionalCatalog, quoteServices } from '@/components/configurator/catalog'
 import type { WizardAdditional, WizardPack, WizardSummary } from '@/components/configurator/types'
 
 const pack: WizardPack = {
@@ -26,17 +27,40 @@ const adicionales: WizardAdditional[] = [
 ]
 
 describe('calculateTotals', () => {
-  it('calcula totales de mano de obra', () => {
+  it('calcula totales para modo asistido con recargos', () => {
     const summary: WizardSummary = {
+      mode: 'ASSISTED',
+      serviceId: 'reforma-parcial',
+      zoneTier: 'SECONDARY',
+      urgencyMultiplier: 1.1,
+      difficultyMultiplier: 1,
       packId: pack.id,
       ambientes: 6,
       bocasExtra: 10,
       adicionales: [{ id: 'add-1', cantidad: 3 }],
+      professionalItems: [],
     }
 
-    const totals = calculateTotals({ pack, adicionales, summary })
-    expect(totals.subtotalPack).toBe(2500000)
-    expect(totals.totalManoObra).toBe(2500000 + 3 * 42000)
-    expect(totals.adicionales[0].subtotal).toBe(3 * 42000)
+    const totals = calculateTotals({ pack, adicionales, summary, services: quoteServices, catalog: professionalCatalog })
+    expect(totals.totalManoObra).toBeGreaterThan(2500000 + 3 * 42000)
+    expect(totals.requiresSurvey).toBe(true)
+  })
+
+  it('usa el mismo motor para profesional', () => {
+    const summary: WizardSummary = {
+      mode: 'PROFESSIONAL',
+      serviceId: 'reforma-parcial',
+      zoneTier: 'PRIORITY',
+      urgencyMultiplier: 1,
+      difficultyMultiplier: 1,
+      packId: pack.id,
+      ambientes: 0,
+      bocasExtra: 0,
+      adicionales: [],
+      professionalItems: [{ id: 'boca-iluminacion', cantidad: 2 }],
+    }
+
+    const totals = calculateTotals({ pack, adicionales, summary, services: quoteServices, catalog: professionalCatalog })
+    expect(totals.adicionales[0].nombre).toContain('Bocas de iluminación')
   })
 })


### PR DESCRIPTION
### Motivation
- Unificar la lógica de cotización para soportar los tres modos (Express, Asistido, Profesional) desde un solo motor reutilizable y evitar duplicación de reglas. 
- Soportar reglas comerciales reales (zonas, urgencia, dificultad, mínimos) y distinguir servicios contratables online de los que requieren relevamiento. 
- Proveer trazabilidad y control en los adicionales en obra para que técnicos no puedan cobrar sin aprobación visible del cliente.

### Description
- Añadido motor central de cálculo en `calculateTotals` y tipos ampliados para modo, zonas y catálogo profesional, reutilizado por todas las interfaces (`components/configurator/calculations.ts`, `components/configurator/types.ts`).
- Introduje un catálogo semiestático de servicios y rubros profesionales reutilizable por UI y acciones (`components/configurator/catalog.ts`) y adapté el `ConfiguratorWizard` para exponer modos Express / Assisted / Professional y ajustes comerciales (zona, urgencia, dificultad). (`components/configurator/ConfiguratorWizard.tsx`).
- Persistencia y creación de cotizaciones ahora consumen el motor central y guardan totales calculados; la action `createConfiguratorQuote` fue actualizada para el nuevo payload (`components/configurator/actions.ts`).
- Refuerzo del flujo operativo de adicionales: schema Prisma extendido (`prisma/schema.prisma`) con campos de aprobación/evidencia/solicitante; acciones server para crear adicionales en estado `PENDING_CLIENT_APPROVAL`, generar preference de pago sólo tras aprobación/solicitud y acción explícita `approveOpsAdditionalByClient`; vistas admin/cliente/técnico actualizadas y nueva vista técnica `/tecnico/obra/[id]` para cargar adicionales con evidencia (`app/(admin)/admin/(shell)/ops/actions.ts`, `app/(admin)/admin/(shell)/ops/projects/[id]/page.tsx`, `app/(site)/clientes/obra/[id]/page.tsx`, `app/(site)/tecnico/obra/[id]/page.tsx`).
- Ajustes en tests unitarios para reflejar cambios (configurador y admin-item mocks): `tests/unit/configurator.test.ts`, `tests/unit/admin-item-route.test.ts`.

### Testing
- Ejecutado `npm run lint` con éxito (solo advertencias relacionadas a imágenes). 
- Ejecutado `npm run test` (Vitest) y todos los tests unitarios pasaron con éxito. 
- Construcción completa con `npm run build` completada correctamente (generación Prisma + Next build). 
- Prueba visual básica: se lanzó la app en `next dev` y se capturó screenshot del nuevo presupuestador con modos; flujo verificado manualmente en entorno local.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a31e52ac888331b230da1d9e0e86d9)