### PR TITLE
Refactor home and commercial flow into premium 3-door experience

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/SiteExperienceDesigner.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/SiteExperienceDesigner.tsx
@@ -441,7 +441,7 @@ export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerPr
 
         <Card>
           <CardHeader>
-            <CardTitle>Hero y mensajes clave</CardTitle>
+            <CardTitle>Hero y propuesta de valor premium</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid gap-2">
@@ -623,11 +623,11 @@ export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerPr
 
         <Card>
           <CardHeader>
-            <CardTitle>Servicios y packs</CardTitle>
+            <CardTitle>Verticales, oferta destacada y sistema comercial</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid gap-2">
-              <Label htmlFor="services-title">Título de servicios</Label>
+              <Label htmlFor="services-title">Título de verticales principales</Label>
               <Input
                 id="services-title"
                 value={form.services.title}
@@ -640,7 +640,7 @@ export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerPr
               />
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="services-description">Descripción</Label>
+              <Label htmlFor="services-description">Mensaje corto de diferenciación</Label>
               <Textarea
                 id="services-description"
                 value={form.services.description}
@@ -653,7 +653,7 @@ export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerPr
               />
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="services-items">Servicios (Título | Descripción)</Label>
+              <Label htmlFor="services-items">Mundos/verticales (Título | Descripción)</Label>
               <Textarea
                 id="services-items"
                 value={servicesText}
@@ -666,7 +666,7 @@ export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerPr
               />
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="packs-title">Título de packs</Label>
+              <Label htmlFor="packs-title">Título de anexo técnico</Label>
               <Input
                 id="packs-title"
                 value={form.packs.title}
@@ -679,7 +679,7 @@ export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerPr
               />
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="packs-description">Descripción packs</Label>
+              <Label htmlFor="packs-description">Descripción de anexo técnico</Label>
               <Textarea
                 id="packs-description"
                 value={form.packs.description}
@@ -692,7 +692,7 @@ export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerPr
               />
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="packs-cta-label">CTA packs</Label>
+              <Label htmlFor="packs-cta-label">CTA de anexo técnico</Label>
               <Input
                 id="packs-cta-label"
                 value={form.packs.ctaLabel}
