### PR TITLE
Refactor responsive integral para sitio, portal clientes y admin

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(site)/clientes/login/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/clientes/login/page.tsx
@@ -50,7 +50,7 @@ export default function LoginPage() {
   }, [status, isAdmin, isClient])
 
   return (
-    <div className="mx-auto flex max-w-5xl flex-col gap-12 px-6 py-16 md:flex-row md:items-start">
+    <div className="mx-auto flex max-w-5xl flex-col gap-8 px-0 py-4 sm:py-8 md:flex-row md:items-start md:gap-10">
       <div className="max-w-md space-y-6">
         <Badge>Portal de clientes</Badge>
         <h1 className="text-3xl font-semibold tracking-tight">Ingresá con tu email</h1>
@@ -87,7 +87,7 @@ export default function LoginPage() {
           .
         </p>
       </div>
-      <div className="flex w-full max-w-sm shrink-0 justify-center md:justify-end">
+      <div className="flex w-full max-w-md shrink-0 justify-center md:justify-end">
         {redirectMessage ? (
           <div className="w-full rounded-lg border border-emerald-100/60 p-6 text-sm text-slate-600 shadow-lg shadow-emerald-100/40">
             {redirectMessage}

--- a/nerin-electric-site-v3-fixed/app/(site)/clientes/obra/[id]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/clientes/obra/[id]/page.tsx
@@ -61,7 +61,7 @@ export default async function ClienteObraPage({ params }: { params: { id: string
   ].sort((a, b) => b.date.getTime() - a.date.getTime())
 
   return (
-    <div className="space-y-10">
+    <div className="space-y-8 sm:space-y-10">
       <header className="space-y-2">
         <Badge>Portal de clientes</Badge>
         <h1>{project.title}</h1>
@@ -73,7 +73,7 @@ export default async function ClienteObraPage({ params }: { params: { id: string
         </Button>
       </header>
 
-      <section className="grid gap-6 lg:grid-cols-2">
+      <section className="grid gap-5 lg:grid-cols-2">
         <Card>
           <CardHeader>
             <CardTitle>Certificados de avance</CardTitle>
@@ -171,7 +171,7 @@ export default async function ClienteObraPage({ params }: { params: { id: string
         </Card>
       </section>
 
-      <section className="grid gap-6 lg:grid-cols-2">
+      <section className="grid gap-5 lg:grid-cols-2">
         <Card>
           <CardHeader>
             <CardTitle>Fotos</CardTitle>

--- a/nerin-electric-site-v3-fixed/app/(site)/clientes/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/clientes/page.tsx
@@ -70,7 +70,7 @@ export default async function ClienteDashboard() {
     : null
 
   return (
-    <div className="space-y-10">
+    <div className="space-y-8 sm:space-y-10">
       <header className="space-y-2">
         <Badge>Portal de clientes</Badge>
         <h1>Hola {displayName}</h1>
@@ -100,13 +100,13 @@ export default async function ClienteDashboard() {
 
       {normalizedClient?.projects.length ? (
         <section className="space-y-6">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-center">
             <h2 className="text-2xl font-semibold text-foreground">Proyectos activos</h2>
             <p className="text-sm text-slate-500">Empresa de envío: {normalizedClient.notas ?? 'Se informará si aplica'}</p>
           </div>
-          <div className="grid gap-6 md:grid-cols-2">
+          <div className="grid gap-5 lg:grid-cols-2">
             {normalizedClient.projects.map((project) => (
-              <Card key={project.id} className="space-y-3">
+              <Card key={project.id} className="space-y-3 overflow-hidden">
                 <CardHeader>
                   <CardTitle>{project.nombre}</CardTitle>
                   <p className="text-sm text-slate-500">Estado: {project.estado}</p>
@@ -199,11 +199,11 @@ export default async function ClienteDashboard() {
 
       {opsClient?.projects.length ? (
         <section className="space-y-6">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-center">
             <h2 className="text-2xl font-semibold text-foreground">Obras operativas</h2>
             <p className="text-sm text-slate-500">Seguimiento de obra y pagos en línea.</p>
           </div>
-          <div className="grid gap-6 md:grid-cols-2">
+          <div className="grid gap-5 lg:grid-cols-2">
             {opsClient.projects.map((project) => (
               <Card key={project.id}>
                 <CardHeader>

--- a/nerin-electric-site-v3-fixed/app/(site)/layout.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/layout.tsx
@@ -121,10 +121,10 @@ export default async function SiteLayout({ children }: { children: ReactNode }) 
           imageUrl: site.logo.imageUrl,
         }}
       />
-      <main className="container pb-24 pt-14">{children}</main>
+      <main className="container pb-20 pt-8 sm:pt-10 lg:pt-12">{children}</main>
       <Footer site={site} />
       <a
-        className="no-underline fixed bottom-6 right-6 hidden h-12 w-12 items-center justify-center rounded-full border border-transparent bg-[#0B0F14] text-white shadow-subtle transition hover:border-[#FBBF24] hover:text-[#FBBF24] focus-visible:ring-2 focus-visible:ring-[#FBBF24]/60 md:inline-flex"
+        className="no-underline fixed bottom-4 right-4 z-40 inline-flex h-12 w-12 items-center justify-center rounded-full border border-transparent bg-[#0B0F14] text-white shadow-subtle transition hover:border-[#FBBF24] hover:text-[#FBBF24] focus-visible:ring-2 focus-visible:ring-[#FBBF24]/60 sm:bottom-5 sm:right-5"
         href={whatsappHref}
         target="_blank"
         rel="noreferrer"

--- a/nerin-electric-site-v3-fixed/app/(site)/mantenimiento/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/mantenimiento/page.tsx
@@ -41,14 +41,14 @@ export default async function MantenimientoPage() {
   const site = await getSiteContent()
 
   return (
-    <div className="space-y-12">
+    <div className="space-y-10 sm:space-y-12">
       <header className="space-y-4">
         <Badge>Mantenimiento</Badge>
         <h1>{site.maintenancePage.introTitle}</h1>
         <p className="max-w-3xl text-lg text-slate-600">{site.maintenancePage.introDescription}</p>
       </header>
 
-      <section className="grid gap-6 md:grid-cols-3">
+      <section className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
         {plans.map((plan) => (
           <Card key={plan.id} className="flex flex-col justify-between">
             <CardHeader>
@@ -80,9 +80,9 @@ export default async function MantenimientoPage() {
         ))}
       </section>
 
-      <section className="rounded-3xl border border-border bg-white p-10 shadow-subtle">
+      <section className="rounded-3xl border border-border bg-white p-5 shadow-subtle sm:p-8 lg:p-10">
         <h2 className="text-2xl font-semibold text-foreground">Alcance operativo</h2>
-        <div className="mt-6 grid gap-6 md:grid-cols-3">
+        <div className="mt-6 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
           {site.maintenancePage.cards.map((card) => (
             <div key={card.title}>
               <h3 className="text-lg font-semibold text-foreground">{card.title}</h3>

--- a/nerin-electric-site-v3-fixed/app/(site)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/page.tsx
@@ -65,9 +65,9 @@ export default async function HomePage() {
   const site = await getSiteContent()
 
   return (
-    <div className="space-y-20">
-      <section className="grid gap-10 lg:grid-cols-[1.1fr_1fr]">
-        <div className="space-y-6">
+    <div className="space-y-14 sm:space-y-16 lg:space-y-20">
+      <section className="grid gap-8 lg:grid-cols-[1.1fr_1fr] lg:gap-10">
+        <div className="space-y-5 sm:space-y-6">
           <Badge>{site.hero.badge}</Badge>
           <h1>Instalaciones eléctricas con criterio comercial y ejecución profesional</h1>
           <p className="max-w-2xl text-lg text-muted-foreground">
@@ -98,7 +98,7 @@ export default async function HomePage() {
           <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Tres caminos claros</p>
           <h2>Elegí tu forma de contratación</h2>
         </div>
-        <div className="grid gap-5 md:grid-cols-3">
+        <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
           {mainPaths.map((path) => (
             <Card key={path.title}>
               <CardHeader>
@@ -120,7 +120,7 @@ export default async function HomePage() {
           <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Servicios destacados</p>
           <h2>Servicios puntuales más solicitados</h2>
         </div>
-        <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid gap-4 sm:grid-cols-2">
           {[
             'Diagnóstico eléctrico premium',
             'Colocación de artefactos',
@@ -136,8 +136,8 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="relative left-1/2 right-1/2 -mx-[50vw] w-screen bg-[#0B0F14] py-16 text-white">
-        <div className="container space-y-8">
+      <section className="relative -mx-4 bg-[#0B0F14] px-4 py-12 text-white sm:-mx-5 sm:px-5 lg:-mx-6 lg:px-6 xl:-mx-10 xl:px-10">
+        <div className="mx-auto max-w-[var(--container)] space-y-8">
           <div className="max-w-2xl space-y-3">
             <p className="text-xs font-semibold uppercase tracking-[0.4em] text-[#FBBF24]">Cobertura premium</p>
             <h2 className="text-white">Atención técnica en zonas priorizadas</h2>
@@ -174,7 +174,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="rounded-3xl border border-border bg-muted/40 p-6">
+      <section className="rounded-3xl border border-border bg-muted/40 p-5 sm:p-6">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div className="space-y-2">
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Contenido técnico</p>

--- a/nerin-electric-site-v3-fixed/app/(site)/presupuestador/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/presupuestador/page.tsx
@@ -63,8 +63,8 @@ export default async function PresupuestadorPage({
   }))
 
   return (
-    <div className="space-y-10">
-      <header className="space-y-5">
+    <div className="space-y-8 sm:space-y-10">
+      <header className="space-y-4 sm:space-y-5">
         <Badge>Hub de cotización</Badge>
         <h1>Elegí cómo querés cotizar tu trabajo eléctrico</h1>
         <p className="max-w-3xl text-lg text-slate-600">

--- a/nerin-electric-site-v3-fixed/app/(site)/presupuesto/PresupuestoForm.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/presupuesto/PresupuestoForm.tsx
@@ -136,7 +136,7 @@ export function PresupuestoForm({ whatsappNumber, leadType, plan }: PresupuestoF
     const message = `Hola, soy ${leadName ?? 'un cliente'}. Envié un pedido de presupuesto (ID: ${leadId}). Quiero coordinar.`
     const whatsappHref = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(message)}`
     return (
-      <div className="space-y-6 rounded-3xl border border-border bg-white p-8 shadow-subtle">
+      <div className="space-y-5 rounded-3xl border border-border bg-white p-4 shadow-subtle sm:p-6 lg:p-8">
         <h2 className="text-2xl font-semibold text-foreground">¡Solicitud enviada!</h2>
         <p className="text-sm text-slate-600">
           Recibimos tu pedido. Tu ID de solicitud es <strong>{leadId}</strong>. Te respondemos en 24–48 h.
@@ -152,9 +152,9 @@ export function PresupuestoForm({ whatsappNumber, leadType, plan }: PresupuestoF
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6 rounded-3xl border border-border bg-white p-8 shadow-subtle">
+    <form onSubmit={handleSubmit} className="space-y-5 rounded-3xl border border-border bg-white p-4 shadow-subtle sm:p-6 lg:p-8">
       <AttributionFields />
-      <div className="grid gap-4 sm:grid-cols-2">
+      <div className="grid gap-4 md:grid-cols-2">
         <div>
           <Label htmlFor="nombre">Nombre y Apellido *</Label>
           <Input id="nombre" name="nombre" required placeholder="Ej: Carla Méndez" />
@@ -173,7 +173,7 @@ export function PresupuestoForm({ whatsappNumber, leadType, plan }: PresupuestoF
             id="cliente"
             name="cliente"
             defaultValue={defaultClientType}
-            className="h-11 w-full rounded-xl border border-border bg-white px-4 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+            className="min-h-11 w-full rounded-xl border border-border bg-white px-4 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
             required
           >
             {clientTypes.map((option) => (
@@ -192,14 +192,14 @@ export function PresupuestoForm({ whatsappNumber, leadType, plan }: PresupuestoF
           <Input id="direccion" name="direccion" placeholder="Calle y número" />
         </div>
       </div>
-      <div className="grid gap-4 sm:grid-cols-2">
+      <div className="grid gap-4 md:grid-cols-2">
         <div>
           <Label htmlFor="trabajo">Tipo de trabajo *</Label>
           <select
             id="trabajo"
             name="trabajo"
             defaultValue={defaultWorkType}
-            className="h-11 w-full rounded-xl border border-border bg-white px-4 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+            className="min-h-11 w-full rounded-xl border border-border bg-white px-4 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
             required
           >
             {workTypes.map((option) => (
@@ -215,7 +215,7 @@ export function PresupuestoForm({ whatsappNumber, leadType, plan }: PresupuestoF
             id="urgencia"
             name="urgencia"
             defaultValue="24-48h"
-            className="h-11 w-full rounded-xl border border-border bg-white px-4 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+            className="min-h-11 w-full rounded-xl border border-border bg-white px-4 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
             required
           >
             {urgencies.map((option) => (
@@ -250,12 +250,12 @@ export function PresupuestoForm({ whatsappNumber, leadType, plan }: PresupuestoF
           type="checkbox"
           name="consentimiento"
           required
-          className="mt-1 h-4 w-4 rounded border-border text-accent focus-visible:ring-accent/40"
+          className="mt-1 h-5 w-5 rounded border-border text-accent focus-visible:ring-accent/40"
         />
         Acepto contacto por WhatsApp/Email.
       </label>
       {status === 'error' && <p className="text-sm text-red-600">{errorMessage}</p>}
-      <Button type="submit" size="lg" disabled={status === 'submitting'}>
+      <Button type="submit" size="lg" disabled={status === 'submitting'} className="w-full sm:w-auto">
         {status === 'submitting' ? 'Enviando...' : 'Enviar solicitud'}
       </Button>
     </form>

--- a/nerin-electric-site-v3-fixed/app/(site)/presupuesto/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/presupuesto/page.tsx
@@ -43,8 +43,8 @@ export default async function PresupuestoPage({
   const plan = searchParams?.plan
 
   return (
-    <div className="grid gap-14 lg:grid-cols-[1.15fr_0.85fr]">
-      <div className="space-y-8">
+    <div className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:gap-12">
+      <div className="space-y-6 sm:space-y-8">
         <Badge>Relevamiento técnico</Badge>
         <h1>Cotización para instalación, obra o reforma</h1>
         <p className="max-w-2xl text-lg text-slate-600">
@@ -53,7 +53,7 @@ export default async function PresupuestoPage({
         </p>
         <PresupuestoForm whatsappNumber={site.contact.whatsappNumber} leadType={leadType} plan={plan} />
       </div>
-      <aside className="space-y-6 rounded-3xl border border-border bg-white p-8 shadow-subtle">
+      <aside className="space-y-5 rounded-3xl border border-border bg-white p-5 shadow-subtle sm:p-7 lg:sticky lg:top-24">
         <h2>Qué validamos en el relevamiento</h2>
         <ul className="space-y-3 text-sm text-slate-600">
           <li>• Estado general de tablero, alimentaciones y protecciones.</li>

--- a/nerin-electric-site-v3-fixed/app/globals.css
+++ b/nerin-electric-site-v3-fixed/app/globals.css
@@ -23,6 +23,7 @@ body {
   background: var(--color-background);
   color: var(--color-foreground);
   font-family: var(--font-plex), system-ui, sans-serif;
+  overflow-x: clip;
 }
 
 a {
@@ -40,8 +41,20 @@ a.no-underline {
   text-decoration: none;
 }
 
+html,
+body {
+  max-width: 100%;
+}
+
+@supports (padding: max(0px)) {
+  body {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}
+
 main {
   display: block;
+  width: 100%;
 }
 
 .focus-ring {
@@ -55,10 +68,10 @@ main {
 
 @layer base {
   h1 {
-    @apply font-display text-4xl md:text-6xl font-semibold tracking-tight text-foreground;
+    @apply font-display text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight text-foreground;
   }
   h2 {
-    @apply font-display text-3xl md:text-4xl font-semibold tracking-tight text-foreground;
+    @apply font-display text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-foreground;
   }
   h3 {
     @apply font-display text-2xl font-semibold text-foreground;
@@ -68,6 +81,7 @@ main {
   }
   .container {
     max-width: var(--container);
+    @apply mx-auto px-4 sm:px-5 lg:px-6;
   }
 }
 
@@ -77,5 +91,14 @@ main {
   }
   .pill {
     @apply inline-flex items-center gap-2 rounded-[var(--radius)] border border-border bg-muted px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground;
+  }
+}
+
+@layer base {
+  input,
+  select,
+  textarea,
+  button {
+    @apply text-base md:text-sm;
   }
 }

--- a/nerin-electric-site-v3-fixed/components/ContactForm.tsx
+++ b/nerin-electric-site-v3-fixed/components/ContactForm.tsx
@@ -25,7 +25,7 @@ export default function ContactForm() {
   return (
     <form
       onSubmit={handleSubmit}
-      className="grid gap-6 md:grid-cols-2 rounded-lg border border-gray-200 p-6 shadow-sm"
+      className="grid gap-5 rounded-xl border border-gray-200 p-4 shadow-sm sm:p-6 md:grid-cols-2"
     >
       <div className="flex flex-col gap-2">
         <label className="text-sm font-medium text-gray-700" htmlFor="nombre">
@@ -33,7 +33,7 @@ export default function ContactForm() {
         </label>
         <input
           id="nombre"
-          className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          className="min-h-11 rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
           placeholder="Nombre"
           value={form.nombre}
           onChange={(event) => setForm((prev) => ({ ...prev, nombre: event.target.value }))}
@@ -48,7 +48,7 @@ export default function ContactForm() {
         <input
           id="email"
           type="email"
-          className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          className="min-h-11 rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
           placeholder="tu@email.com"
           value={form.email}
           onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
@@ -56,7 +56,7 @@ export default function ContactForm() {
         />
       </div>
 
-      <div className="md:col-span-2 flex flex-col gap-2">
+      <div className="flex flex-col gap-2 md:col-span-2">
         <label className="text-sm font-medium text-gray-700" htmlFor="mensaje">
           Mensaje
         </label>
@@ -71,10 +71,10 @@ export default function ContactForm() {
         />
       </div>
 
-      <div className="md:col-span-2 flex flex-col gap-3 sm:flex-row sm:items-center">
+      <div className="flex flex-col gap-3 md:col-span-2 sm:flex-row sm:items-center">
         <button
           type="submit"
-          className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300"
+          className="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300"
         >
           Enviar
         </button>

--- a/nerin-electric-site-v3-fixed/components/Footer.tsx
+++ b/nerin-electric-site-v3-fixed/components/Footer.tsx
@@ -22,7 +22,7 @@ export function Footer({ site }: FooterProps) {
   const whatsappHref = getWhatsappHref(site)
   return (
     <footer className="border-t border-border bg-white">
-      <div className="container grid gap-12 py-14 md:grid-cols-4">
+      <div className="container grid gap-10 py-12 sm:py-14 md:grid-cols-2 lg:grid-cols-4">
         <div className="space-y-3">
           <p className="text-sm uppercase tracking-[0.35em] text-muted-foreground">NERIN</p>
           <p className="text-sm text-muted-foreground">{site.tagline}</p>
@@ -35,7 +35,7 @@ export function Footer({ site }: FooterProps) {
           <ul className="mt-3 space-y-2 text-sm text-foreground">
             {quickLinks.map((item) => (
               <li key={item.href}>
-                <Link className="hover:text-foreground" href={item.href} data-track={item.href === "/presupuesto" ? "lead" : undefined} data-content-name={item.href === "/presupuesto" ? "Pedir presupuesto footer" : undefined}>
+                <Link className="hover:text-foreground" href={item.href} data-track={item.href === '/presupuesto' ? 'lead' : undefined} data-content-name={item.href === '/presupuesto' ? 'Pedir presupuesto footer' : undefined}>
                   {item.label}
                 </Link>
               </li>
@@ -51,7 +51,7 @@ export function Footer({ site }: FooterProps) {
               </a>
             </li>
             <li>
-              <a href={`mailto:${site.contact.email}`} className="hover:text-foreground">
+              <a href={`mailto:${site.contact.email}`} className="hover:text-foreground break-all">
                 {site.contact.email}
               </a>
             </li>
@@ -76,9 +76,9 @@ export function Footer({ site }: FooterProps) {
         </div>
       </div>
       <div className="border-t border-border bg-muted py-6">
-        <div className="container flex flex-col gap-3 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between">
+        <div className="container flex flex-col gap-3 text-sm text-muted-foreground lg:flex-row lg:items-center lg:justify-between">
           <span>© {new Date().getFullYear()} NERIN Electric. Todos los derechos reservados.</span>
-          <div className="flex flex-col gap-2 md:items-end">
+          <div className="flex flex-col gap-2 lg:items-end">
             <span>Desarrollado con foco en performance, accesibilidad AA y cumplimiento normativo AEA 90364-7-771.</span>
             <Link href="/admin" className="text-xs uppercase tracking-[0.3em] text-muted-foreground hover:text-foreground">
               Panel admin

--- a/nerin-electric-site-v3-fixed/components/Header.tsx
+++ b/nerin-electric-site-v3-fixed/components/Header.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { useState } from 'react'
 import { Logo } from './Logo'
 import { Button } from './ui/button'
 import { useSession } from 'next-auth/react'
@@ -30,24 +31,27 @@ const clientDashboardRoute = '/clientes' as const
 
 export function Header({ contact, logo }: HeaderProps) {
   const { data: session } = useSession()
+  const [menuOpen, setMenuOpen] = useState(false)
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border/80 bg-white/95 backdrop-blur">
-      <div className="container flex items-center justify-between gap-6 py-3">
-        <Logo title={logo.title} subtitle={logo.subtitle} imageUrl={logo.imageUrl} />
-        <nav className="hidden items-center gap-6 text-sm font-medium text-muted-foreground lg:flex">
+    <header className="sticky top-0 z-50 border-b border-border/80 bg-white/95 backdrop-blur supports-[padding:env(safe-area-inset-top)]:pt-[env(safe-area-inset-top)]">
+      <div className="container flex items-center justify-between gap-3 py-2.5 sm:gap-4 sm:py-3">
+        <Logo title={logo.title} subtitle={logo.subtitle} imageUrl={logo.imageUrl} className="min-w-0" />
+
+        <nav className="hidden items-center gap-5 text-sm font-medium text-muted-foreground xl:flex">
           {navigation.map((item) => (
             <Link key={item.href} href={item.href} className="hover:text-foreground">
               {item.label}
             </Link>
           ))}
         </nav>
-        <div className="flex items-center gap-3">
+
+        <div className="flex items-center gap-2 sm:gap-3">
           <Button
             variant="outline"
             size="sm"
             asChild
-            className="hidden items-center gap-2 border border-border bg-white text-foreground md:inline-flex"
+            className="hidden items-center gap-2 border border-border bg-white text-foreground lg:inline-flex"
           >
             <a
               href={contact.whatsappHref}
@@ -64,21 +68,66 @@ export function Header({ contact, logo }: HeaderProps) {
               WhatsApp
             </a>
           </Button>
-          <Button size="sm" asChild className="hidden md:inline-flex">
+          <Button size="sm" asChild className="hidden lg:inline-flex">
             <Link href="/presupuesto" data-track="lead" data-content-name="Pedir presupuesto header">Pedir presupuesto</Link>
           </Button>
+
           {!session?.user && (
-            <Button variant="secondary" size="sm" asChild>
+            <Button variant="secondary" size="sm" asChild className="hidden sm:inline-flex">
               <Link href="/clientes/login">Ingresar</Link>
             </Button>
           )}
           {session?.user && session.user.role !== 'admin' && (
-            <Button variant="secondary" size="sm" asChild>
+            <Button variant="secondary" size="sm" asChild className="hidden sm:inline-flex">
               <Link href={clientDashboardRoute}>Portal clientes</Link>
             </Button>
           )}
+
+          <button
+            type="button"
+            onClick={() => setMenuOpen((prev) => !prev)}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-white text-foreground xl:hidden"
+            aria-expanded={menuOpen}
+            aria-label="Abrir menú de navegación"
+          >
+            <svg aria-hidden viewBox="0 0 24 24" className="h-5 w-5 stroke-current" fill="none" strokeWidth="1.8">
+              {menuOpen ? <path d="M6 6l12 12M18 6 6 18" /> : <path d="M4 7h16M4 12h16M4 17h16" />}
+            </svg>
+          </button>
         </div>
       </div>
+
+      {menuOpen && (
+        <div className="border-t border-border bg-white xl:hidden">
+          <div className="container space-y-5 py-4">
+            <nav className="grid gap-1 text-sm font-medium text-foreground">
+              {navigation.map((item) => (
+                <Link key={item.href} href={item.href} className="rounded-lg px-3 py-2 hover:bg-muted" onClick={() => setMenuOpen(false)}>
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <Button asChild onClick={() => setMenuOpen(false)}>
+                <Link href="/presupuesto">Pedir presupuesto</Link>
+              </Button>
+              <Button variant="outline" asChild>
+                <a href={contact.whatsappHref} target="_blank" rel="noopener noreferrer">WhatsApp</a>
+              </Button>
+              {!session?.user && (
+                <Button variant="secondary" asChild className="sm:col-span-2" onClick={() => setMenuOpen(false)}>
+                  <Link href="/clientes/login">Ingresar al portal</Link>
+                </Button>
+              )}
+              {session?.user && session.user.role !== 'admin' && (
+                <Button variant="secondary" asChild className="sm:col-span-2" onClick={() => setMenuOpen(false)}>
+                  <Link href={clientDashboardRoute}>Ir al portal clientes</Link>
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </header>
   )
 }

--- a/nerin-electric-site-v3-fixed/components/Logo.tsx
+++ b/nerin-electric-site-v3-fixed/components/Logo.tsx
@@ -16,8 +16,8 @@ export function Logo({ className, imageUrl, subtitle, title }: LogoProps) {
   const showImage = Boolean(imageUrl) && !imageFailed
 
   return (
-    <Link href="/" className={cn('no-underline flex items-center gap-3 font-display text-lg', className)}>
-      <span className="inline-flex h-10 w-10 items-center justify-center overflow-hidden rounded-[var(--radius)] border border-border bg-white p-1">
+    <Link href="/" className={cn('no-underline flex min-w-0 items-center gap-2.5 font-display text-lg sm:gap-3', className)}>
+      <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-[var(--radius)] border border-border bg-white p-1 sm:h-10 sm:w-10">
         {showImage ? (
           <img
             src={imageUrl ?? undefined}
@@ -32,9 +32,9 @@ export function Logo({ className, imageUrl, subtitle, title }: LogoProps) {
           </svg>
         )}
       </span>
-      <div className="flex flex-col leading-tight">
-        <span className="text-base font-semibold uppercase tracking-[0.2em] text-foreground">{title}</span>
-        <span className="text-xs text-muted-foreground">{subtitle}</span>
+      <div className="flex min-w-0 flex-col leading-tight">
+        <span className="truncate text-sm font-semibold uppercase tracking-[0.16em] text-foreground sm:text-base sm:tracking-[0.2em]">{title}</span>
+        <span className="hidden text-xs text-muted-foreground sm:block">{subtitle}</span>
       </div>
     </Link>
   )

--- a/nerin-electric-site-v3-fixed/components/admin/AdminShell.tsx
+++ b/nerin-electric-site-v3-fixed/components/admin/AdminShell.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 import { AdminSidebar } from '@/components/admin/AdminSidebar'
 import { AdminTopbar } from '@/components/admin/AdminTopbar'
 
@@ -9,15 +9,32 @@ type AdminShellProps = {
 }
 
 export function AdminShell({ children }: AdminShellProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
   return (
     <div className="min-h-screen bg-slate-100 text-foreground">
       <div className="mx-auto flex min-h-screen w-full max-w-[1600px]">
         <div className="hidden lg:flex">
           <AdminSidebar />
         </div>
-        <div className="flex min-h-screen flex-1 flex-col">
-          <AdminTopbar />
-          <div className="flex-1 px-6 py-6 lg:px-10 lg:py-8">
+
+        {sidebarOpen && (
+          <>
+            <button
+              type="button"
+              className="fixed inset-0 z-30 bg-slate-900/40 lg:hidden"
+              onClick={() => setSidebarOpen(false)}
+              aria-label="Cerrar navegación"
+            />
+            <div className="fixed inset-y-0 left-0 z-40 lg:hidden">
+              <AdminSidebar onNavigate={() => setSidebarOpen(false)} className="h-full w-[84vw] max-w-xs shadow-2xl" />
+            </div>
+          </>
+        )}
+
+        <div className="flex min-h-screen min-w-0 flex-1 flex-col">
+          <AdminTopbar onToggleSidebar={() => setSidebarOpen(true)} />
+          <div className="flex-1 px-4 py-4 sm:px-5 sm:py-5 lg:px-10 lg:py-8">
             <div className="mx-auto w-full max-w-6xl">{children}</div>
           </div>
         </div>

--- a/nerin-electric-site-v3-fixed/components/admin/AdminSidebar.tsx
+++ b/nerin-electric-site-v3-fixed/components/admin/AdminSidebar.tsx
@@ -5,20 +5,23 @@ import { usePathname } from 'next/navigation'
 import { adminNav } from '@/components/admin/nav'
 import { cn } from '@/lib/utils'
 
-export function AdminSidebar() {
+type AdminSidebarProps = {
+  onNavigate?: () => void
+  className?: string
+}
+
+export function AdminSidebar({ onNavigate, className }: AdminSidebarProps) {
   const pathname = usePathname()
 
   return (
-    <aside className="flex h-full w-64 flex-col gap-6 border-r border-border bg-white px-4 py-6">
+    <aside className={cn('flex h-full w-72 flex-col gap-6 border-r border-border bg-white px-4 py-6', className)}>
       <div className="flex items-center gap-2 px-2 text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">
         Admin Nerin
       </div>
-      <nav className="flex flex-1 flex-col gap-6 text-sm">
+      <nav className="flex flex-1 flex-col gap-5 text-sm">
         {adminNav.map((section) => (
           <div key={section.label} className="space-y-2">
-            <p className="px-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
-              {section.label}
-            </p>
+            <p className="px-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">{section.label}</p>
             <div className="flex flex-col gap-1">
               {section.items.map((item) => {
                 const isActive =
@@ -29,8 +32,9 @@ export function AdminSidebar() {
                   <Link
                     key={item.href}
                     href={item.href}
+                    onClick={onNavigate}
                     className={cn(
-                      'rounded-xl px-3 py-2 text-sm transition hover:bg-slate-100',
+                      'rounded-xl px-3 py-2.5 text-sm transition hover:bg-slate-100',
                       isActive ? 'bg-slate-100 font-semibold text-foreground' : 'text-slate-600',
                     )}
                   >

--- a/nerin-electric-site-v3-fixed/components/admin/AdminTopbar.tsx
+++ b/nerin-electric-site-v3-fixed/components/admin/AdminTopbar.tsx
@@ -4,18 +4,34 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { adminNav, findAdminNavMatch } from '@/components/admin/nav'
 
-export function AdminTopbar() {
+type AdminTopbarProps = {
+  onToggleSidebar?: () => void
+}
+
+export function AdminTopbar({ onToggleSidebar }: AdminTopbarProps) {
   const pathname = usePathname()
   const match = findAdminNavMatch(pathname)
   const sectionLabel = match?.sectionLabel ?? adminNav[0]?.label ?? 'Admin'
   const title = match?.title ?? 'Panel administrativo'
 
   return (
-    <div className="sticky top-0 z-10 border-b border-border bg-white/95 px-6 py-4 backdrop-blur">
+    <div className="sticky top-0 z-20 border-b border-border bg-white/95 px-4 py-3 backdrop-blur sm:px-6 sm:py-4">
       <div className="flex flex-wrap items-center justify-between gap-4">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">{sectionLabel}</p>
-          <h1 className="text-xl font-semibold text-foreground">{title}</h1>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={onToggleSidebar}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-white lg:hidden"
+            aria-label="Abrir menú de administración"
+          >
+            <svg aria-hidden viewBox="0 0 24 24" className="h-5 w-5 stroke-current" fill="none" strokeWidth="1.8">
+              <path d="M4 7h16M4 12h16M4 17h16" />
+            </svg>
+          </button>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">{sectionLabel}</p>
+            <h1 className="text-lg font-semibold text-foreground sm:text-xl">{title}</h1>
+          </div>
         </div>
         <div className="flex items-center gap-3">
           <div className="hidden items-center gap-2 rounded-full border border-border bg-slate-50 px-3 py-2 text-xs text-slate-500 md:flex">

--- a/nerin-electric-site-v3-fixed/components/configurator/ConfiguratorWizard.tsx
+++ b/nerin-electric-site-v3-fixed/components/configurator/ConfiguratorWizard.tsx
@@ -118,14 +118,14 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
   }
 
   return (
-    <div className="space-y-8">
-      <section className="grid gap-4 md:grid-cols-3">
+    <div className="space-y-6 sm:space-y-8">
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {modeCards.map((card) => (
           <button
             key={card.mode}
             type="button"
             onClick={() => updateMode(card.mode)}
-            className={`rounded-2xl border p-5 text-left transition ${
+            className={`rounded-2xl border p-4 sm:p-5 text-left transition min-h-32 ${
               summary.mode === card.mode ? 'border-accent bg-accent/5' : 'border-border bg-white'
             }`}
           >
@@ -135,7 +135,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
         ))}
       </section>
 
-      <section className="grid gap-6 lg:grid-cols-[1.45fr_0.9fr]">
+      <section className="grid gap-5 lg:grid-cols-[1.35fr_0.9fr] xl:gap-6">
         <Card>
           <CardHeader>
             <CardTitle>
@@ -144,14 +144,14 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
               {summary.mode === 'PROFESSIONAL' && 'Cotización profesional por ítems'}
             </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-6">
+          <CardContent className="space-y-5">
             <div className="grid gap-3">
               {visibleServices.map((service) => (
                 <button
                   key={service.id}
                   type="button"
                   onClick={() => setSummary((prev) => ({ ...prev, serviceId: service.id }))}
-                  className={`rounded-xl border p-4 text-left ${summary.serviceId === service.id ? 'border-accent bg-accent/5' : 'border-border'}`}
+                  className={`rounded-xl border p-3.5 sm:p-4 text-left ${summary.serviceId === service.id ? 'border-accent bg-accent/5' : 'border-border'}`}
                 >
                   <p className="font-semibold text-foreground">{service.name}</p>
                   <p className="mt-1 text-sm text-slate-600">{service.description}</p>
@@ -163,7 +163,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
             </div>
 
             {summary.mode === 'EXPRESS' && (
-              <div className="grid gap-4 sm:grid-cols-2">
+              <div className="grid gap-4 md:grid-cols-2">
                 <div>
                   <Label>Unidades de servicio</Label>
                   <Input
@@ -190,7 +190,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
 
             {summary.mode === 'ASSISTED' && (
               <>
-                <div className="grid gap-4 sm:grid-cols-3">
+                <div className="grid gap-4 md:grid-cols-3">
                   <div>
                     <Label>Ambientes</Label>
                     <Input
@@ -226,9 +226,9 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
                 </div>
                 <div className="space-y-2">
                   <p className="text-sm font-semibold text-foreground">Ajustes editables</p>
-                  <div className="grid gap-3 md:grid-cols-2">
+                  <div className="grid gap-3 lg:grid-cols-2">
                     {adicionales.slice(0, 8).map((item) => (
-                      <div key={item.id} className="grid grid-cols-[1fr_92px] items-center gap-3">
+                      <div key={item.id} className="grid grid-cols-1 gap-2 rounded-xl border border-border/70 p-3 sm:grid-cols-[1fr_110px] sm:items-center sm:gap-3">
                         <span className="text-sm text-slate-600">{item.nombre}</span>
                         <Input
                           type="number"
@@ -244,9 +244,9 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
             )}
 
             {summary.mode === 'PROFESSIONAL' && (
-              <div className="grid gap-3 md:grid-cols-2">
+              <div className="grid gap-3 lg:grid-cols-2">
                 {professionalCatalog.map((item) => (
-                  <div key={item.id} className="grid grid-cols-[1fr_90px] items-center gap-3">
+                  <div key={item.id} className="grid grid-cols-1 gap-2 rounded-xl border border-border/70 p-3 sm:grid-cols-[1fr_110px] sm:items-center sm:gap-3">
                     <span className="text-sm text-slate-600">{item.name}</span>
                     <Input
                       type="number"
@@ -269,7 +269,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="h-fit lg:sticky lg:top-24">
           <CardHeader>
             <CardTitle>Resumen comercial</CardTitle>
           </CardHeader>
@@ -299,7 +299,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
                 value={contacto.email}
                 onChange={(event) => setContacto((prev) => ({ ...prev, email: event.target.value }))}
               />
-              <Button onClick={submitQuote} disabled={isPending}>
+              <Button onClick={submitQuote} disabled={isPending} className="w-full">
                 {isPending ? 'Guardando...' : 'Guardar cotización'}
               </Button>
               {pdfUrl && (

--- a/nerin-electric-site-v3-fixed/components/ui/table.tsx
+++ b/nerin-electric-site-v3-fixed/components/ui/table.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-export const Table = ({ className, ...props }: React.HTMLAttributes<HTMLTableElement>) => (
-  <table className={cn('w-full border-collapse text-sm text-slate-700', className)} {...props} />
+export const Table = ({ className, ...props }: React.TableHTMLAttributes<HTMLTableElement>) => (
+  <div className="w-full overflow-x-auto rounded-xl">
+    <table className={cn('min-w-[620px] w-full border-collapse text-sm text-slate-700', className)} {...props} />
+  </div>
 )
 
 export const TableHead = ({ className, ...props }: React.ThHTMLAttributes<HTMLTableCellElement>) => (
-  <th className={cn('border-b border-border pb-3 text-left font-medium text-slate-500', className)} {...props} />
+  <th className={cn('border-b border-border pb-3 pr-4 text-left font-medium text-slate-500', className)} {...props} />
 )
 
 export const TableRow = ({ className, ...props }: React.HTMLAttributes<HTMLTableRowElement>) => (
@@ -14,5 +16,5 @@ export const TableRow = ({ className, ...props }: React.HTMLAttributes<HTMLTable
 )
 
 export const TableCell = ({ className, ...props }: React.TdHTMLAttributes<HTMLTableCellElement>) => (
-  <td className={cn('py-4 align-middle text-slate-700', className)} {...props} />
+  <td className={cn('py-4 pr-4 align-middle text-slate-700', className)} {...props} />
 )


### PR DESCRIPTION
### Motivation
- Adaptar de forma coherente y profesional toda la UI (sitio público, portal clientes y admin) para mobile pequeño, mobile grande, tablet/iPad vertical y horizontal, manteniendo la estética premium actual. 
- Resolver problemas concretos: navegación móvil inexistente, tablas rotas en pantallas chicas, formularios y configurador incómodos en touch, sidebar admin inaccesible en tablet/móvil y overflow horizontal accidental.

### Description
- Implementé una capa responsive global y safe-area en `app/globals.css` y ajusté paddings/typografía para los breakpoints solicitados. 
- Añadí un menú hamburguesa/desplegable en `components/Header.tsx` y optimicé el `Logo` y el `Footer` para evitar colisiones y facilitar lectura en móviles. 
- Reimplementé tablas con un wrapper horizontal seguro en `components/ui/table.tsx` para evitar roturas y mantener scroll cuando corresponde. 
- Mejoré formularios y el configurador para touch: `components/ContactForm.tsx`, `app/(site)/presupuesto/PresupuestoForm.tsx` y `components/configurator/ConfiguratorWizard.tsx` con grids adaptativos, inputs más altos y CTA/summary adaptados (resumen sticky en desktop). 
- Hice admin usable en iPad/móvil con offcanvas sidebar y topbar táctil (`components/admin/AdminShell.tsx`, `AdminSidebar.tsx`, `AdminTopbar.tsx`). 
- Ajusté múltiples páginas y layouts para evitar compresión y overflows (`app/(site)/layout.tsx`, `app/(site)/page.tsx`, `app/(site)/mantenimiento/page.tsx`, `app/(site)/presupuestador/page.tsx`, `app/(site)/presupuesto/*`, `app/(site)/clientes/*`).

### Testing
- Ejecuté `npm run lint` y terminó correctamente; quedaron warnings no bloqueantes (uso de `<img>` en áreas no modificadas). ✅
- Ejecuté `npm run build` y la build completó correctamente; aparecieron warnings de entorno/DB local (tablas faltantes) que no bloquean la compilación en este entorno. ✅
- Levanté la app local y generé capturas con Playwright; el intento con Chromium falló por un crash en este entorno, pero la ejecución con Firefox generó screenshots de verificación (home mobile y admin tablet). ✅ (Chromium crash → reintento con Firefox OK)
- Comprobé manualmente navegación móvil (hamburguesa/desplegable), offcanvas admin en tablet, tablas con scroll horizontal y formularios touch-friendly; no se detectaron overflows horizontales accidentaless en las pantallas probadas. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a33fe8aca48331a8ebaf205041c7a4)