### PR TITLE
Unifica uploads y previews de media en el admin

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/BlogManager.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/BlogManager.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Table, TableCell, TableHead, TableRow } from '@/components/ui/table'
+import { AdminMediaField } from '@/components/admin/AdminMediaField'
 
 interface BlogSummary {
   slug: string
@@ -251,14 +252,13 @@ export function BlogManager() {
               onChange={(event) => setForm((prev) => ({ ...prev, publishedAt: event.target.value }))}
             />
           </div>
-          <div className="grid gap-2">
-            <Label htmlFor="blog-hero">Imagen principal (URL opcional)</Label>
-            <Input
-              id="blog-hero"
-              value={form.heroImage ?? ''}
-              onChange={(event) => setForm((prev) => ({ ...prev, heroImage: event.target.value }))}
-            />
-          </div>
+          <AdminMediaField
+            id="blog-hero"
+            label="Imagen principal"
+            value={form.heroImage ?? ''}
+            onChange={(next) => setForm((prev) => ({ ...prev, heroImage: next }))}
+            uploadFolder="blog"
+          />
           <div className="grid gap-2">
             <Label htmlFor="blog-tags">Tags (separadas por coma)</Label>
             <Input

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/BrandManager.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/BrandManager.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { AdminMediaField } from '@/components/admin/AdminMediaField'
 import { Table, TableCell, TableHead, TableRow } from '@/components/ui/table'
 
 interface Brand {
@@ -130,8 +131,7 @@ export function BrandManager({ initialBrands }: BrandManagerProps) {
           <div>
             <CardTitle>Marcas y partners tecnológicos</CardTitle>
             <p className="text-sm text-slate-600">
-              Cargá marcas que se muestran en el home y en la página de contacto. Podés incluir la URL del logo hospedado en
-              CDN propio.
+              Cargá marcas que se muestran en el home y en la página de contacto usando un flujo unificado de media.
             </p>
             {message && (
               <p className={`text-xs ${message.type === 'success' ? 'text-emerald-600' : 'text-red-600'}`}>{message.message}</p>
@@ -155,15 +155,14 @@ export function BrandManager({ initialBrands }: BrandManagerProps) {
               required
             />
           </div>
-          <div className="grid gap-2">
-            <Label htmlFor="brand-logo">Logo (URL opcional)</Label>
-            <Input
-              id="brand-logo"
-              value={form.logoUrl}
-              onChange={(event) => setForm((prev) => ({ ...prev, logoUrl: event.target.value }))}
-              placeholder="https://..."
-            />
-          </div>
+          <AdminMediaField
+            id="brand-logo"
+            label="Logo de la marca"
+            value={form.logoUrl}
+            onChange={(next) => setForm((prev) => ({ ...prev, logoUrl: next }))}
+            uploadFolder="brands"
+            description="Podés subir archivo desde el dispositivo o pegar una URL externa."
+          />
           <Button type="submit" disabled={loading}>
             {isEditing ? 'Actualizar' : 'Agregar'}
           </Button>
@@ -184,9 +183,12 @@ export function BrandManager({ initialBrands }: BrandManagerProps) {
                   <TableCell>{brand.nombre}</TableCell>
                   <TableCell className="text-sm text-slate-500">
                     {brand.logoUrl ? (
-                      <a className="text-accent underline" href={brand.logoUrl} target="_blank" rel="noreferrer">
-                        {brand.logoUrl}
-                      </a>
+                      <div className="flex items-center gap-3">
+                        <img src={brand.logoUrl} alt={brand.nombre} className="h-10 w-10 rounded-md border border-border object-contain bg-white p-1" />
+                        <a className="max-w-[260px] truncate text-accent underline" href={brand.logoUrl} target="_blank" rel="noreferrer">
+                          {brand.logoUrl}
+                        </a>
+                      </div>
                     ) : (
                       <span className="text-slate-400">Sin logo</span>
                     )}

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/ProjectsManager.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/ProjectsManager.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Table, TableCell, TableHead, TableRow } from '@/components/ui/table'
+import { AdminMediaField } from '@/components/admin/AdminMediaField'
 
 type Project = {
   id?: string
@@ -162,21 +163,44 @@ export function ProjectsManager() {
               />
             </div>
           </div>
-          <div className="grid gap-2">
-            <Label htmlFor="project-images">Imágenes (URLs separadas por coma)</Label>
-            <Input
-              id="project-images"
-              value={form.images.join(', ')}
-              onChange={(event) =>
-                setForm((prev) => ({
-                  ...prev,
-                  images: event.target.value
-                    .split(',')
-                    .map((url) => url.trim())
-                    .filter(Boolean),
-                }))
-              }
-            />
+          <div className="grid gap-3">
+            <Label>Imágenes del proyecto</Label>
+            {form.images.map((image, index) => (
+              <div key={`${form.id ?? 'new'}-${index}`} className="space-y-2 rounded-xl border border-border p-3">
+                <AdminMediaField
+                  id={`project-image-${index}`}
+                  label={`Imagen ${index + 1}`}
+                  value={image}
+                  onChange={(next) =>
+                    setForm((prev) => ({
+                      ...prev,
+                      images: prev.images.map((current, currentIndex) => (currentIndex === index ? next : current)),
+                    }))
+                  }
+                  uploadFolder="projects"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() =>
+                    setForm((prev) => ({
+                      ...prev,
+                      images: prev.images.filter((_, currentIndex) => currentIndex !== index),
+                    }))
+                  }
+                >
+                  Eliminar imagen
+                </Button>
+              </div>
+            ))}
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setForm((prev) => ({ ...prev, images: [...prev.images, ''] }))}
+            >
+              Agregar imagen
+            </Button>
           </div>
           <div className="flex gap-3">
             <Button type="submit">{isEditing ? 'Actualizar' : 'Crear'}</Button>

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/SiteExperienceDesigner.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/SiteExperienceDesigner.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
+import { AdminMediaField } from '@/components/admin/AdminMediaField'
 import { Button } from '@/components/ui/button'
 
 interface SiteExperienceDesignerProps {
@@ -482,19 +483,18 @@ export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerPr
                 }
               />
             </div>
-            <div className="grid gap-2">
-              <Label htmlFor="hero-background">Imagen de fondo (URL)</Label>
-              <Input
-                id="hero-background"
-                value={form.hero.backgroundImage}
-                onChange={(event) =>
-                  setForm((prev) => ({
-                    ...prev,
-                    hero: { ...prev.hero, backgroundImage: event.target.value },
-                  }))
-                }
-              />
-            </div>
+            <AdminMediaField
+              id="hero-background"
+              label="Imagen de fondo"
+              value={form.hero.backgroundImage}
+              onChange={(next) =>
+                setForm((prev) => ({
+                  ...prev,
+                  hero: { ...prev.hero, backgroundImage: next },
+                }))
+              }
+              uploadFolder="site/hero"
+            />
             <div className="grid gap-2">
               <Label htmlFor="hero-caption">Leyenda de la imagen</Label>
               <Textarea

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/noticias/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/noticias/page.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Table, TableCell, TableHead, TableRow } from '@/components/ui/table'
 import { Textarea } from '@/components/ui/textarea'
+import { AdminMediaField } from '@/components/admin/AdminMediaField'
 
 type Metric = { label: string; value: string }
 
@@ -88,6 +89,8 @@ export default function AdminNoticiasPage() {
   const [saving, setSaving] = useState(false)
 
   const isEditing = useMemo(() => Boolean(form.id), [form.id])
+
+  const fotos = textToFotos(form.fotosText)
 
   const resetForm = useCallback(() => {
     setForm(emptyForm)
@@ -325,13 +328,40 @@ export default function AdminNoticiasPage() {
                 onChange={(event) => setForm((prev) => ({ ...prev, metricasText: event.target.value }))}
               />
             </div>
-            <div className="grid gap-2">
-              <Label htmlFor="fotos">URLs de fotos (una por línea)</Label>
-              <Textarea
-                id="fotos"
-                value={form.fotosText}
-                onChange={(event) => setForm((prev) => ({ ...prev, fotosText: event.target.value }))}
-              />
+            <div className="grid gap-3">
+              <Label>Fotos de la noticia</Label>
+              {fotos.map((foto, index) => (
+                <div key={`${form.id ?? 'new'}-foto-${index}`} className="space-y-2 rounded-xl border border-border p-3">
+                  <AdminMediaField
+                    id={`case-study-foto-${index}`}
+                    label={`Foto ${index + 1}`}
+                    value={foto}
+                    onChange={(next) => {
+                      const nextFotos = fotos.map((item, itemIndex) => (itemIndex === index ? next : item)).filter(Boolean)
+                      setForm((prev) => ({ ...prev, fotosText: nextFotos.join('\n') }))
+                    }}
+                    uploadFolder="case-studies"
+                  />
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => {
+                      const nextFotos = fotos.filter((_, itemIndex) => itemIndex !== index)
+                      setForm((prev) => ({ ...prev, fotosText: nextFotos.join('\n') }))
+                    }}
+                  >
+                    Eliminar foto
+                  </Button>
+                </div>
+              ))}
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setForm((prev) => ({ ...prev, fotosText: [...fotos, ''].join('\n') }))}
+              >
+                Agregar foto
+              </Button>
             </div>
             <label className="flex items-center gap-2 text-sm text-slate-600">
               <input

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/operativo/ProjectPhotoUploader.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/operativo/ProjectPhotoUploader.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+export function ProjectPhotoUploader({ projectId }: { projectId: string }) {
+  const [title, setTitle] = useState('')
+  const [file, setFile] = useState<File | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!file) {
+      setError('Seleccioná una imagen para subir')
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    setMessage(null)
+
+    try {
+      const formData = new FormData()
+      formData.append('projectId', projectId)
+      formData.append('title', title)
+      formData.append('file', file)
+
+      const response = await fetch('/api/upload/project-photo', {
+        method: 'POST',
+        body: formData,
+      })
+
+      const payload = (await response.json().catch(() => null)) as { error?: string } | null
+      if (!response.ok) {
+        throw new Error(payload?.error ?? 'No se pudo subir la foto')
+      }
+
+      setMessage('Foto subida. Recargando listado...')
+      setTitle('')
+      setFile(null)
+      setPreviewUrl((current) => {
+        if (current) URL.revokeObjectURL(current)
+        return null
+      })
+      window.location.reload()
+    } catch (uploadError) {
+      setError(uploadError instanceof Error ? uploadError.message : 'No se pudo subir la foto')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="grid gap-3">
+      <div className="grid gap-2">
+        <Label htmlFor={`photo-title-${projectId}`}>Título</Label>
+        <Input id={`photo-title-${projectId}`} value={title} onChange={(event) => setTitle(event.target.value)} />
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor={`photo-file-${projectId}`}>Archivo</Label>
+        <Input
+          id={`photo-file-${projectId}`}
+          name="file"
+          type="file"
+          accept="image/*"
+          required
+          onChange={(event) => {
+            const selected = event.target.files?.[0] ?? null
+            setFile(selected)
+            setPreviewUrl((current) => {
+              if (current) URL.revokeObjectURL(current)
+              return selected ? URL.createObjectURL(selected) : null
+            })
+          }}
+        />
+      </div>
+      {previewUrl ? <img src={previewUrl} alt="Preview" className="h-28 w-full rounded-lg object-cover" /> : null}
+      {error ? <p className="text-xs text-red-600">{error}</p> : null}
+      {message ? <p className="text-xs text-amber-600">{message}</p> : null}
+      <Button type="submit" variant="secondary" disabled={loading}>
+        {loading ? 'Subiendo...' : 'Subir foto'}
+      </Button>
+    </form>
+  )
+}

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/operativo/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/operativo/page.tsx
@@ -11,6 +11,8 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { toPublicMediaUrl } from '@/lib/media'
+import { ProjectPhotoUploader } from './ProjectPhotoUploader'
 import { Table, TableCell, TableHead, TableRow } from '@/components/ui/table'
 
 const formatCurrency = (value: number) =>
@@ -135,31 +137,13 @@ export default async function AdminOperativoPage() {
 
                     <div className="space-y-4">
                       <h3 className="text-base font-semibold text-foreground">Fotos de obra</h3>
-                      <form
-                        action="/api/upload/project-photo"
-                        method="post"
-                        encType="multipart/form-data"
-                        className="grid gap-3"
-                      >
-                        <input type="hidden" name="projectId" value={project.id} />
-                        <div className="grid gap-2">
-                          <Label htmlFor={`photo-title-${project.id}`}>Título</Label>
-                          <Input id={`photo-title-${project.id}`} name="title" placeholder="Ingreso de materiales" />
-                        </div>
-                        <div className="grid gap-2">
-                          <Label htmlFor={`photo-file-${project.id}`}>Archivo</Label>
-                          <Input id={`photo-file-${project.id}`} name="file" type="file" accept="image/*" required />
-                        </div>
-                        <Button type="submit" variant="secondary">
-                          Subir foto
-                        </Button>
-                      </form>
+                      <ProjectPhotoUploader projectId={project.id} />
                       {project.photos.length ? (
                         <div className="grid grid-cols-2 gap-3">
                           {project.photos.map((photo) => (
                             <figure key={photo.id} className="space-y-2">
                               <img
-                                src={`/uploads/${photo.storedPath}`}
+                                src={toPublicMediaUrl(photo.storedPath)}
                                 alt={photo.title ?? 'Foto de obra'}
                                 className="h-32 w-full rounded-lg object-cover"
                                 loading="lazy"

--- a/nerin-electric-site-v3-fixed/app/api/admin/upload/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/upload/route.ts
@@ -2,9 +2,20 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
-import { getMediaDir, getMediaPublicUrl, sanitizeMediaFilename } from '@/lib/media'
+import { getMediaDir, getMediaPublicUrl, sanitizeMediaFilename, sanitizeMediaFolder } from '@/lib/media'
 
-const ALLOWED_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/svg+xml'])
+const ALLOWED_MIME_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/svg+xml',
+  'image/gif',
+  'application/pdf',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+])
 
 export async function POST(req: Request) {
   await requireAdmin()
@@ -20,18 +31,22 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Formato no permitido' }, { status: 400 })
   }
 
+  const folder = sanitizeMediaFolder(form.get('folder')?.toString())
   const originalName = (form.get('name') as string) || file.name || 'upload.png'
 
   try {
     const safeName = sanitizeMediaFilename(originalName)
     const uniqueName = `${Date.now()}-${safeName}`
+    const relativePath = folder ? path.posix.join(folder, uniqueName) : uniqueName
     const mediaDir = getMediaDir()
-    const outPath = path.join(mediaDir, uniqueName)
-    const arrayBuffer = await file.arrayBuffer()
+    const outPath = path.join(mediaDir, relativePath)
 
+    fs.mkdirSync(path.dirname(outPath), { recursive: true })
+
+    const arrayBuffer = await file.arrayBuffer()
     fs.writeFileSync(outPath, Buffer.from(arrayBuffer))
 
-    return NextResponse.json({ ok: true, url: getMediaPublicUrl(uniqueName) })
+    return NextResponse.json({ ok: true, url: getMediaPublicUrl(relativePath) })
   } catch (error) {
     const message = error instanceof Error ? error.message : 'No se pudo subir el archivo'
     return NextResponse.json({ error: message }, { status: 400 })

--- a/nerin-electric-site-v3-fixed/components/admin/AdminMediaField.tsx
+++ b/nerin-electric-site-v3-fixed/components/admin/AdminMediaField.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+function getFilenameFromValue(value?: string) {
+  if (!value) return null
+  const normalized = value.split('?')[0]
+  const parts = normalized.split('/')
+  return decodeURIComponent(parts[parts.length - 1] || 'archivo')
+}
+
+function isImagePath(value?: string) {
+  if (!value) return false
+  return /\.(png|jpe?g|webp|gif|svg)$/i.test(value)
+}
+
+type AdminMediaFieldProps = {
+  id: string
+  label: string
+  value?: string
+  onChange: (value: string) => void
+  description?: string
+  uploadFolder?: string
+  accept?: string
+  allowManualUrl?: boolean
+}
+
+export function AdminMediaField({
+  id,
+  label,
+  value,
+  onChange,
+  description,
+  uploadFolder = 'admin',
+  accept = 'image/*',
+  allowManualUrl = true,
+}: AdminMediaFieldProps) {
+  const [isUploading, setIsUploading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [localPreview, setLocalPreview] = useState<string | null>(null)
+  const [pendingSave, setPendingSave] = useState(false)
+
+  const previewSrc = localPreview ?? value ?? ''
+  const fileName = useMemo(() => getFilenameFromValue(value), [value])
+
+  const handleUpload = useCallback(
+    async (file: File) => {
+      setError(null)
+      setIsUploading(true)
+      setPendingSave(false)
+
+      if (isImagePath(file.name)) {
+        setLocalPreview((current) => {
+          if (current) {
+            URL.revokeObjectURL(current)
+          }
+          return URL.createObjectURL(file)
+        })
+      }
+
+      try {
+        const formData = new FormData()
+        formData.append('file', file)
+        formData.append('name', file.name)
+        formData.append('folder', uploadFolder)
+
+        const response = await fetch('/api/admin/upload', {
+          method: 'POST',
+          body: formData,
+        })
+
+        const payload = (await response.json().catch(() => null)) as { url?: string; error?: string } | null
+
+        if (!response.ok || !payload?.url) {
+          throw new Error(payload?.error ?? 'No se pudo subir el archivo')
+        }
+
+        onChange(payload.url)
+        setPendingSave(true)
+      } catch (uploadError) {
+        setError(uploadError instanceof Error ? uploadError.message : 'No se pudo subir el archivo')
+      } finally {
+        setIsUploading(false)
+      }
+    },
+    [onChange, uploadFolder],
+  )
+
+  return (
+    <div className="space-y-2 rounded-xl border border-border bg-white p-3">
+      <div className="space-y-1">
+        <Label htmlFor={id}>{label}</Label>
+        {description ? <p className="text-xs text-slate-500">{description}</p> : null}
+      </div>
+
+      <Input
+        id={id}
+        type="file"
+        accept={accept}
+        onChange={(event) => {
+          const file = event.target.files?.[0]
+          if (!file) return
+          void handleUpload(file)
+          event.currentTarget.value = ''
+        }}
+      />
+
+      {allowManualUrl ? (
+        <Input
+          value={value ?? ''}
+          onChange={(event) => {
+            setError(null)
+            setPendingSave(false)
+            onChange(event.target.value)
+          }}
+          placeholder="https://..."
+        />
+      ) : null}
+
+      {(isImagePath(previewSrc) && previewSrc) ? (
+        <div className="space-y-2">
+          <img src={previewSrc} alt={label} className="h-24 w-full rounded-lg border border-border object-cover" loading="lazy" />
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap gap-2 text-xs text-slate-500">
+        {fileName ? <span>Archivo: {fileName}</span> : <span>Sin archivo seleccionado</span>}
+        {isUploading ? <span className="text-slate-600">Subiendo...</span> : null}
+        {pendingSave ? <span className="text-amber-600">Archivo cargado, falta guardar cambios.</span> : null}
+      </div>
+
+      {error ? <p className="text-xs text-red-600">{error}</p> : null}
+
+      {value ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            setError(null)
+            setPendingSave(false)
+            setLocalPreview((current) => {
+              if (current) {
+                URL.revokeObjectURL(current)
+              }
+              return null
+            })
+            onChange('')
+          }}
+        >
+          Quitar archivo
+        </Button>
+      ) : null}
+    </div>
+  )
+}


### PR DESCRIPTION
### Motivation
- Uniformar y profesionalizar la gestión de imágenes/archivos desde el admin para evitar soluciones sueltas por pantalla y mejorar UX móvil/desktop. 
- Hacer que subir, previsualizar, reemplazar, quitar y persistir media sea consistente y reusable sin tocar el flujo del logo ya resuelto. 

### Description
- Nuevo componente reusable `AdminMediaField` (`components/admin/AdminMediaField.tsx`) que soporta: selección de archivo, preview inmediato para imágenes, estado de carga, error, reemplazo, eliminación, y entrada manual de URL opcional. 
- Nueva capa/media utilities en `lib/media.ts` y helpers `toPublicMediaUrl`, `sanitizeMediaFolder` y ampliación de extensiones soportadas para unificar almacenamiento público bajo `/media/*`. 
- Endpoint de upload unificado `app/api/admin/upload/route.ts` ahora acepta `folder` para organizar uploads por contexto, valida tipos adicionales y devuelve URLs públicas normalizadas; `app/api/upload/project-photo/route.ts` adaptado para guardar fotos de obra en `/media/projects/...`. 
- Migraciones de formularios/admin managers para usar el flujo unificado: `BrandManager`, `ProjectsManager`, `BlogManager`, `Noticias/CaseStudies`, `SiteExperienceDesigner` y el panel `operativo` (nuevo `ProjectPhotoUploader` cliente con preview). 
- Visualización y compatibilidad: las vistas de fotos de obra y proyectos usan `toPublicMediaUrl` para resolver rutas nuevas y mantener compatibilidad con `/uploads/*` existentes; no se modifica el flujo del logo si ya está funcionando. 

### Testing
- Ejecutado `npm run lint` y completó correctamente con warnings preexistentes por uso de `<img>` (no bloqueantes). 
- Ejecutado `npm run build` y la build finalizó OK; se registraron warnings relacionados con entorno/DB no inicializada en este entorno de CI pero no impidieron el build. 
- Levantado `npm run dev` y validado visualmente mediante script Playwright que inicia sesión en `/admin/login` y captura screenshot (`artifacts/admin-media-system.png`), confirmando que los formularios y previews cargan en runtime; el script terminó con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3580852008331a79b80fcd2dcd1d6)