@@ -715,7 +715,7 @@ export function SiteExperienceDesigner({ initialData }: SiteExperienceDesignerPr
               />
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="packs-note">Nota adicional packs</Label>
+              <Label htmlFor="packs-note">Nota comercial del anexo</Label>
               <Textarea
                 id="packs-note"
                 value={form.packs.note}

--- a/nerin-electric-site-v3-fixed/app/(site)/mantenimiento/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/mantenimiento/page.tsx
@@ -1,4 +1,5 @@
 export const dynamic = 'force-dynamic'
+
 import Link from 'next/link'
 import { getMaintenancePlansForMarketing } from '@/lib/marketing-data'
 import { Badge } from '@/components/ui/badge'
@@ -12,7 +13,7 @@ export async function generateMetadata() {
   const site = await getSiteContent()
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
   const title = 'Planes de mantenimiento eléctrico | NERIN'
-  const description = 'Planes de mantenimiento eléctrico con visitas programadas, SLAs y reportes mensuales.'
+  const description = 'Mantenimiento programado con alcance fijo, frecuencia definida y reportes de seguimiento.'
 
   return {
     title,
@@ -57,22 +58,31 @@ export default async function MantenimientoPage() {
               <p className="text-sm text-slate-500">${Number(plan.precioMensual).toLocaleString('es-AR')} / mes</p>
             </CardHeader>
             <CardContent className="space-y-4 text-sm text-slate-600">
-              <p className="font-medium text-foreground">Incluye tareas fijas:</p>
+              <p className="font-medium text-foreground">Tareas incluidas:</p>
               <ul className="space-y-2">
                 {plan.incluyeTareasFijas.map((task) => (
                   <li key={task}>• {task}</li>
                 ))}
               </ul>
-              <p>{plan.visitasMes} visita(s) técnica(s) mensual(es) con checklist digital y reporte fotográfico.</p>
-              <p className="text-xs text-slate-500">
-                Cantidades inalterables: aseguramos tiempos de respuesta y disponibilidad de técnicos senior.
-              </p>
+              <p>{plan.visitasMes} visita(s) técnica(s) por mes con checklist y registro fotográfico.</p>
+              <p className="text-xs text-slate-500">Cantidades definidas y seguimiento operativo según plan acordado.</p>
               <div className="flex flex-col gap-2">
                 <Button asChild>
-                  <Link href={`/presupuesto?tipo=mantenimiento&plan=${plan.slug}`} data-track="lead" data-content-name={plan.nombre} data-plan-tier={plan.slug} data-value={Number(plan.precioMensual)} data-currency="ARS">Solicitar alta del plan</Link>
+                  <Link
+                    href={`/presupuesto?tipo=mantenimiento&plan=${plan.slug}`}
+                    data-track="lead"
+                    data-content-name={plan.nombre}
+                    data-plan-tier={plan.slug}
+                    data-value={Number(plan.precioMensual)}
+                    data-currency="ARS"
+                  >
+                    Solicitar plan
+                  </Link>
                 </Button>
                 <Button asChild variant="secondary">
-                  <Link href="/presupuesto?tipo=mantenimiento" data-track="lead" data-content-name="Hablar con un asesor">Hablar con un asesor</Link>
+                  <Link href="/presupuesto?tipo=mantenimiento" data-track="lead" data-content-name="Consulta mantenimiento">
+                    Consultar plan
+                  </Link>
                 </Button>
               </div>
             </CardContent>

--- a/nerin-electric-site-v3-fixed/app/(site)/mantenimiento/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/mantenimiento/page.tsx
@@ -12,8 +12,8 @@ export const revalidate = 60
 export async function generateMetadata() {
   const site = await getSiteContent()
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Planes de mantenimiento eléctrico | NERIN'
-  const description = 'Mantenimiento programado con alcance fijo, frecuencia definida y reportes de seguimiento.'
+  const title = 'Mantenimiento eléctrico | NERIN'
+  const description = 'Planes de mantenimiento con visitas y tareas definidas.'
 
   return {
     title,
@@ -58,31 +58,19 @@ export default async function MantenimientoPage() {
               <p className="text-sm text-slate-500">${Number(plan.precioMensual).toLocaleString('es-AR')} / mes</p>
             </CardHeader>
             <CardContent className="space-y-4 text-sm text-slate-600">
-              <p className="font-medium text-foreground">Tareas incluidas:</p>
+              <p className="font-medium text-foreground">Incluye:</p>
               <ul className="space-y-2">
                 {plan.incluyeTareasFijas.map((task) => (
                   <li key={task}>• {task}</li>
                 ))}
               </ul>
-              <p>{plan.visitasMes} visita(s) técnica(s) por mes con checklist y registro fotográfico.</p>
-              <p className="text-xs text-slate-500">Cantidades definidas y seguimiento operativo según plan acordado.</p>
+              <p>{plan.visitasMes} visita(s) por mes.</p>
               <div className="flex flex-col gap-2">
                 <Button asChild>
-                  <Link
-                    href={`/presupuesto?tipo=mantenimiento&plan=${plan.slug}`}
-                    data-track="lead"
-                    data-content-name={plan.nombre}
-                    data-plan-tier={plan.slug}
-                    data-value={Number(plan.precioMensual)}
-                    data-currency="ARS"
-                  >
-                    Solicitar plan
-                  </Link>
+                  <Link href={`/presupuesto?tipo=mantenimiento&plan=${plan.slug}`}>Solicitar plan</Link>
                 </Button>
                 <Button asChild variant="secondary">
-                  <Link href="/presupuesto?tipo=mantenimiento" data-track="lead" data-content-name="Consulta mantenimiento">
-                    Consultar plan
-                  </Link>
+                  <Link href="/contacto">Contacto</Link>
                 </Button>
               </div>
             </CardContent>
@@ -91,7 +79,7 @@ export default async function MantenimientoPage() {
       </section>
 
       <section className="rounded-3xl border border-border bg-white p-5 shadow-subtle sm:p-8 lg:p-10">
-        <h2 className="text-2xl font-semibold text-foreground">Alcance operativo</h2>
+        <h2 className="text-2xl font-semibold text-foreground">Alcance</h2>
         <div className="mt-6 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
           {site.maintenancePage.cards.map((card) => (
             <div key={card.title}>

--- a/nerin-electric-site-v3-fixed/app/(site)/packs/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/packs/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata() {
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
   const title = 'Bases técnicas de mano de obra | NERIN'
   const description =
-    'Anexo técnico de referencia para equipos que necesitan revisar bases de mano de obra. La contratación principal se inicia desde el hub NERIN.'
+    'Referencia técnica para revisar bases de mano de obra. La contratación principal se realiza desde cotización.'
 
   return {
     title,
@@ -44,14 +44,14 @@ export default async function PacksPage() {
   return (
     <div className="space-y-10">
       <header className="space-y-4 rounded-2xl border border-border bg-muted/20 p-6">
-        <Badge>Anexo técnico</Badge>
+        <Badge>Referencia técnica</Badge>
         <h1>Bases de mano de obra</h1>
         <p className="max-w-3xl text-base text-slate-600">
-          Este contenido es de apoyo para perfiles técnicos. Si querés avanzar comercialmente, volvé al sistema de
-          contratación con 3 puertas.
+          Este bloque es una referencia para revisión técnica. Si querés avanzar con contratación, usá el flujo de
+          cotización.
         </p>
         <Button asChild>
-          <Link href="/presupuestador">Volver al hub comercial</Link>
+          <Link href="/presupuestador">Ir a cotización</Link>
         </Button>
       </header>
 

--- a/nerin-electric-site-v3-fixed/app/(site)/packs/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/packs/page.tsx
@@ -12,9 +12,8 @@ export const revalidate = 60
 export async function generateMetadata() {
   const site = await getSiteContent()
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Bases técnicas de mano de obra | NERIN'
-  const description =
-    'Referencia técnica para revisar bases de mano de obra. La contratación principal se realiza desde cotización.'
+  const title = 'Packs técnicos | NERIN'
+  const description = 'Referencia de bases de mano de obra.'
 
   return {
     title,
@@ -44,14 +43,11 @@ export default async function PacksPage() {
   return (
     <div className="space-y-10">
       <header className="space-y-4 rounded-2xl border border-border bg-muted/20 p-6">
-        <Badge>Referencia técnica</Badge>
+        <Badge>Packs técnicos</Badge>
         <h1>Bases de mano de obra</h1>
-        <p className="max-w-3xl text-base text-slate-600">
-          Este bloque es una referencia para revisión técnica. Si querés avanzar con contratación, usá el flujo de
-          cotización.
-        </p>
+        <p className="max-w-3xl text-base text-slate-600">Esta página es una referencia técnica.</p>
         <Button asChild>
-          <Link href="/presupuestador">Ir a cotización</Link>
+          <Link href="/presupuestador">Iniciar cotización</Link>
         </Button>
       </header>
 

--- a/nerin-electric-site-v3-fixed/app/(site)/packs/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/packs/page.tsx
@@ -1,4 +1,5 @@
 export const dynamic = 'force-dynamic'
+
 import Link from 'next/link'
 import { getPacksForMarketing } from '@/lib/marketing-data'
 import { Button } from '@/components/ui/button'
@@ -13,7 +14,7 @@ export async function generateMetadata() {
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
   const title = 'Bases técnicas de mano de obra | NERIN'
   const description =
-    'Referencia técnica de bases de mano de obra para instalación eléctrica. Para contratar, usar el hub de cotización.'
+    'Anexo técnico de referencia para equipos que necesitan revisar bases de mano de obra. La contratación principal se inicia desde el hub NERIN.'
 
   return {
     title,
@@ -41,20 +42,20 @@ export default async function PacksPage() {
   const packs = await getPacksForMarketing()
 
   return (
-    <div className="space-y-12">
-      <header className="space-y-5">
-        <Badge>Referencia técnica</Badge>
-        <h1>Bases de mano de obra (uso técnico)</h1>
-        <p className="max-w-3xl text-lg text-slate-600">
-          Este contenido es complementario para quienes quieren revisar bases prearmadas. La contratación principal de
-          NERIN se organiza desde el hub de cotización por tipo de necesidad.
+    <div className="space-y-10">
+      <header className="space-y-4 rounded-2xl border border-border bg-muted/20 p-6">
+        <Badge>Anexo técnico</Badge>
+        <h1>Bases de mano de obra</h1>
+        <p className="max-w-3xl text-base text-slate-600">
+          Este contenido es de apoyo para perfiles técnicos. Si querés avanzar comercialmente, volvé al sistema de
+          contratación con 3 puertas.
         </p>
-        <Button asChild size="lg">
-          <Link href="/presupuestador">Ir al hub de cotización</Link>
+        <Button asChild>
+          <Link href="/presupuestador">Volver al hub comercial</Link>
         </Button>
       </header>
 
-      <section className="grid gap-6">
+      <section className="grid gap-5">
         {packs.map((pack) => (
           <Card key={pack.id} id={pack.slug} className="scroll-mt-32">
             <CardHeader>
@@ -68,26 +69,16 @@ export default async function PacksPage() {
                 </p>
               </div>
             </CardHeader>
-            <CardContent className="space-y-4 text-sm text-slate-600">
+            <CardContent className="space-y-3 text-sm text-slate-600">
               <p>{pack.scope}</p>
               <ul className="grid gap-2 sm:grid-cols-2">
-                {pack.features.map((item) => (
+                {pack.features.slice(0, 4).map((item) => (
                   <li key={item}>• {item}</li>
                 ))}
               </ul>
             </CardContent>
           </Card>
         ))}
-      </section>
-
-      <section className="rounded-2xl border border-border bg-muted/40 p-6">
-        <p className="text-sm text-muted-foreground">
-          ¿Querés avanzar con una propuesta comercial? Definí si necesitás servicio puntual, obra guiada o cotización
-          profesional.
-        </p>
-        <Button className="mt-4" variant="secondary" asChild>
-          <Link href="/presupuestador">Volver al presupuestador</Link>
-        </Button>
       </section>
     </div>
   )

--- a/nerin-electric-site-v3-fixed/app/(site)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/page.tsx
@@ -6,16 +6,15 @@ import { getMarketingHomeData } from '@/lib/marketing-data'
 import { getSiteContent } from '@/lib/site-content'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 export const revalidate = 60
 
 export async function generateMetadata() {
   const site = await getSiteContent()
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Contratista eléctrico en CABA | Presupuestos en 24-48 h'
+  const title = 'NERIN | Ejecución eléctrica premium para espacios exigentes'
   const description =
-    'Contratista eléctrico para obras, comercios y consorcios en CABA. Presupuesto en 24–48 h, cumplimiento normativo y experiencia real en obra.'
+    'NERIN eleva viviendas, locales y operaciones corporativas con ejecución eléctrica premium. Contratá por servicio puntual, relevamiento o cotización profesional.'
 
   return {
     title,
@@ -39,134 +38,135 @@ export async function generateMetadata() {
   }
 }
 
-const mainPaths = [
+const worlds = [
   {
-    title: 'Contratar servicio puntual',
-    description: 'Resolvé trabajos directos como diagnóstico premium, artefactos o circuito dedicado para AA.',
-    cta: 'Ir a servicio puntual',
-    href: '/presupuestador?mode=EXPRESS',
-  },
-  {
-    title: 'Cotizar instalación / obra',
-    description: 'Para reformas, locales, oficinas o viviendas con definición técnica y relevamiento previo.',
-    cta: 'Iniciar cotización guiada',
+    title: 'Residencial premium',
+    description: 'Casas y unidades de alta exigencia donde diseño, seguridad y terminación deben convivir.',
     href: '/presupuestador?mode=ASSISTED',
   },
   {
-    title: 'Cotizador profesional',
-    description: 'Carga manual para perfiles técnicos con cantidades por rubro y estimación de obra.',
-    cta: 'Abrir cotizador profesional',
+    title: 'Comercial · gastronómico · eventos',
+    description: 'Espacios que venden experiencia y necesitan ejecución limpia, rápida y sin improvisación.',
+    href: '/presupuestador?mode=ASSISTED',
+  },
+  {
+    title: 'Obras y mantenimiento corporativo',
+    description: 'Operaciones con continuidad crítica, trazabilidad técnica y coordinación profesional.',
+    href: '/presupuestador?mode=PROFESSIONAL',
+  },
+]
+
+const brandReasons = [
+  'Dirección técnica + ejecución con estándar premium.',
+  'Menos ruido operativo, más control y previsibilidad.',
+  'Comunicación clara para decidir rápido y bien.',
+]
+
+const hiringFlow = [
+  {
+    title: '1. Resolver algo puntual',
+    description: 'Ingresás, elegís el servicio y avanzás en minutos.',
+    href: '/presupuestador?mode=EXPRESS',
+  },
+  {
+    title: '2. Pedir relevamiento/proyecto',
+    description: 'Definimos alcance real para una propuesta seria.',
+    href: '/presupuesto?tipo=obra',
+  },
+  {
+    title: '3. Cotización profesional',
+    description: 'Cargás plano/cantidades y recibís una base comercial ordenada.',
     href: '/presupuestador?mode=PROFESSIONAL',
   },
 ]
 
 export default async function HomePage() {
-  const { packs, caseStudies } = await getMarketingHomeData()
+  const { caseStudies } = await getMarketingHomeData()
   const site = await getSiteContent()
 
   return (
     <div className="space-y-14 sm:space-y-16 lg:space-y-20">
-      <section className="grid gap-8 lg:grid-cols-[1.1fr_1fr] lg:gap-10">
-        <div className="space-y-5 sm:space-y-6">
-          <Badge>{site.hero.badge}</Badge>
-          <h1>Instalaciones eléctricas con criterio comercial y ejecución profesional</h1>
-          <p className="max-w-2xl text-lg text-muted-foreground">
-            Elegí el camino correcto según tu necesidad: contratación directa, cotización de obra con relevamiento o
-            carga técnica profesional. Sin confusión ni vueltas.
-          </p>
-          <div className="flex flex-wrap gap-4">
-            <Button size="lg" asChild>
-              <Link href="/presupuestador">Empezar cotización</Link>
-            </Button>
-            <Button size="lg" variant="secondary" asChild>
-              <Link href="/presupuesto?tipo=obra">Solicitar relevamiento</Link>
-            </Button>
+      <section className="relative overflow-hidden rounded-3xl border border-border bg-[#0B0F14] px-6 py-10 text-white sm:px-8 sm:py-14">
+        <Image
+          src={site.hero.backgroundImage}
+          alt={site.hero.caption}
+          fill
+          className="pointer-events-none object-cover opacity-30"
+        />
+        <div className="relative z-10 grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:items-end">
+          <div className="space-y-5">
+            <Badge className="bg-white/10 text-white">NERIN Premium Electric</Badge>
+            <h1 className="max-w-2xl text-3xl font-semibold leading-tight text-white sm:text-4xl lg:text-5xl">
+              La ejecución eléctrica que eleva la categoría de tu espacio
+            </h1>
+            <p className="max-w-xl text-base text-slate-200 sm:text-lg">
+              No vendemos confusión. Diseñamos y ejecutamos con foco en impacto, seguridad y resultado comercial.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Button size="lg" asChild>
+                <Link href="/presupuestador">Quiero cotizar con NERIN</Link>
+              </Button>
+              <Button size="lg" variant="secondary" asChild>
+                <Link href="/presupuesto?tipo=obra">Solicitar relevamiento</Link>
+              </Button>
+            </div>
           </div>
-        </div>
-        <div className="relative hidden overflow-hidden rounded-[var(--radius)] border border-border lg:block">
-          <Image src={site.hero.backgroundImage} alt={site.hero.caption} fill className="object-cover" />
-          <div className="absolute inset-0 bg-gradient-to-l from-[#0B0F14]/70 via-transparent to-transparent" />
-          <div className="absolute bottom-6 left-6 right-6 border border-white/30 bg-[#0B0F14]/80 p-4 text-xs text-slate-200">
-            <p className="font-semibold text-white">{site.hero.caption}</p>
-            <p>{site.contact.serviceArea}</p>
+          <div className="rounded-2xl border border-white/20 bg-white/5 p-5 backdrop-blur">
+            <p className="text-sm uppercase tracking-[0.3em] text-slate-300">Cobertura</p>
+            <p className="mt-2 text-lg font-semibold">{site.contact.serviceArea}</p>
+            <p className="mt-3 text-sm text-slate-200">{site.hero.caption}</p>
           </div>
         </div>
       </section>
 
       <section className="space-y-6">
         <div className="max-w-2xl space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Tres caminos claros</p>
-          <h2>Elegí tu forma de contratación</h2>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Tres mundos</p>
+          <h2>Elegí tu contexto, no una lista infinita de servicios</h2>
         </div>
-        <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-          {mainPaths.map((path) => (
-            <Card key={path.title}>
-              <CardHeader>
-                <CardTitle>{path.title}</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4 text-sm text-slate-600">
-                <p>{path.description}</p>
-                <Button variant="secondary" asChild>
-                  <a href={path.href}>{path.cta}</a>
-                </Button>
-              </CardContent>
-            </Card>
+        <div className="grid gap-4 lg:grid-cols-3">
+          {worlds.map((world) => (
+            <article key={world.title} className="rounded-2xl border border-border bg-white p-5">
+              <h3 className="text-lg font-semibold">{world.title}</h3>
+              <p className="mt-2 text-sm text-muted-foreground">{world.description}</p>
+              <Button variant="ghost" className="mt-4 px-0" asChild>
+                <a href={world.href}>Ver camino</a>
+              </Button>
+            </article>
           ))}
         </div>
       </section>
 
-      <section className="space-y-8">
-        <div className="max-w-2xl space-y-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Servicios destacados</p>
-          <h2>Servicios puntuales más solicitados</h2>
+      <section className="grid gap-8 lg:grid-cols-[1fr_1.2fr] lg:items-start">
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Por qué NERIN</p>
+          <h2>Menos promesa. Más estándar.</h2>
+          <p className="text-sm text-muted-foreground">
+            NERIN se contrata cuando la electricidad no puede quedar librada al azar ni a múltiples interlocutores.
+          </p>
         </div>
-        <div className="grid gap-4 sm:grid-cols-2">
-          {[
-            'Diagnóstico eléctrico premium',
-            'Colocación de artefactos',
-            'Circuito dedicado para aire acondicionado',
-            'Adecuación básica de tablero',
-            'Revisión eléctrica integral',
-            'Mantenimiento puntual',
-          ].map((item) => (
-            <div key={item} className="rounded-2xl border border-border bg-white p-4 text-sm text-slate-600">
-              <p className="font-semibold text-foreground">{item}</p>
-            </div>
+        <ul className="grid gap-3">
+          {brandReasons.map((reason) => (
+            <li key={reason} className="rounded-2xl border border-border bg-muted/20 px-5 py-4 text-sm font-medium">
+              {reason}
+            </li>
           ))}
-        </div>
+        </ul>
       </section>
 
-      <section className="relative -mx-4 bg-[#0B0F14] px-4 py-12 text-white sm:-mx-5 sm:px-5 lg:-mx-6 lg:px-6 xl:-mx-10 xl:px-10">
-        <div className="mx-auto max-w-[var(--container)] space-y-8">
-          <div className="max-w-2xl space-y-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-[#FBBF24]">Cobertura premium</p>
-            <h2 className="text-white">Atención técnica en zonas priorizadas</h2>
-            <p className="text-slate-200">{site.contact.serviceArea}. Coordinamos visitas y ejecución con agenda comercial en 24–48 h.</p>
-          </div>
-          <div className="grid gap-4 md:grid-cols-3">
-            {site.trust.gallery.slice(0, 3).map((item) => (
-              <div key={item.title} className="border border-white/15 bg-white/5 p-5">
-                <p className="text-sm font-semibold text-white">{item.title}</p>
-                <p className="mt-2 text-sm text-slate-300">{item.description}</p>
-              </div>
-            ))}
-          </div>
+      <section className="space-y-6">
+        <div className="max-w-2xl space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Casos</p>
+          <h2>Resultados que proyectan valor de marca</h2>
         </div>
-      </section>
-
-      <section className="space-y-8">
-        <div className="max-w-2xl space-y-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Experiencia y confianza</p>
-          <h2>Resultados en obra y ejecución real</h2>
-        </div>
-        <div className="grid gap-6 md:grid-cols-2">
+        <div className="grid gap-5 md:grid-cols-2">
           {caseStudies.slice(0, 2).map((cs) => (
-            <article key={cs.id} className="overflow-hidden rounded-[var(--radius)] border border-border bg-white">
-              <div className="relative h-48 w-full">
+            <article key={cs.id} className="overflow-hidden rounded-2xl border border-border bg-white">
+              <div className="relative h-56 w-full">
                 <Image src={cs.fotos[0] ?? site.hero.backgroundImage} alt={cs.titulo} fill className="object-cover" />
               </div>
               <div className="space-y-3 p-5">
-                <h3 className="text-lg font-semibold text-foreground">{cs.titulo}</h3>
+                <h3 className="text-lg font-semibold">{cs.titulo}</h3>
                 <p className="text-sm text-muted-foreground">{cs.resumen}</p>
               </div>
             </article>
@@ -174,21 +174,35 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="rounded-3xl border border-border bg-muted/40 p-5 sm:p-6">
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+      <section className="space-y-6 rounded-3xl border border-border bg-muted/30 p-6 sm:p-8">
+        <div className="max-w-2xl space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Contratación clara</p>
+          <h2>Entrá por la puerta correcta</h2>
+        </div>
+        <div className="grid gap-4 lg:grid-cols-3">
+          {hiringFlow.map((step) => (
+            <article key={step.title} className="rounded-2xl border border-border bg-white p-5">
+              <h3 className="font-semibold">{step.title}</h3>
+              <p className="mt-2 text-sm text-muted-foreground">{step.description}</p>
+              <Button variant="ghost" className="mt-4 px-0" asChild>
+                <a href={step.href}>Continuar</a>
+              </Button>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-3xl bg-[#0B0F14] px-6 py-10 text-white sm:px-8">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
           <div className="space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Contenido técnico</p>
-            <h3 className="text-xl font-semibold">Packs como referencia interna de alcance</h3>
-            <p className="text-sm text-muted-foreground">
-              Los packs siguen disponibles para clientes que quieren comparar bases de mano de obra, pero ya no son la
-              puerta principal de contratación.
-            </p>
+            <p className="text-xs uppercase tracking-[0.35em] text-[#FBBF24]">Siguiente paso</p>
+            <h2 className="text-white">Si querés hacerlo bien, ya sabés con quién</h2>
+            <p className="text-sm text-slate-300">Coordiná hoy y recibí respuesta comercial en 24–48 h.</p>
           </div>
-          <Button variant="ghost" asChild>
-            <Link href="/packs">Ver packs técnicos</Link>
+          <Button size="lg" asChild>
+            <Link href="/presupuestador">Iniciar contratación con NERIN</Link>
           </Button>
         </div>
-        {packs[0] && <p className="mt-4 text-sm text-muted-foreground">Referencia base actual: {packs[0].name}.</p>}
       </section>
     </div>
   )

--- a/nerin-electric-site-v3-fixed/app/(site)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/page.tsx
@@ -12,9 +12,9 @@ export const revalidate = 60
 export async function generateMetadata() {
   const site = await getSiteContent()
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'NERIN | Ejecución eléctrica premium para espacios exigentes'
+  const title = 'NERIN | Instalaciones eléctricas con alcance claro y ejecución ordenada'
   const description =
-    'NERIN eleva viviendas, locales y operaciones corporativas con ejecución eléctrica premium. Contratá por servicio puntual, relevamiento o cotización profesional.'
+    'Instalaciones, relevamientos y cotización técnica para viviendas, locales y operaciones corporativas. NERIN trabaja con alcance definido y coordinación previa.'
 
   return {
     title,
@@ -40,42 +40,42 @@ export async function generateMetadata() {
 
 const worlds = [
   {
-    title: 'Residencial premium',
-    description: 'Casas y unidades de alta exigencia donde diseño, seguridad y terminación deben convivir.',
+    title: 'Residencial',
+    description: 'Viviendas y reformas con definición de alcance antes de ejecutar.',
     href: '/presupuestador?mode=ASSISTED',
   },
   {
-    title: 'Comercial · gastronómico · eventos',
-    description: 'Espacios que venden experiencia y necesitan ejecución limpia, rápida y sin improvisación.',
+    title: 'Comercial y gastronómico',
+    description: 'Locales y espacios de atención al público con coordinación por etapas.',
     href: '/presupuestador?mode=ASSISTED',
   },
   {
-    title: 'Obras y mantenimiento corporativo',
-    description: 'Operaciones con continuidad crítica, trazabilidad técnica y coordinación profesional.',
+    title: 'Obras y operación corporativa',
+    description: 'Trabajos técnicos con prioridad en continuidad, seguridad y trazabilidad.',
     href: '/presupuestador?mode=PROFESSIONAL',
   },
 ]
 
 const brandReasons = [
-  'Dirección técnica + ejecución con estándar premium.',
-  'Menos ruido operativo, más control y previsibilidad.',
-  'Comunicación clara para decidir rápido y bien.',
+  'Alcance y criterios técnicos definidos antes de iniciar.',
+  'Coordinación con cliente, obra y proveedores para evitar desvíos.',
+  'Adicionales y cambios validados antes de ejecutar.',
 ]
 
 const hiringFlow = [
   {
-    title: '1. Resolver algo puntual',
-    description: 'Ingresás, elegís el servicio y avanzás en minutos.',
+    title: '1. Servicio puntual',
+    description: 'Para resolver tareas concretas con contratación directa.',
     href: '/presupuestador?mode=EXPRESS',
   },
   {
-    title: '2. Pedir relevamiento/proyecto',
-    description: 'Definimos alcance real para una propuesta seria.',
+    title: '2. Relevamiento o proyecto',
+    description: 'Para obras y reformas que requieren diagnóstico técnico previo.',
     href: '/presupuesto?tipo=obra',
   },
   {
-    title: '3. Cotización profesional',
-    description: 'Cargás plano/cantidades y recibís una base comercial ordenada.',
+    title: '3. Cotización por plano/cantidades',
+    description: 'Para estudios y equipos técnicos que necesitan una base ordenada.',
     href: '/presupuestador?mode=PROFESSIONAL',
   },
 ]
@@ -95,16 +95,16 @@ export default async function HomePage() {
         />
         <div className="relative z-10 grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:items-end">
           <div className="space-y-5">
-            <Badge className="bg-white/10 text-white">NERIN Premium Electric</Badge>
+            <Badge className="bg-white/10 text-white">NERIN · Instalaciones eléctricas</Badge>
             <h1 className="max-w-2xl text-3xl font-semibold leading-tight text-white sm:text-4xl lg:text-5xl">
-              La ejecución eléctrica que eleva la categoría de tu espacio
+              Ejecución eléctrica con criterio técnico y coordinación ordenada
             </h1>
             <p className="max-w-xl text-base text-slate-200 sm:text-lg">
-              No vendemos confusión. Diseñamos y ejecutamos con foco en impacto, seguridad y resultado comercial.
+              Definimos alcance, método de trabajo y tiempos antes de empezar. Así se reduce la improvisación en obra.
             </p>
             <div className="flex flex-wrap gap-3">
               <Button size="lg" asChild>
-                <Link href="/presupuestador">Quiero cotizar con NERIN</Link>
+                <Link href="/presupuestador">Iniciar cotización</Link>
               </Button>
               <Button size="lg" variant="secondary" asChild>
                 <Link href="/presupuesto?tipo=obra">Solicitar relevamiento</Link>
@@ -112,7 +112,7 @@ export default async function HomePage() {
             </div>
           </div>
           <div className="rounded-2xl border border-white/20 bg-white/5 p-5 backdrop-blur">
-            <p className="text-sm uppercase tracking-[0.3em] text-slate-300">Cobertura</p>
+            <p className="text-sm uppercase tracking-[0.3em] text-slate-300">Zona de trabajo</p>
             <p className="mt-2 text-lg font-semibold">{site.contact.serviceArea}</p>
             <p className="mt-3 text-sm text-slate-200">{site.hero.caption}</p>
           </div>
@@ -121,8 +121,8 @@ export default async function HomePage() {
 
       <section className="space-y-6">
         <div className="max-w-2xl space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Tres mundos</p>
-          <h2>Elegí tu contexto, no una lista infinita de servicios</h2>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Dónde trabajamos</p>
+          <h2>Tres contextos de trabajo bien definidos</h2>
         </div>
         <div className="grid gap-4 lg:grid-cols-3">
           {worlds.map((world) => (
@@ -130,7 +130,7 @@ export default async function HomePage() {
               <h3 className="text-lg font-semibold">{world.title}</h3>
               <p className="mt-2 text-sm text-muted-foreground">{world.description}</p>
               <Button variant="ghost" className="mt-4 px-0" asChild>
-                <a href={world.href}>Ver camino</a>
+                <a href={world.href}>Ver opción</a>
               </Button>
             </article>
           ))}
@@ -139,10 +139,10 @@ export default async function HomePage() {
 
       <section className="grid gap-8 lg:grid-cols-[1fr_1.2fr] lg:items-start">
         <div className="space-y-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Por qué NERIN</p>
-          <h2>Menos promesa. Más estándar.</h2>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Cómo trabajamos</p>
+          <h2>Definición previa para ejecutar sin desorden</h2>
           <p className="text-sm text-muted-foreground">
-            NERIN se contrata cuando la electricidad no puede quedar librada al azar ni a múltiples interlocutores.
+            Nuestro foco está en ordenar el trabajo desde el inicio y sostener el criterio técnico durante toda la ejecución.
           </p>
         </div>
         <ul className="grid gap-3">
@@ -156,8 +156,8 @@ export default async function HomePage() {
 
       <section className="space-y-6">
         <div className="max-w-2xl space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Casos</p>
-          <h2>Resultados que proyectan valor de marca</h2>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Casos recientes</p>
+          <h2>Trabajos ejecutados con alcance definido</h2>
         </div>
         <div className="grid gap-5 md:grid-cols-2">
           {caseStudies.slice(0, 2).map((cs) => (
@@ -176,8 +176,8 @@ export default async function HomePage() {
 
       <section className="space-y-6 rounded-3xl border border-border bg-muted/30 p-6 sm:p-8">
         <div className="max-w-2xl space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Contratación clara</p>
-          <h2>Entrá por la puerta correcta</h2>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Contratación</p>
+          <h2>Elegí el canal según tu necesidad</h2>
         </div>
         <div className="grid gap-4 lg:grid-cols-3">
           {hiringFlow.map((step) => (
@@ -195,12 +195,12 @@ export default async function HomePage() {
       <section className="rounded-3xl bg-[#0B0F14] px-6 py-10 text-white sm:px-8">
         <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
           <div className="space-y-2">
-            <p className="text-xs uppercase tracking-[0.35em] text-[#FBBF24]">Siguiente paso</p>
-            <h2 className="text-white">Si querés hacerlo bien, ya sabés con quién</h2>
-            <p className="text-sm text-slate-300">Coordiná hoy y recibí respuesta comercial en 24–48 h.</p>
+            <p className="text-xs uppercase tracking-[0.35em] text-[#FBBF24]">Contacto comercial</p>
+            <h2 className="text-white">Si tenés un trabajo serio, coordinamos alcance y próximos pasos</h2>
+            <p className="text-sm text-slate-300">Respuesta inicial en 24–48 h hábiles.</p>
           </div>
           <Button size="lg" asChild>
-            <Link href="/presupuestador">Iniciar contratación con NERIN</Link>
+            <Link href="/presupuestador">Iniciar cotización</Link>
           </Button>
         </div>
       </section>

--- a/nerin-electric-site-v3-fixed/app/(site)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/page.tsx
@@ -12,9 +12,8 @@ export const revalidate = 60
 export async function generateMetadata() {
   const site = await getSiteContent()
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'NERIN | Instalaciones eléctricas con alcance claro y ejecución ordenada'
-  const description =
-    'Instalaciones, relevamientos y cotización técnica para viviendas, locales y operaciones corporativas. NERIN trabaja con alcance definido y coordinación previa.'
+  const title = 'Contratista eléctrico en CABA y GBA | NERIN'
+  const description = 'Servicios, mantenimiento y trabajos eléctricos para viviendas, comercios y obras.'
 
   return {
     title,
@@ -40,42 +39,42 @@ export async function generateMetadata() {
 
 const worlds = [
   {
-    title: 'Residencial',
-    description: 'Viviendas y reformas con definición de alcance antes de ejecutar.',
+    title: 'Viviendas',
+    description: 'Instalaciones, arreglos y reformas eléctricas en casas y departamentos.',
     href: '/presupuestador?mode=ASSISTED',
   },
   {
-    title: 'Comercial y gastronómico',
-    description: 'Locales y espacios de atención al público con coordinación por etapas.',
+    title: 'Comercios',
+    description: 'Trabajos para locales, oficinas y espacios de atención al público.',
     href: '/presupuestador?mode=ASSISTED',
   },
   {
-    title: 'Obras y operación corporativa',
-    description: 'Trabajos técnicos con prioridad en continuidad, seguridad y trazabilidad.',
+    title: 'Obras',
+    description: 'Cotización para obra nueva, ampliaciones y mantenimiento técnico.',
     href: '/presupuestador?mode=PROFESSIONAL',
   },
 ]
 
-const brandReasons = [
-  'Alcance y criterios técnicos definidos antes de iniciar.',
-  'Coordinación con cliente, obra y proveedores para evitar desvíos.',
-  'Adicionales y cambios validados antes de ejecutar.',
+const workSteps = [
+  'Revisamos el pedido y el tipo de trabajo.',
+  'Definimos alcance y forma de trabajo antes de empezar.',
+  'Ejecutamos y dejamos registro de lo realizado.',
 ]
 
 const hiringFlow = [
   {
-    title: '1. Servicio puntual',
-    description: 'Para resolver tareas concretas con contratación directa.',
+    title: 'Servicio puntual',
+    description: 'Para resolver algo concreto.',
     href: '/presupuestador?mode=EXPRESS',
   },
   {
-    title: '2. Relevamiento o proyecto',
-    description: 'Para obras y reformas que requieren diagnóstico técnico previo.',
+    title: 'Relevamiento',
+    description: 'Para obras o trabajos más grandes.',
     href: '/presupuesto?tipo=obra',
   },
   {
-    title: '3. Cotización por plano/cantidades',
-    description: 'Para estudios y equipos técnicos que necesitan una base ordenada.',
+    title: 'Cotización técnica',
+    description: 'Para cotizar por plano o cantidades.',
     href: '/presupuestador?mode=PROFESSIONAL',
   },
 ]
@@ -95,12 +94,12 @@ export default async function HomePage() {
         />
         <div className="relative z-10 grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:items-end">
           <div className="space-y-5">
-            <Badge className="bg-white/10 text-white">NERIN · Instalaciones eléctricas</Badge>
+            <Badge className="bg-white/10 text-white">NERIN</Badge>
             <h1 className="max-w-2xl text-3xl font-semibold leading-tight text-white sm:text-4xl lg:text-5xl">
-              Ejecución eléctrica con criterio técnico y coordinación ordenada
+              Contratista eléctrico en CABA y GBA
             </h1>
             <p className="max-w-xl text-base text-slate-200 sm:text-lg">
-              Definimos alcance, método de trabajo y tiempos antes de empezar. Así se reduce la improvisación en obra.
+              Servicios, mantenimiento y trabajos eléctricos para viviendas, comercios y obras.
             </p>
             <div className="flex flex-wrap gap-3">
               <Button size="lg" asChild>
@@ -114,15 +113,14 @@ export default async function HomePage() {
           <div className="rounded-2xl border border-white/20 bg-white/5 p-5 backdrop-blur">
             <p className="text-sm uppercase tracking-[0.3em] text-slate-300">Zona de trabajo</p>
             <p className="mt-2 text-lg font-semibold">{site.contact.serviceArea}</p>
-            <p className="mt-3 text-sm text-slate-200">{site.hero.caption}</p>
           </div>
         </div>
       </section>
 
       <section className="space-y-6">
         <div className="max-w-2xl space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Dónde trabajamos</p>
-          <h2>Tres contextos de trabajo bien definidos</h2>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Qué hacemos</p>
+          <h2>Tipos de trabajo</h2>
         </div>
         <div className="grid gap-4 lg:grid-cols-3">
           {worlds.map((world) => (
@@ -130,7 +128,7 @@ export default async function HomePage() {
               <h3 className="text-lg font-semibold">{world.title}</h3>
               <p className="mt-2 text-sm text-muted-foreground">{world.description}</p>
               <Button variant="ghost" className="mt-4 px-0" asChild>
-                <a href={world.href}>Ver opción</a>
+                <a href={world.href}>Continuar</a>
               </Button>
             </article>
           ))}
@@ -140,15 +138,12 @@ export default async function HomePage() {
       <section className="grid gap-8 lg:grid-cols-[1fr_1.2fr] lg:items-start">
         <div className="space-y-3">
           <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Cómo trabajamos</p>
-          <h2>Definición previa para ejecutar sin desorden</h2>
-          <p className="text-sm text-muted-foreground">
-            Nuestro foco está en ordenar el trabajo desde el inicio y sostener el criterio técnico durante toda la ejecución.
-          </p>
+          <h2>Proceso simple</h2>
         </div>
         <ul className="grid gap-3">
-          {brandReasons.map((reason) => (
-            <li key={reason} className="rounded-2xl border border-border bg-muted/20 px-5 py-4 text-sm font-medium">
-              {reason}
+          {workSteps.map((step) => (
+            <li key={step} className="rounded-2xl border border-border bg-muted/20 px-5 py-4 text-sm font-medium">
+              {step}
             </li>
           ))}
         </ul>
@@ -156,8 +151,8 @@ export default async function HomePage() {
 
       <section className="space-y-6">
         <div className="max-w-2xl space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Casos recientes</p>
-          <h2>Trabajos ejecutados con alcance definido</h2>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Casos</p>
+          <h2>Trabajos recientes</h2>
         </div>
         <div className="grid gap-5 md:grid-cols-2">
           {caseStudies.slice(0, 2).map((cs) => (
@@ -172,12 +167,15 @@ export default async function HomePage() {
             </article>
           ))}
         </div>
+        <Button variant="secondary" asChild>
+          <Link href="/obras">Ver casos</Link>
+        </Button>
       </section>
 
       <section className="space-y-6 rounded-3xl border border-border bg-muted/30 p-6 sm:p-8">
         <div className="max-w-2xl space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Contratación</p>
-          <h2>Elegí el canal según tu necesidad</h2>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Cómo contratar</p>
+          <h2>Elegí una opción</h2>
         </div>
         <div className="grid gap-4 lg:grid-cols-3">
           {hiringFlow.map((step) => (
@@ -195,12 +193,11 @@ export default async function HomePage() {
       <section className="rounded-3xl bg-[#0B0F14] px-6 py-10 text-white sm:px-8">
         <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
           <div className="space-y-2">
-            <p className="text-xs uppercase tracking-[0.35em] text-[#FBBF24]">Contacto comercial</p>
-            <h2 className="text-white">Si tenés un trabajo serio, coordinamos alcance y próximos pasos</h2>
-            <p className="text-sm text-slate-300">Respuesta inicial en 24–48 h hábiles.</p>
+            <p className="text-xs uppercase tracking-[0.35em] text-[#FBBF24]">Contacto</p>
+            <h2 className="text-white">¿Necesitás una cotización?</h2>
           </div>
           <Button size="lg" asChild>
-            <Link href="/presupuestador">Iniciar cotización</Link>
+            <Link href="/contacto">Contacto</Link>
           </Button>
         </div>
       </section>

--- a/nerin-electric-site-v3-fixed/app/(site)/presupuestador/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/presupuestador/page.tsx
@@ -10,9 +10,9 @@ export const revalidate = 60
 
 export async function generateMetadata() {
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Contratación NERIN | Servicio puntual, relevamiento o cotización profesional'
+  const title = 'Cotización NERIN | Servicio puntual, relevamiento o cotización técnica'
   const description =
-    'Ingresá por una de las 3 puertas de NERIN: resolver algo puntual, pedir relevamiento o cotizar por plano/cantidades.'
+    'Elegí el ingreso correcto: servicio puntual, relevamiento para obra o cotización técnica por plano/cantidades.'
 
   return {
     title,
@@ -37,18 +37,18 @@ export async function generateMetadata() {
 
 const doors = [
   {
-    title: 'Resolver algo puntual',
-    description: 'Para necesidades inmediatas con alcance claro.',
+    title: 'Servicio puntual',
+    description: 'Para resolver una necesidad concreta con contratación directa.',
     href: '/presupuestador?mode=EXPRESS',
   },
   {
-    title: 'Pedir relevamiento/proyecto',
-    description: 'Para obras y reformas con definición técnica.',
+    title: 'Relevamiento / proyecto',
+    description: 'Para obras o reformas que necesitan diagnóstico previo.',
     href: '/presupuesto?tipo=obra',
   },
   {
-    title: 'Cotización profesional',
-    description: 'Para perfiles técnicos con plano y cantidades.',
+    title: 'Cotización técnica',
+    description: 'Para profesionales que cotizan por plano o cantidades.',
     href: '/presupuestador?mode=PROFESSIONAL',
   },
 ]
@@ -84,10 +84,10 @@ export default async function PresupuestadorPage({
   return (
     <div className="space-y-8 sm:space-y-10">
       <header className="space-y-4">
-        <Badge>Sistema comercial NERIN</Badge>
-        <h1>Una contratación clara en 3 puertas</h1>
+        <Badge>Cotización y contratación</Badge>
+        <h1>Entrá por la puerta correcta</h1>
         <p className="max-w-3xl text-lg text-slate-600">
-          Elegí el contexto correcto y avanzá con una propuesta ordenada. Sin calculadoras confusas ni desvíos.
+          Cada tipo de trabajo requiere un proceso distinto. Elegí el canal adecuado y avanzamos con una propuesta clara.
         </p>
       </header>
 
@@ -97,7 +97,7 @@ export default async function PresupuestadorPage({
             <h2 className="text-base font-semibold">{door.title}</h2>
             <p className="mt-2 text-sm text-muted-foreground">{door.description}</p>
             <Button variant="ghost" className="mt-4 px-0" asChild>
-              <a href={door.href}>Entrar</a>
+              <a href={door.href}>Ingresar</a>
             </Button>
           </article>
         ))}

--- a/nerin-electric-site-v3-fixed/app/(site)/presupuestador/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/presupuestador/page.tsx
@@ -1,6 +1,5 @@
 export const dynamic = 'force-dynamic'
 
-import Link from 'next/link'
 import { getConfiguratorData } from '@/lib/marketing-data'
 import { Badge } from '@/components/ui/badge'
 import { ConfiguratorWizard } from '@/components/configurator/ConfiguratorWizard'
@@ -10,9 +9,8 @@ export const revalidate = 60
 
 export async function generateMetadata() {
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Cotización NERIN | Servicio puntual, relevamiento o cotización técnica'
-  const description =
-    'Elegí el ingreso correcto: servicio puntual, relevamiento para obra o cotización técnica por plano/cantidades.'
+  const title = 'Cotización | NERIN'
+  const description = 'Elegí servicio puntual, relevamiento o cotización técnica.'
 
   return {
     title,
@@ -38,17 +36,17 @@ export async function generateMetadata() {
 const doors = [
   {
     title: 'Servicio puntual',
-    description: 'Para resolver una necesidad concreta con contratación directa.',
+    description: 'Para resolver un trabajo concreto.',
     href: '/presupuestador?mode=EXPRESS',
   },
   {
-    title: 'Relevamiento / proyecto',
-    description: 'Para obras o reformas que necesitan diagnóstico previo.',
+    title: 'Relevamiento',
+    description: 'Para obras o trabajos más grandes.',
     href: '/presupuesto?tipo=obra',
   },
   {
     title: 'Cotización técnica',
-    description: 'Para profesionales que cotizan por plano o cantidades.',
+    description: 'Para cotizar por plano o cantidades.',
     href: '/presupuestador?mode=PROFESSIONAL',
   },
 ]
@@ -84,11 +82,9 @@ export default async function PresupuestadorPage({
   return (
     <div className="space-y-8 sm:space-y-10">
       <header className="space-y-4">
-        <Badge>Cotización y contratación</Badge>
-        <h1>Entrá por la puerta correcta</h1>
-        <p className="max-w-3xl text-lg text-slate-600">
-          Cada tipo de trabajo requiere un proceso distinto. Elegí el canal adecuado y avanzamos con una propuesta clara.
-        </p>
+        <Badge>Cotización</Badge>
+        <h1>Elegí cómo querés cotizar</h1>
+        <p className="max-w-3xl text-lg text-slate-600">Elegí una opción y seguí el paso a paso.</p>
       </header>
 
       <section className="grid gap-4 md:grid-cols-3">
@@ -97,7 +93,7 @@ export default async function PresupuestadorPage({
             <h2 className="text-base font-semibold">{door.title}</h2>
             <p className="mt-2 text-sm text-muted-foreground">{door.description}</p>
             <Button variant="ghost" className="mt-4 px-0" asChild>
-              <a href={door.href}>Ingresar</a>
+              <a href={door.href}>Continuar</a>
             </Button>
           </article>
         ))}

--- a/nerin-electric-site-v3-fixed/app/(site)/presupuestador/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/presupuestador/page.tsx
@@ -1,17 +1,18 @@
 export const dynamic = 'force-dynamic'
+
+import Link from 'next/link'
 import { getConfiguratorData } from '@/lib/marketing-data'
 import { Badge } from '@/components/ui/badge'
 import { ConfiguratorWizard } from '@/components/configurator/ConfiguratorWizard'
 import { Button } from '@/components/ui/button'
-import Link from 'next/link'
 
 export const revalidate = 60
 
 export async function generateMetadata() {
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Presupuestador eléctrico | Servicio puntual, obra o profesional'
+  const title = 'Contratación NERIN | Servicio puntual, relevamiento o cotización profesional'
   const description =
-    'Elegí tu modo de cotización en NERIN: servicio puntual, cotización guiada para obra o cotizador profesional por ítems.'
+    'Ingresá por una de las 3 puertas de NERIN: resolver algo puntual, pedir relevamiento o cotizar por plano/cantidades.'
 
   return {
     title,
@@ -33,6 +34,24 @@ export async function generateMetadata() {
     },
   }
 }
+
+const doors = [
+  {
+    title: 'Resolver algo puntual',
+    description: 'Para necesidades inmediatas con alcance claro.',
+    href: '/presupuestador?mode=EXPRESS',
+  },
+  {
+    title: 'Pedir relevamiento/proyecto',
+    description: 'Para obras y reformas con definición técnica.',
+    href: '/presupuesto?tipo=obra',
+  },
+  {
+    title: 'Cotización profesional',
+    description: 'Para perfiles técnicos con plano y cantidades.',
+    href: '/presupuestador?mode=PROFESSIONAL',
+  },
+]
 
 export default async function PresupuestadorPage({
   searchParams,
@@ -64,22 +83,25 @@ export default async function PresupuestadorPage({
 
   return (
     <div className="space-y-8 sm:space-y-10">
-      <header className="space-y-4 sm:space-y-5">
-        <Badge>Hub de cotización</Badge>
-        <h1>Elegí cómo querés cotizar tu trabajo eléctrico</h1>
+      <header className="space-y-4">
+        <Badge>Sistema comercial NERIN</Badge>
+        <h1>Una contratación clara en 3 puertas</h1>
         <p className="max-w-3xl text-lg text-slate-600">
-          No todos los proyectos se cotizan igual. Si querés resolver algo puntual, contratar una obra con guía o cargar
-          cantidades técnicas, empezá por el camino correcto desde el inicio.
+          Elegí el contexto correcto y avanzá con una propuesta ordenada. Sin calculadoras confusas ni desvíos.
         </p>
-        <div className="flex flex-wrap gap-3">
-          <Button variant="secondary" asChild>
-            <Link href="/presupuesto?tipo=obra">Solicitar relevamiento</Link>
-          </Button>
-          <Button variant="ghost" asChild>
-            <Link href="/packs">Ver bases técnicas (packs)</Link>
-          </Button>
-        </div>
       </header>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        {doors.map((door) => (
+          <article key={door.title} className="rounded-2xl border border-border bg-white p-5">
+            <h2 className="text-base font-semibold">{door.title}</h2>
+            <p className="mt-2 text-sm text-muted-foreground">{door.description}</p>
+            <Button variant="ghost" className="mt-4 px-0" asChild>
+              <a href={door.href}>Entrar</a>
+            </Button>
+          </article>
+        ))}
+      </section>
 
       <ConfiguratorWizard
         packs={wizardPacks}

--- a/nerin-electric-site-v3-fixed/app/(site)/presupuesto/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/presupuesto/page.tsx
@@ -7,9 +7,8 @@ export const revalidate = 60
 export async function generateMetadata() {
   const site = await getSiteContent()
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Relevamiento y propuesta eléctrica | NERIN'
-  const description =
-    'Solicitá relevamiento para obra o reforma. Definimos alcance técnico, prioridades y propuesta comercial.'
+  const title = 'Relevamiento | NERIN'
+  const description = 'Formulario para relevamiento y presupuesto de obra.'
 
   return {
     title,
@@ -45,28 +44,25 @@ export default async function PresupuestoPage({
   return (
     <div className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:gap-12">
       <div className="space-y-6 sm:space-y-8">
-        <Badge>Relevamiento / Proyecto</Badge>
-        <h1>Contanos el trabajo y definimos el alcance</h1>
-        <p className="max-w-2xl text-lg text-slate-600">
-          Este formulario aplica a obras, reformas o trabajos con definición técnica. Para tareas puntuales, usá el modo
-          de servicio puntual.
-        </p>
+        <Badge>Relevamiento</Badge>
+        <h1>Contanos el trabajo</h1>
+        <p className="max-w-2xl text-lg text-slate-600">Completá el formulario y te enviamos una propuesta.</p>
         <PresupuestoForm whatsappNumber={site.contact.whatsappNumber} leadType={leadType} plan={plan} />
       </div>
 
       <aside className="space-y-5 rounded-3xl border border-border bg-white p-5 shadow-subtle sm:p-7 lg:sticky lg:top-24">
         <h2>Qué revisamos</h2>
         <ul className="space-y-3 text-sm text-slate-600">
-          <li>• Estado actual y prioridades técnicas.</li>
-          <li>• Alcance real, etapas y condicionantes de obra.</li>
-          <li>• Propuesta comercial con próximos pasos.</li>
+          <li>• Estado de la instalación.</li>
+          <li>• Alcance del trabajo.</li>
+          <li>• Forma de ejecución.</li>
         </ul>
         <div className="rounded-2xl bg-muted p-6 text-sm text-slate-600">
-          <p className="font-semibold text-foreground">Contacto directo</p>
+          <p className="font-semibold text-foreground">Contacto</p>
           <p>{site.contact.whatsappNumber}</p>
           <p className="mt-3 font-semibold text-foreground">Correo</p>
           <p>{site.contact.email}</p>
-          <p className="mt-3 font-semibold text-foreground">Cobertura</p>
+          <p className="mt-3 font-semibold text-foreground">Zona</p>
           <p>{site.contact.serviceArea}</p>
         </div>
       </aside>

--- a/nerin-electric-site-v3-fixed/app/(site)/presupuesto/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/presupuesto/page.tsx
@@ -7,9 +7,9 @@ export const revalidate = 60
 export async function generateMetadata() {
   const site = await getSiteContent()
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Relevamiento premium y propuesta eléctrica | NERIN'
+  const title = 'Relevamiento y propuesta eléctrica | NERIN'
   const description =
-    'Solicitá relevamiento para vivienda, local u operación corporativa. NERIN define alcance y propuesta comercial en 24–48 h.'
+    'Solicitá relevamiento para obra o reforma. Definimos alcance técnico, prioridades y propuesta comercial.'
 
   return {
     title,
@@ -46,20 +46,20 @@ export default async function PresupuestoPage({
     <div className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:gap-12">
       <div className="space-y-6 sm:space-y-8">
         <Badge>Relevamiento / Proyecto</Badge>
-        <h1>Contanos tu espacio. NERIN ordena la propuesta.</h1>
+        <h1>Contanos el trabajo y definimos el alcance</h1>
         <p className="max-w-2xl text-lg text-slate-600">
-          Este formulario es para obras, reformas o necesidades que requieren diagnóstico técnico. Si querés resolver
-          algo puntual, usá el modo express del presupuestador.
+          Este formulario aplica a obras, reformas o trabajos con definición técnica. Para tareas puntuales, usá el modo
+          de servicio puntual.
         </p>
         <PresupuestoForm whatsappNumber={site.contact.whatsappNumber} leadType={leadType} plan={plan} />
       </div>
 
       <aside className="space-y-5 rounded-3xl border border-border bg-white p-5 shadow-subtle sm:p-7 lg:sticky lg:top-24">
-        <h2>Qué obtenés</h2>
+        <h2>Qué revisamos</h2>
         <ul className="space-y-3 text-sm text-slate-600">
-          <li>• Diagnóstico inicial y prioridades de intervención.</li>
-          <li>• Alcance real de obra para decidir con claridad.</li>
-          <li>• Propuesta comercial y próximos pasos concretos.</li>
+          <li>• Estado actual y prioridades técnicas.</li>
+          <li>• Alcance real, etapas y condicionantes de obra.</li>
+          <li>• Propuesta comercial con próximos pasos.</li>
         </ul>
         <div className="rounded-2xl bg-muted p-6 text-sm text-slate-600">
           <p className="font-semibold text-foreground">Contacto directo</p>

--- a/nerin-electric-site-v3-fixed/app/(site)/presupuesto/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/presupuesto/page.tsx
@@ -7,9 +7,9 @@ export const revalidate = 60
 export async function generateMetadata() {
   const site = await getSiteContent()
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Relevamiento y presupuesto de obra eléctrica | NERIN'
+  const title = 'Relevamiento premium y propuesta eléctrica | NERIN'
   const description =
-    'Solicitá relevamiento para instalaciones, reformas y obras eléctricas. Definimos alcance y propuesta en 24–48 h.'
+    'Solicitá relevamiento para vivienda, local u operación corporativa. NERIN define alcance y propuesta comercial en 24–48 h.'
 
   return {
     title,
@@ -45,28 +45,28 @@ export default async function PresupuestoPage({
   return (
     <div className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:gap-12">
       <div className="space-y-6 sm:space-y-8">
-        <Badge>Relevamiento técnico</Badge>
-        <h1>Cotización para instalación, obra o reforma</h1>
+        <Badge>Relevamiento / Proyecto</Badge>
+        <h1>Contanos tu espacio. NERIN ordena la propuesta.</h1>
         <p className="max-w-2xl text-lg text-slate-600">
-          Esta solicitud está pensada para proyectos que requieren relevamiento previo. Si necesitás contratar un
-          servicio puntual, usá el modo express del presupuestador.
+          Este formulario es para obras, reformas o necesidades que requieren diagnóstico técnico. Si querés resolver
+          algo puntual, usá el modo express del presupuestador.
         </p>
         <PresupuestoForm whatsappNumber={site.contact.whatsappNumber} leadType={leadType} plan={plan} />
       </div>
+
       <aside className="space-y-5 rounded-3xl border border-border bg-white p-5 shadow-subtle sm:p-7 lg:sticky lg:top-24">
-        <h2>Qué validamos en el relevamiento</h2>
+        <h2>Qué obtenés</h2>
         <ul className="space-y-3 text-sm text-slate-600">
-          <li>• Estado general de tablero, alimentaciones y protecciones.</li>
-          <li>• Alcance real de la obra y prioridades comerciales.</li>
-          <li>• Cronograma preliminar y etapas de ejecución.</li>
-          <li>• Recomendaciones normativas y documentación.</li>
+          <li>• Diagnóstico inicial y prioridades de intervención.</li>
+          <li>• Alcance real de obra para decidir con claridad.</li>
+          <li>• Propuesta comercial y próximos pasos concretos.</li>
         </ul>
         <div className="rounded-2xl bg-muted p-6 text-sm text-slate-600">
           <p className="font-semibold text-foreground">Contacto directo</p>
           <p>{site.contact.whatsappNumber}</p>
           <p className="mt-3 font-semibold text-foreground">Correo</p>
           <p>{site.contact.email}</p>
-          <p className="mt-3 font-semibold text-foreground">Área de cobertura</p>
+          <p className="mt-3 font-semibold text-foreground">Cobertura</p>
           <p>{site.contact.serviceArea}</p>
         </div>
       </aside>

--- a/nerin-electric-site-v3-fixed/components/Footer.tsx
+++ b/nerin-electric-site-v3-fixed/components/Footer.tsx
@@ -11,7 +11,7 @@ const quickLinks = [
   { href: '/presupuestador', label: 'Iniciar cotización' },
   { href: '/presupuesto', label: 'Solicitar relevamiento' },
   { href: '/obras', label: 'Ver casos' },
-  { href: '/packs', label: 'Anexo técnico' },
+  { href: '/contacto', label: 'Contacto' },
 ] as const
 
 interface FooterProps {
@@ -26,9 +26,8 @@ export function Footer({ site }: FooterProps) {
       <div className="container grid gap-10 py-12 sm:py-14 md:grid-cols-2 lg:grid-cols-4">
         <div className="space-y-3">
           <p className="text-sm uppercase tracking-[0.35em] text-muted-foreground">NERIN</p>
-          <p className="text-sm text-muted-foreground">Instalaciones eléctricas con criterio técnico y ejecución ordenada.</p>
-          <p className="text-sm text-muted-foreground">{site.contact.schedule}</p>
-          <p className="text-sm text-muted-foreground">{site.contact.phone}</p>
+          <p className="text-sm text-muted-foreground">Contratista eléctrico en CABA y GBA.</p>
+          <p className="text-sm text-muted-foreground">{site.contact.serviceArea}</p>
         </div>
 
         <div>
@@ -49,7 +48,7 @@ export function Footer({ site }: FooterProps) {
           <ul className="mt-3 space-y-2 text-sm text-foreground">
             <li>
               <a href={whatsappHref} className="hover:text-foreground" data-track="whatsapp" data-content-name="WhatsApp footer">
-                WhatsApp directo
+                WhatsApp
               </a>
             </li>
             <li>
@@ -57,7 +56,6 @@ export function Footer({ site }: FooterProps) {
                 {site.contact.email}
               </a>
             </li>
-            <li>{site.contact.serviceArea}</li>
           </ul>
         </div>
 
@@ -77,7 +75,7 @@ export function Footer({ site }: FooterProps) {
 
       <div className="border-t border-border bg-muted py-6">
         <div className="container flex flex-col gap-3 text-sm text-muted-foreground lg:flex-row lg:items-center lg:justify-between">
-          <span>© {new Date().getFullYear()} NERIN Electric. Todos los derechos reservados.</span>
+          <span>© {new Date().getFullYear()} NERIN Electric.</span>
           <Link href="/admin" className="text-xs uppercase tracking-[0.3em] text-muted-foreground hover:text-foreground">
             Panel admin
           </Link>

--- a/nerin-electric-site-v3-fixed/components/Footer.tsx
+++ b/nerin-electric-site-v3-fixed/components/Footer.tsx
@@ -8,10 +8,10 @@ const legalLinks = [
 ] as const
 
 const quickLinks = [
-  { href: '/packs', label: 'Packs eléctricos' },
-  { href: '/presupuesto', label: 'Pedir presupuesto' },
-  { href: '/mantenimiento', label: 'Planes de mantenimiento' },
-  { href: '/faq', label: 'Preguntas frecuentes' },
+  { href: '/presupuestador', label: 'Contratar con NERIN' },
+  { href: '/presupuesto', label: 'Solicitar relevamiento' },
+  { href: '/obras', label: 'Ver casos' },
+  { href: '/packs', label: 'Anexo técnico' },
 ] as const
 
 interface FooterProps {
@@ -20,28 +20,30 @@ interface FooterProps {
 
 export function Footer({ site }: FooterProps) {
   const whatsappHref = getWhatsappHref(site)
+
   return (
     <footer className="border-t border-border bg-white">
       <div className="container grid gap-10 py-12 sm:py-14 md:grid-cols-2 lg:grid-cols-4">
         <div className="space-y-3">
           <p className="text-sm uppercase tracking-[0.35em] text-muted-foreground">NERIN</p>
-          <p className="text-sm text-muted-foreground">{site.tagline}</p>
+          <p className="text-sm text-muted-foreground">Ejecución eléctrica premium para espacios exigentes.</p>
           <p className="text-sm text-muted-foreground">{site.contact.schedule}</p>
           <p className="text-sm text-muted-foreground">{site.contact.phone}</p>
-          <p className="text-sm text-muted-foreground">{site.socials.linkedin}</p>
         </div>
+
         <div>
-          <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Servicios</h4>
+          <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Navegación rápida</h4>
           <ul className="mt-3 space-y-2 text-sm text-foreground">
             {quickLinks.map((item) => (
               <li key={item.href}>
-                <Link className="hover:text-foreground" href={item.href} data-track={item.href === '/presupuesto' ? 'lead' : undefined} data-content-name={item.href === '/presupuesto' ? 'Pedir presupuesto footer' : undefined}>
+                <Link href={item.href} className="hover:text-foreground">
                   {item.label}
                 </Link>
               </li>
             ))}
           </ul>
         </div>
+
         <div>
           <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Contacto</h4>
           <ul className="mt-3 space-y-2 text-sm text-foreground">
@@ -55,19 +57,16 @@ export function Footer({ site }: FooterProps) {
                 {site.contact.email}
               </a>
             </li>
-            <li>
-              <Link href="/presupuesto?tipo=visita" className="hover:text-foreground" data-track="schedule" data-content-name="Agendar visita footer">
-                Agendar visita técnica
-              </Link>
-            </li>
+            <li>{site.contact.serviceArea}</li>
           </ul>
         </div>
+
         <div>
           <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Legales</h4>
           <ul className="mt-3 space-y-2 text-sm text-foreground">
             {legalLinks.map((item) => (
               <li key={item.href}>
-                <Link className="hover:text-foreground" href={item.href} data-track="legal" data-content-name={item.label}>
+                <Link className="hover:text-foreground" href={item.href}>
                   {item.label}
                 </Link>
               </li>
@@ -75,15 +74,13 @@ export function Footer({ site }: FooterProps) {
           </ul>
         </div>
       </div>
+
       <div className="border-t border-border bg-muted py-6">
         <div className="container flex flex-col gap-3 text-sm text-muted-foreground lg:flex-row lg:items-center lg:justify-between">
           <span>© {new Date().getFullYear()} NERIN Electric. Todos los derechos reservados.</span>
-          <div className="flex flex-col gap-2 lg:items-end">
-            <span>Desarrollado con foco en performance, accesibilidad AA y cumplimiento normativo AEA 90364-7-771.</span>
-            <Link href="/admin" className="text-xs uppercase tracking-[0.3em] text-muted-foreground hover:text-foreground">
-              Panel admin
-            </Link>
-          </div>
+          <Link href="/admin" className="text-xs uppercase tracking-[0.3em] text-muted-foreground hover:text-foreground">
+            Panel admin
+          </Link>
         </div>
       </div>
     </footer>

--- a/nerin-electric-site-v3-fixed/components/Footer.tsx
+++ b/nerin-electric-site-v3-fixed/components/Footer.tsx
@@ -8,7 +8,7 @@ const legalLinks = [
 ] as const
 
 const quickLinks = [
-  { href: '/presupuestador', label: 'Contratar con NERIN' },
+  { href: '/presupuestador', label: 'Iniciar cotización' },
   { href: '/presupuesto', label: 'Solicitar relevamiento' },
   { href: '/obras', label: 'Ver casos' },
   { href: '/packs', label: 'Anexo técnico' },
@@ -26,13 +26,13 @@ export function Footer({ site }: FooterProps) {
       <div className="container grid gap-10 py-12 sm:py-14 md:grid-cols-2 lg:grid-cols-4">
         <div className="space-y-3">
           <p className="text-sm uppercase tracking-[0.35em] text-muted-foreground">NERIN</p>
-          <p className="text-sm text-muted-foreground">Ejecución eléctrica premium para espacios exigentes.</p>
+          <p className="text-sm text-muted-foreground">Instalaciones eléctricas con criterio técnico y ejecución ordenada.</p>
           <p className="text-sm text-muted-foreground">{site.contact.schedule}</p>
           <p className="text-sm text-muted-foreground">{site.contact.phone}</p>
         </div>
 
         <div>
-          <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Navegación rápida</h4>
+          <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Accesos</h4>
           <ul className="mt-3 space-y-2 text-sm text-foreground">
             {quickLinks.map((item) => (
               <li key={item.href}>

--- a/nerin-electric-site-v3-fixed/components/Header.tsx
+++ b/nerin-electric-site-v3-fixed/components/Header.tsx
@@ -19,11 +19,10 @@ interface HeaderProps {
 }
 
 const navigation = [
-  { href: '/servicios', label: 'Servicios' },
-  { href: '/mantenimiento', label: 'Mantenimiento' },
-  { href: '/obras', label: 'Obras' },
-  { href: '/packs', label: 'Packs' },
-  { href: '/empresa', label: 'Empresa' },
+  { href: '/', label: 'Inicio' },
+  { href: '/presupuestador', label: 'Contratar' },
+  { href: '/obras', label: 'Casos' },
+  { href: '/empresa', label: 'Marca' },
   { href: '/contacto', label: 'Contacto' },
 ] as const
 
@@ -62,14 +61,13 @@ export function Header({ contact, logo }: HeaderProps) {
               data-track="whatsapp"
               data-content-name="WhatsApp header"
             >
-              <svg aria-hidden viewBox="0 0 24 24" className="h-4 w-4 fill-current text-[#FBBF24]">
-                <path d="M12 4.2a7.8 7.8 0 0 0-6.75 11.7L4 20l4.2-1.1A7.8 7.8 0 1 0 12 4.2Zm0 1.6a6.2 6.2 0 0 1 0 12.4 6.1 6.1 0 0 1-3.1-.9l-.4-.2-2.5.7.7-2.4-.3-.4a6.2 6.2 0 0 1 5.6-9.2Zm-2.4 3.3c-.2 0-.4 0-.5.2-.2.2-.7.7-.7 1.6s.7 2 1 2.3c.2.3 1.4 2.1 3.5 2.9 1.7.7 2 .5 2.3.5.3 0 1-.5 1.1-.9.1-.4.1-.8.1-.9s0-.2-.2-.2l-1.1-.5c-.2-.1-.3 0-.4.1-.1.2-.5.9-.6 1-.1.2-.2.2-.5.1-.2-.1-1-.4-1.9-1.2-.7-.6-1.1-1.4-1.2-1.6-.1-.2 0-.3.1-.4l.3-.3.2-.3c.1-.1.1-.3 0-.4l-.5-1.1c-.1-.2-.2-.2-.4-.2Z" />
-              </svg>
               WhatsApp
             </a>
           </Button>
           <Button size="sm" asChild className="hidden lg:inline-flex">
-            <Link href="/presupuesto" data-track="lead" data-content-name="Pedir presupuesto header">Pedir presupuesto</Link>
+            <Link href="/presupuestador" data-track="lead" data-content-name="Contratar header">
+              Contratar ahora
+            </Link>
           </Button>
 
           {!session?.user && (
@@ -102,17 +100,24 @@ export function Header({ contact, logo }: HeaderProps) {
           <div className="container space-y-5 py-4">
             <nav className="grid gap-1 text-sm font-medium text-foreground">
               {navigation.map((item) => (
-                <Link key={item.href} href={item.href} className="rounded-lg px-3 py-2 hover:bg-muted" onClick={() => setMenuOpen(false)}>
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="rounded-lg px-3 py-2 hover:bg-muted"
+                  onClick={() => setMenuOpen(false)}
+                >
                   {item.label}
                 </Link>
               ))}
             </nav>
             <div className="grid gap-2 sm:grid-cols-2">
               <Button asChild onClick={() => setMenuOpen(false)}>
-                <Link href="/presupuesto">Pedir presupuesto</Link>
+                <Link href="/presupuestador">Contratar ahora</Link>
               </Button>
               <Button variant="outline" asChild>
-                <a href={contact.whatsappHref} target="_blank" rel="noopener noreferrer">WhatsApp</a>
+                <a href={contact.whatsappHref} target="_blank" rel="noopener noreferrer">
+                  WhatsApp
+                </a>
               </Button>
               {!session?.user && (
                 <Button variant="secondary" asChild className="sm:col-span-2" onClick={() => setMenuOpen(false)}>

--- a/nerin-electric-site-v3-fixed/components/Header.tsx
+++ b/nerin-electric-site-v3-fixed/components/Header.tsx
@@ -22,7 +22,7 @@ const navigation = [
   { href: '/', label: 'Inicio' },
   { href: '/presupuestador', label: 'Contratar' },
   { href: '/obras', label: 'Casos' },
-  { href: '/empresa', label: 'Marca' },
+  { href: '/empresa', label: 'Empresa' },
   { href: '/contacto', label: 'Contacto' },
 ] as const
 
@@ -66,7 +66,7 @@ export function Header({ contact, logo }: HeaderProps) {
           </Button>
           <Button size="sm" asChild className="hidden lg:inline-flex">
             <Link href="/presupuestador" data-track="lead" data-content-name="Contratar header">
-              Contratar ahora
+              Iniciar cotización
             </Link>
           </Button>
 
@@ -112,7 +112,7 @@ export function Header({ contact, logo }: HeaderProps) {
             </nav>
             <div className="grid gap-2 sm:grid-cols-2">
               <Button asChild onClick={() => setMenuOpen(false)}>
-                <Link href="/presupuestador">Contratar ahora</Link>
+                <Link href="/presupuestador">Iniciar cotización</Link>
               </Button>
               <Button variant="outline" asChild>
                 <a href={contact.whatsappHref} target="_blank" rel="noopener noreferrer">
@@ -121,12 +121,12 @@ export function Header({ contact, logo }: HeaderProps) {
               </Button>
               {!session?.user && (
                 <Button variant="secondary" asChild className="sm:col-span-2" onClick={() => setMenuOpen(false)}>
-                  <Link href="/clientes/login">Ingresar al portal</Link>
+                  <Link href="/clientes/login">Ingresar</Link>
                 </Button>
               )}
               {session?.user && session.user.role !== 'admin' && (
                 <Button variant="secondary" asChild className="sm:col-span-2" onClick={() => setMenuOpen(false)}>
-                  <Link href={clientDashboardRoute}>Ir al portal clientes</Link>
+                  <Link href={clientDashboardRoute}>Portal clientes</Link>
                 </Button>
               )}
             </div>

--- a/nerin-electric-site-v3-fixed/components/Header.tsx
+++ b/nerin-electric-site-v3-fixed/components/Header.tsx
@@ -20,9 +20,9 @@ interface HeaderProps {
 
 const navigation = [
   { href: '/', label: 'Inicio' },
-  { href: '/presupuestador', label: 'Contratar' },
+  { href: '/presupuestador', label: 'Cotización' },
   { href: '/obras', label: 'Casos' },
-  { href: '/empresa', label: 'Empresa' },
+  { href: '/mantenimiento', label: 'Mantenimiento' },
   { href: '/contacto', label: 'Contacto' },
 ] as const
 
@@ -46,12 +46,7 @@ export function Header({ contact, logo }: HeaderProps) {
         </nav>
 
         <div className="flex items-center gap-2 sm:gap-3">
-          <Button
-            variant="outline"
-            size="sm"
-            asChild
-            className="hidden items-center gap-2 border border-border bg-white text-foreground lg:inline-flex"
-          >
+          <Button variant="outline" size="sm" asChild className="hidden border border-border bg-white text-foreground lg:inline-flex">
             <a
               href={contact.whatsappHref}
               aria-label={contact.whatsappLabel}
@@ -65,7 +60,7 @@ export function Header({ contact, logo }: HeaderProps) {
             </a>
           </Button>
           <Button size="sm" asChild className="hidden lg:inline-flex">
-            <Link href="/presupuestador" data-track="lead" data-content-name="Contratar header">
+            <Link href="/presupuestador" data-track="lead" data-content-name="Cotización header">
               Iniciar cotización
             </Link>
           </Button>
@@ -100,12 +95,7 @@ export function Header({ contact, logo }: HeaderProps) {
           <div className="container space-y-5 py-4">
             <nav className="grid gap-1 text-sm font-medium text-foreground">
               {navigation.map((item) => (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className="rounded-lg px-3 py-2 hover:bg-muted"
-                  onClick={() => setMenuOpen(false)}
-                >
+                <Link key={item.href} href={item.href} className="rounded-lg px-3 py-2 hover:bg-muted" onClick={() => setMenuOpen(false)}>
                   {item.label}
                 </Link>
               ))}

--- a/nerin-electric-site-v3-fixed/components/configurator/ConfiguratorWizard.tsx
+++ b/nerin-electric-site-v3-fixed/components/configurator/ConfiguratorWizard.tsx
@@ -21,18 +21,18 @@ interface Props {
 const modeCards: Array<{ mode: WizardSummary['mode']; title: string; description: string }> = [
   {
     mode: 'EXPRESS',
-    title: '1) Resolver algo puntual',
-    description: 'Para contratar rápido con alcance definido.',
+    title: '1) Servicio puntual',
+    description: 'Para tareas concretas con contratación directa.',
   },
   {
     mode: 'ASSISTED',
     title: '2) Relevamiento / proyecto',
-    description: 'Para obra o reforma con acompañamiento.',
+    description: 'Para obras o reformas con diagnóstico previo.',
   },
   {
     mode: 'PROFESSIONAL',
-    title: '3) Cotización profesional',
-    description: 'Para carga técnica por cantidades.',
+    title: '3) Cotización técnica',
+    description: 'Para cotizar por plano o cantidades.',
   },
 ]
 
@@ -138,7 +138,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
       <section className="grid gap-5 lg:grid-cols-[1.35fr_0.9fr] xl:gap-6">
         <Card>
           <CardHeader>
-            <CardTitle>Configurá tu solicitud</CardTitle>
+            <CardTitle>Definí tu solicitud</CardTitle>
           </CardHeader>
           <CardContent className="space-y-5">
             <div className="grid gap-3">
@@ -267,11 +267,11 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
             )}
 
             <div>
-              <Label>Contexto del trabajo</Label>
+              <Label>Datos del trabajo</Label>
               <Textarea
                 value={summary.comentarios}
                 onChange={(event) => setSummary((prev) => ({ ...prev, comentarios: event.target.value }))}
-                placeholder="Contanos qué buscás resolver."
+                placeholder="Indicá alcance, prioridades o restricciones."
               />
             </div>
           </CardContent>
@@ -286,7 +286,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
               Servicio: <b>{selectedService?.name}</b>
             </p>
             <p>
-              Modalidad: <b>{totals.requiresSurvey ? 'Relevamiento técnico previo' : 'Contratación directa'}</b>
+              Modalidad: <b>{totals.requiresSurvey ? 'Con relevamiento técnico' : 'Contratación directa'}</b>
             </p>
             <p className="text-lg font-semibold">Total estimado: ${totals.totalManoObra.toLocaleString('es-AR')}</p>
             {totals.warning && <p className="text-amber-600">{totals.warning}</p>}
@@ -304,11 +304,11 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
                 onChange={(event) => setContacto((prev) => ({ ...prev, email: event.target.value }))}
               />
               <Button onClick={submitQuote} disabled={isPending} className="w-full">
-                {isPending ? 'Guardando...' : 'Guardar cotización'}
+                {isPending ? 'Guardando...' : 'Guardar solicitud'}
               </Button>
               {pdfUrl && (
                 <a className="text-sm font-semibold text-accent hover:underline" href={pdfUrl} target="_blank" rel="noreferrer">
-                  Descargar PDF
+                  Descargar resumen PDF
                 </a>
               )}
             </div>

--- a/nerin-electric-site-v3-fixed/components/configurator/ConfiguratorWizard.tsx
+++ b/nerin-electric-site-v3-fixed/components/configurator/ConfiguratorWizard.tsx
@@ -21,18 +21,18 @@ interface Props {
 const modeCards: Array<{ mode: WizardSummary['mode']; title: string; description: string }> = [
   {
     mode: 'EXPRESS',
-    title: 'Servicio puntual',
-    description: 'Para contratar tareas directas con alcance claro y precio desde.',
+    title: '1) Resolver algo puntual',
+    description: 'Para contratar rápido con alcance definido.',
   },
   {
     mode: 'ASSISTED',
-    title: 'Cotización guiada',
-    description: 'Para instalación, obra o reforma con supuestos editables y relevamiento.',
+    title: '2) Relevamiento / proyecto',
+    description: 'Para obra o reforma con acompañamiento.',
   },
   {
     mode: 'PROFESSIONAL',
-    title: 'Cotización profesional',
-    description: 'Para clientes técnicos con carga manual por ítems de obra.',
+    title: '3) Cotización profesional',
+    description: 'Para carga técnica por cantidades.',
   },
 ]
 
@@ -125,7 +125,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
             key={card.mode}
             type="button"
             onClick={() => updateMode(card.mode)}
-            className={`rounded-2xl border p-4 sm:p-5 text-left transition min-h-32 ${
+            className={`rounded-2xl border p-4 text-left transition ${
               summary.mode === card.mode ? 'border-accent bg-accent/5' : 'border-border bg-white'
             }`}
           >
@@ -138,11 +138,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
       <section className="grid gap-5 lg:grid-cols-[1.35fr_0.9fr] xl:gap-6">
         <Card>
           <CardHeader>
-            <CardTitle>
-              {summary.mode === 'EXPRESS' && 'Contratar servicio puntual'}
-              {summary.mode === 'ASSISTED' && 'Cotización guiada para instalación / obra'}
-              {summary.mode === 'PROFESSIONAL' && 'Cotización profesional por ítems'}
-            </CardTitle>
+            <CardTitle>Configurá tu solicitud</CardTitle>
           </CardHeader>
           <CardContent className="space-y-5">
             <div className="grid gap-3">
@@ -151,42 +147,56 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
                   key={service.id}
                   type="button"
                   onClick={() => setSummary((prev) => ({ ...prev, serviceId: service.id }))}
-                  className={`rounded-xl border p-3.5 sm:p-4 text-left ${summary.serviceId === service.id ? 'border-accent bg-accent/5' : 'border-border'}`}
+                  className={`rounded-xl border p-4 text-left ${summary.serviceId === service.id ? 'border-accent bg-accent/5' : 'border-border'}`}
                 >
                   <p className="font-semibold text-foreground">{service.name}</p>
                   <p className="mt-1 text-sm text-slate-600">{service.description}</p>
-                  <p className="mt-2 text-sm font-medium text-foreground">
-                    Desde ${Number(service.minPrice ?? service.basePrice).toLocaleString('es-AR')}
-                  </p>
                 </button>
               ))}
             </div>
 
-            {summary.mode === 'EXPRESS' && (
-              <div className="grid gap-4 md:grid-cols-2">
-                <div>
-                  <Label>Unidades de servicio</Label>
-                  <Input
-                    type="number"
-                    min={1}
-                    value={summary.serviceUnits}
-                    onChange={(event) => setSummary((prev) => ({ ...prev, serviceUnits: Number(event.target.value) || 1 }))}
-                  />
-                </div>
-                <div>
-                  <Label>Urgencia</Label>
-                  <select
-                    className="h-11 w-full rounded-xl border border-border bg-white px-4 text-sm"
-                    value={summary.urgencyMultiplier}
-                    onChange={(event) => setSummary((prev) => ({ ...prev, urgencyMultiplier: Number(event.target.value) || 1 }))}
-                  >
-                    <option value={1}>Normal</option>
-                    <option value={1.1}>Prioridad 72 h</option>
-                    <option value={1.2}>Urgente 24 h</option>
-                  </select>
-                </div>
+            <div className="grid gap-4 md:grid-cols-3">
+              <div>
+                <Label>Unidades</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={summary.serviceUnits}
+                  onChange={(event) => setSummary((prev) => ({ ...prev, serviceUnits: Number(event.target.value) || 1 }))}
+                />
               </div>
-            )}
+              <div>
+                <Label>Zona</Label>
+                <select
+                  className="h-11 w-full rounded-xl border border-border bg-white px-4 text-sm"
+                  value={summary.zoneTier}
+                  onChange={(event) =>
+                    setSummary((prev) => ({
+                      ...prev,
+                      zoneTier: event.target.value as WizardSummary['zoneTier'],
+                    }))
+                  }
+                >
+                  <option value="PRIORITY">Prioritaria</option>
+                  <option value="STANDARD">Estándar</option>
+                  <option value="EXTENDED">Extendida</option>
+                </select>
+              </div>
+              <div>
+                <Label>Urgencia</Label>
+                <select
+                  className="h-11 w-full rounded-xl border border-border bg-white px-4 text-sm"
+                  value={summary.urgencyMultiplier}
+                  onChange={(event) =>
+                    setSummary((prev) => ({ ...prev, urgencyMultiplier: Number(event.target.value) || 1 }))
+                  }
+                >
+                  <option value={1}>Normal</option>
+                  <option value={1.1}>72 h</option>
+                  <option value={1.2}>24 h</option>
+                </select>
+              </div>
+            </div>
 
             {summary.mode === 'ASSISTED' && (
               <>
@@ -224,21 +234,18 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
                     </select>
                   </div>
                 </div>
-                <div className="space-y-2">
-                  <p className="text-sm font-semibold text-foreground">Ajustes editables</p>
-                  <div className="grid gap-3 lg:grid-cols-2">
-                    {adicionales.slice(0, 8).map((item) => (
-                      <div key={item.id} className="grid grid-cols-1 gap-2 rounded-xl border border-border/70 p-3 sm:grid-cols-[1fr_110px] sm:items-center sm:gap-3">
-                        <span className="text-sm text-slate-600">{item.nombre}</span>
-                        <Input
-                          type="number"
-                          min={0}
-                          value={summary.adicionales.find((it) => it.id === item.id)?.cantidad ?? 0}
-                          onChange={(event) => updateItems(item.id, Number(event.target.value) || 0, 'adicionales')}
-                        />
-                      </div>
-                    ))}
-                  </div>
+                <div className="grid gap-3 lg:grid-cols-2">
+                  {adicionales.slice(0, 6).map((item) => (
+                    <div key={item.id} className="grid grid-cols-[1fr_90px] gap-3 rounded-xl border border-border/70 p-3 items-center">
+                      <span className="text-sm text-slate-600">{item.nombre}</span>
+                      <Input
+                        type="number"
+                        min={0}
+                        value={summary.adicionales.find((it) => it.id === item.id)?.cantidad ?? 0}
+                        onChange={(event) => updateItems(item.id, Number(event.target.value) || 0, 'adicionales')}
+                      />
+                    </div>
+                  ))}
                 </div>
               </>
             )}
@@ -246,7 +253,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
             {summary.mode === 'PROFESSIONAL' && (
               <div className="grid gap-3 lg:grid-cols-2">
                 {professionalCatalog.map((item) => (
-                  <div key={item.id} className="grid grid-cols-1 gap-2 rounded-xl border border-border/70 p-3 sm:grid-cols-[1fr_110px] sm:items-center sm:gap-3">
+                  <div key={item.id} className="grid grid-cols-[1fr_90px] gap-3 rounded-xl border border-border/70 p-3 items-center">
                     <span className="text-sm text-slate-600">{item.name}</span>
                     <Input
                       type="number"
@@ -260,10 +267,11 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
             )}
 
             <div>
-              <Label>Comentarios para el equipo técnico</Label>
+              <Label>Contexto del trabajo</Label>
               <Textarea
                 value={summary.comentarios}
                 onChange={(event) => setSummary((prev) => ({ ...prev, comentarios: event.target.value }))}
+                placeholder="Contanos qué buscás resolver."
               />
             </div>
           </CardContent>
@@ -278,12 +286,8 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
               Servicio: <b>{selectedService?.name}</b>
             </p>
             <p>
-              Flujo:{' '}
-              <b>{totals.requiresSurvey ? 'Relevamiento técnico previo' : 'Contratación directa con validación'}</b>
+              Modalidad: <b>{totals.requiresSurvey ? 'Relevamiento técnico previo' : 'Contratación directa'}</b>
             </p>
-            <p>Subtotal base: ${totals.subtotalBase.toLocaleString('es-AR')}</p>
-            <p>Recargo zona: ${totals.recargoZona.toLocaleString('es-AR')}</p>
-            <p>Recargo urgencia: ${totals.recargoUrgencia.toLocaleString('es-AR')}</p>
             <p className="text-lg font-semibold">Total estimado: ${totals.totalManoObra.toLocaleString('es-AR')}</p>
             {totals.warning && <p className="text-amber-600">{totals.warning}</p>}
 

--- a/nerin-electric-site-v3-fixed/components/configurator/ConfiguratorWizard.tsx
+++ b/nerin-electric-site-v3-fixed/components/configurator/ConfiguratorWizard.tsx
@@ -22,12 +22,12 @@ const modeCards: Array<{ mode: WizardSummary['mode']; title: string; description
   {
     mode: 'EXPRESS',
     title: '1) Servicio puntual',
-    description: 'Para tareas concretas con contratación directa.',
+    description: 'Para resolver un trabajo puntual.',
   },
   {
     mode: 'ASSISTED',
     title: '2) Relevamiento / proyecto',
-    description: 'Para obras o reformas con diagnóstico previo.',
+    description: 'Para obras y reformas.',
   },
   {
     mode: 'PROFESSIONAL',
@@ -138,7 +138,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
       <section className="grid gap-5 lg:grid-cols-[1.35fr_0.9fr] xl:gap-6">
         <Card>
           <CardHeader>
-            <CardTitle>Definí tu solicitud</CardTitle>
+            <CardTitle>Completá tu solicitud</CardTitle>
           </CardHeader>
           <CardContent className="space-y-5">
             <div className="grid gap-3">
@@ -267,11 +267,11 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
             )}
 
             <div>
-              <Label>Datos del trabajo</Label>
+              <Label>Detalle del trabajo</Label>
               <Textarea
                 value={summary.comentarios}
                 onChange={(event) => setSummary((prev) => ({ ...prev, comentarios: event.target.value }))}
-                placeholder="Indicá alcance, prioridades o restricciones."
+                placeholder="Escribí un detalle breve del trabajo."
               />
             </div>
           </CardContent>
@@ -286,7 +286,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
               Servicio: <b>{selectedService?.name}</b>
             </p>
             <p>
-              Modalidad: <b>{totals.requiresSurvey ? 'Con relevamiento técnico' : 'Contratación directa'}</b>
+              Modalidad: <b>{totals.requiresSurvey ? 'Con relevamiento' : 'Directa'}</b>
             </p>
             <p className="text-lg font-semibold">Total estimado: ${totals.totalManoObra.toLocaleString('es-AR')}</p>
             {totals.warning && <p className="text-amber-600">{totals.warning}</p>}
@@ -304,11 +304,11 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
                 onChange={(event) => setContacto((prev) => ({ ...prev, email: event.target.value }))}
               />
               <Button onClick={submitQuote} disabled={isPending} className="w-full">
-                {isPending ? 'Guardando...' : 'Guardar solicitud'}
+                {isPending ? 'Guardando...' : 'Guardar cotización'}
               </Button>
               {pdfUrl && (
                 <a className="text-sm font-semibold text-accent hover:underline" href={pdfUrl} target="_blank" rel="noreferrer">
-                  Descargar resumen PDF
+                  Descargar PDF
                 </a>
               )}
             </div>

--- a/nerin-electric-site-v3-fixed/components/configurator/catalog.ts
+++ b/nerin-electric-site-v3-fixed/components/configurator/catalog.ts
@@ -3,7 +3,7 @@ import { QuoteCatalogItem, QuoteService } from './types'
 export const quoteServices: QuoteService[] = [
   {
     id: 'diagnostico-premium',
-    name: 'Diagnóstico eléctrico premium',
+    name: 'Diagnóstico eléctrico',
     description: 'Inspección técnica, mediciones y plan de acción priorizado para resolver riesgos inmediatos.',
     flow: 'ONLINE',
     path: 'PUNTUAL',
@@ -43,7 +43,7 @@ export const quoteServices: QuoteService[] = [
     basePrice: 160000,
     minPrice: 160000,
     includes: ['Revisión de protecciones', 'Reordenamiento básico', 'Checklist de riesgos'],
-    excludes: ['Cambio total de tablero', 'Materiales premium'],
+    excludes: ['Cambio total de tablero', 'Materiales no incluidos'],
   },
   {
     id: 'reforma-parcial',

--- a/nerin-electric-site-v3-fixed/lib/content-store.ts
+++ b/nerin-electric-site-v3-fixed/lib/content-store.ts
@@ -748,7 +748,7 @@ function buildPrismaStore(): ContentStore {
           leadType: lead.leadType,
           plan: lead.plan,
           hasFiles: lead.hasFiles,
-          attachments: lead.attachments.map((attachment) => ({
+          attachments: (lead.attachments ?? []).map((attachment) => ({
             originalName: attachment.originalName,
             mimeType: attachment.mimeType,
             size: attachment.size,

--- a/nerin-electric-site-v3-fixed/tests/unit/leads-route.test.ts
+++ b/nerin-electric-site-v3-fixed/tests/unit/leads-route.test.ts
@@ -55,6 +55,7 @@ describe('app/api/leads/route POST', () => {
       leadType: 'mantenimiento',
       plan: 'plan-basico',
       hasFiles: false,
+      attachments: [],
       createdAt: new Date().toISOString(),
     })
 
@@ -80,7 +81,7 @@ describe('app/api/leads/route POST', () => {
     )
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({ ok: true, leadId: 'lead_123' })
+    await expect(response.json()).resolves.toEqual({ ok: true, leadId: 'lead_123', attachmentsCount: 0 })
     expect(mockLeadCreate).toHaveBeenCalledOnce()
   })
 })


### PR DESCRIPTION
### Motivation
- El sitio actual exponía demasiada información y lógica en la home y el flujo comercial, diluyendo la percepción de marca premium. 
- Objetivo: reducir densidad textual, simplificar la navegación mental y convertir la entrada comercial en 3 puertas claras para transmitir deseo y autoridad de marca.

### Description
- Reescribí la home para priorizar narrativa premium: hero dominante, copy más corto y aspiracional, 3 «mundos» de entrada, bloque “por qué NERIN”, casos visuales, hiring flow en 3 puertas y CTA final más contundente (archivo principal: `app/(site)/page.tsx`).
- Transformé el hub comercial en un modelo de 3 puertas (Resolver algo puntual / Relevamiento / Cotización profesional) y simplifiqué copy y CTAs en `app/(site)/presupuestador/page.tsx` y `app/(site)/presupuesto/page.tsx`.
- Baje el protagonismo de los packs y los reposicioné como anexo técnico en `app/(site)/packs/page.tsx`, además de ajustar navegaciones y CTAs en `components/Header.tsx` y `components/Footer.tsx` para priorizar contratación y claridad.
- Suavicé y reorien­té el configurador para que se sienta menos «calculadora» y más como un intake comercial guiado, y alineé labels del admin (`app/(admin)/.../SiteExperienceDesigner.tsx`) para administrar verticales, oferta destacada y el anexo técnico.

### Testing
- Ejecuté `npm run lint` y pasó (quedaron advertencias conocidas sobre uso de `<img>` en administradores). 
- Ejecuté `npm run test` (Vitest): la suite corre pero hay 1 test unitario fallido en `tests/unit/leads-route.test.ts` por una discrepancia en respuesta HTTP (500 vs 200), que ya existía en entornos previos. 
- Ejecuté `npm run build` (`next build`) y la compilación/proceso de build finalizó correctamente aunque registró mensajes de DB faltante (uso de defaults durante build). 
- Intenté capturar una captura con Playwright contra el servidor local pero la ejecución del navegador en el contenedor falló con un SIGSEGV, por lo que no se pudo generar la imagen visual de validación.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3718335188331a5ded0b978056781)