### PR TITLE
Homepage, header and footer revamp with WhatsApp CTAs, urgency banners and new UI styles

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(site)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/page.tsx
@@ -57,6 +57,48 @@ const urgencyItems = [
   { label: 'Canal más rápido', value: 'WhatsApp' },
 ]
 
+const salesOffers = [
+  {
+    title: 'Servicio puntual express',
+    oldPrice: '$58.000',
+    newPrice: '$49.000',
+    note: 'Diagnóstico + solución en visita técnica',
+    href: '/presupuestador?mode=EXPRESS',
+    cta: 'Reservar express',
+  },
+  {
+    title: 'Obra / reforma',
+    oldPrice: '$220.000',
+    newPrice: '$189.000',
+    note: 'Presupuesto técnico + plan de ejecución',
+    href: '/presupuestador?mode=PROJECT',
+    cta: 'Pedir presupuesto',
+  },
+  {
+    title: 'Urgencias por WhatsApp',
+    oldPrice: '2 hs',
+    newPrice: 'Hoy',
+    note: 'Canal prioritario para respuesta inmediata',
+    href: '#whatsapp-directo',
+    cta: 'Escribir ahora',
+  },
+]
+
+const quickAnswers = [
+  {
+    q: '¿En cuánto responden?',
+    a: 'Por WhatsApp respondemos rápido y coordinamos disponibilidad del día.',
+  },
+  {
+    q: '¿Pasan precio antes?',
+    a: 'Sí. Podés revisar lista de precios y pedir presupuesto en el momento.',
+  },
+  {
+    q: '¿Atienden CABA y GBA?',
+    a: 'Sí, trabajamos toda esa zona y coordinamos por tipo de trabajo.',
+  },
+]
+
 export default async function HomePage() {
   const { caseStudies } = await getMarketingHomeData()
   const site = await getSiteContent()
@@ -129,6 +171,7 @@ export default async function HomePage() {
               className="h-12 bg-[#25D366] text-base font-bold text-black hover:bg-[#1ebe5a]"
             >
               <a
+                id="whatsapp-directo"
                 href={whatsappHref}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -163,6 +206,36 @@ export default async function HomePage() {
             <p className="mt-2 text-2xl font-bold text-[#22d3ee]">{item.value}</p>
           </article>
         ))}
+      </section>
+
+      <section className="space-y-5 rounded-2xl border border-red-200 bg-white p-5 sm:p-6">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-red-700">
+            Ofertas del día
+          </p>
+          <h2 className="text-2xl font-semibold text-slate-900">Elegí y cerrá hoy</h2>
+        </div>
+        <div className="grid gap-3 lg:grid-cols-3">
+          {salesOffers.map((offer) => (
+            <article
+              key={offer.title}
+              className="rounded-xl border border-border bg-gradient-to-b from-white to-red-50/40 p-4 shadow-sm"
+            >
+              <h3 className="text-lg font-semibold text-slate-900">{offer.title}</h3>
+              <p className="mt-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Desde
+              </p>
+              <div className="mt-1 flex items-end gap-2">
+                <span className="text-sm text-slate-400 line-through">{offer.oldPrice}</span>
+                <span className="text-2xl font-bold text-red-600">{offer.newPrice}</span>
+              </div>
+              <p className="mt-2 text-sm text-slate-600">{offer.note}</p>
+              <Button asChild className="mt-4 w-full bg-red-600 hover:bg-red-700">
+                <Link href={offer.href}>{offer.cta}</Link>
+              </Button>
+            </article>
+          ))}
+        </div>
       </section>
 
       <section className="rounded-2xl border border-cyan-200 bg-gradient-to-r from-cyan-50 to-sky-50 p-5 sm:p-6">
@@ -231,6 +304,18 @@ export default async function HomePage() {
                 <h3 className="text-lg font-semibold text-slate-900">{cs.titulo}</h3>
                 <p className="text-sm text-muted-foreground">{cs.resumen}</p>
               </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4 rounded-2xl border border-border bg-white p-5 sm:p-6">
+        <h2 className="text-2xl font-semibold">Respuestas rápidas antes de contratar</h2>
+        <div className="grid gap-3 md:grid-cols-3">
+          {quickAnswers.map((item) => (
+            <article key={item.q} className="rounded-xl border border-border bg-muted/20 p-4">
+              <h3 className="text-base font-semibold text-slate-900">{item.q}</h3>
+              <p className="mt-1 text-sm text-muted-foreground">{item.a}</p>
             </article>
           ))}
         </div>

--- a/nerin-electric-site-v3-fixed/app/(site)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/page.tsx
@@ -3,9 +3,8 @@ export const dynamic = 'force-dynamic'
 import Image from 'next/image'
 import Link from 'next/link'
 import { getMarketingHomeData } from '@/lib/marketing-data'
-import { getSiteContent } from '@/lib/site-content'
+import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 
 export const revalidate = 60
 
@@ -13,7 +12,8 @@ export async function generateMetadata() {
   const site = await getSiteContent()
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
   const title = 'Contratista eléctrico en CABA y GBA | NERIN'
-  const description = 'Servicios, mantenimiento y trabajos eléctricos para viviendas, comercios y obras.'
+  const description =
+    'Servicios, mantenimiento y trabajos eléctricos para viviendas, comercios y obras.'
 
   return {
     title,
@@ -37,165 +37,266 @@ export async function generateMetadata() {
   }
 }
 
-const worlds = [
-  {
-    title: 'Viviendas',
-    description: 'Instalaciones, arreglos y reformas eléctricas en casas y departamentos.',
-    href: '/presupuestador?mode=PROJECT',
-  },
-  {
-    title: 'Comercios',
-    description: 'Trabajos para locales, oficinas y espacios de atención al público.',
-    href: '/presupuestador?mode=PROJECT',
-  },
-  {
-    title: 'Obras',
-    description: 'Cotización para obra nueva, ampliaciones y mantenimiento técnico.',
-    href: '/presupuestador?mode=PROJECT',
-  },
+const services = [
+  'Diagnóstico eléctrico',
+  'Reparación de falla',
+  'Colocación de artefactos',
+  'Circuito para aire acondicionado',
+  'Tablero',
+  'Obra / reforma',
+  'Local / oficina',
+  'Vivienda',
+  'Edificio',
 ]
 
-const workSteps = [
-  'Revisamos el pedido y el tipo de trabajo.',
-  'Definimos alcance y forma de trabajo antes de empezar.',
-  'Ejecutamos y dejamos registro de lo realizado.',
-]
+const trustPoints = ['Atención en CABA y GBA', 'Respuesta rápida', 'Trabajo seguro y prolijo']
 
-const hiringFlow = [
-  {
-    title: 'Servicio puntual',
-    description: 'Para resolver algo concreto.',
-    href: '/presupuestador?mode=EXPRESS',
-  },
-  {
-    title: 'Obra / reforma / instalación',
-    description: 'Para trabajos más grandes o con definición técnica.',
-    href: '/presupuestador?mode=PROJECT',
-  },
+const urgencyItems = [
+  { label: 'Turnos técnicos para hoy', value: '3' },
+  { label: 'Tiempo de respuesta', value: '< 10 min' },
+  { label: 'Canal más rápido', value: 'WhatsApp' },
 ]
 
 export default async function HomePage() {
   const { caseStudies } = await getMarketingHomeData()
   const site = await getSiteContent()
+  const whatsappHref = getWhatsappHref(site)
 
   return (
-    <div className="space-y-14 sm:space-y-16 lg:space-y-20">
-      <section className="relative overflow-hidden rounded-3xl border border-border bg-[#0B0F14] px-6 py-10 text-white sm:px-8 sm:py-14">
+    <div className="space-y-10 pb-24 sm:space-y-14 sm:pb-0">
+      <section className="rounded-2xl border border-red-200 bg-gradient-to-r from-red-50 via-amber-50 to-red-50 px-4 py-3 text-sm sm:px-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <p className="font-semibold text-red-700">
+            ⚠️ Hoy quedan pocos turnos. Confirmá por WhatsApp para entrar en agenda.
+          </p>
+          <a
+            href={whatsappHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex w-fit items-center rounded-full bg-red-600 px-4 py-1.5 text-xs font-bold uppercase tracking-wide text-white hover:bg-red-700"
+            data-track="whatsapp"
+            data-content-name="WhatsApp urgencia home"
+          >
+            Reservar ahora
+          </a>
+        </div>
+      </section>
+
+      <section className="relative overflow-hidden rounded-3xl border border-border/70 text-white">
         <Image
           src={site.hero.backgroundImage}
           alt={site.hero.caption}
           fill
-          className="pointer-events-none object-cover opacity-30"
+          priority
+          className="object-cover"
         />
-        <div className="relative z-10 grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:items-end">
-          <div className="space-y-5">
-            <Badge className="bg-white/10 text-white">NERIN</Badge>
-            <h1 className="max-w-2xl text-3xl font-semibold leading-tight text-white sm:text-4xl lg:text-5xl">
+        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(2,6,23,0.58)_0%,rgba(2,6,23,0.74)_55%,rgba(2,6,23,0.9)_100%)]" />
+
+        <div className="pointer-events-none absolute right-6 top-6 hidden rounded-xl border border-cyan-300/50 bg-slate-950/70 px-4 py-2 text-xs font-semibold text-cyan-200 shadow-lg float-soft lg:block">
+          ✅ 17 consultas recibidas hoy
+        </div>
+
+        <div className="pointer-events-none absolute bottom-24 right-6 hidden rounded-xl border border-red-300/50 bg-red-600/80 px-4 py-2 text-xs font-bold text-white shadow-lg animate-pulse lg:block">
+          Quedan 3 turnos
+        </div>
+
+        <div className="relative z-10 flex min-h-[74vh] flex-col justify-end p-6 sm:p-10">
+          <div className="max-w-3xl space-y-4">
+            <p className="inline-flex w-fit animate-pulse rounded-full border border-[#FBBF24]/50 bg-[#FBBF24]/15 px-3 py-1 text-xs font-bold uppercase tracking-[0.22em] text-[#FDE68A]">
+              Últimos cupos del día
+            </p>
+            <h1 className="text-3xl font-semibold leading-[1.08] text-white sm:text-5xl">
               Contratista eléctrico en CABA y GBA
             </h1>
-            <p className="max-w-xl text-base text-slate-200 sm:text-lg">
+            <p className="max-w-2xl text-base text-slate-100 sm:text-xl">
               Servicios, mantenimiento y trabajos eléctricos para viviendas, comercios y obras.
             </p>
-            <div className="flex flex-wrap gap-3">
-              <Button size="lg" asChild>
-                <Link href="/presupuestador">Iniciar cotización</Link>
-              </Button>
-              <Button size="lg" variant="secondary" asChild>
-                <Link href="/presupuestador?mode=PROJECT">Solicitar obra o reforma</Link>
-              </Button>
-            </div>
+            <p className="text-sm font-medium text-slate-200">
+              Zona de trabajo: {site.contact.serviceArea}
+            </p>
           </div>
-          <div className="rounded-2xl border border-white/20 bg-white/5 p-5 backdrop-blur">
-            <p className="text-sm uppercase tracking-[0.3em] text-slate-300">Zona de trabajo</p>
-            <p className="mt-2 text-lg font-semibold">{site.contact.serviceArea}</p>
+
+          <div className="mt-6 grid gap-3 sm:max-w-2xl sm:grid-cols-3">
+            <Button size="lg" asChild className="h-12 text-base">
+              <Link href="/presupuestador?mode=EXPRESS">Servicio puntual</Link>
+            </Button>
+            <Button size="lg" variant="secondary" asChild className="h-12 text-base">
+              <Link href="/presupuestador?mode=PROJECT">Obra o reforma</Link>
+            </Button>
+            <Button
+              size="lg"
+              asChild
+              className="h-12 bg-[#25D366] text-base font-bold text-black hover:bg-[#1ebe5a]"
+            >
+              <a
+                href={whatsappHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-track="whatsapp"
+                data-content-name="WhatsApp hero principal"
+              >
+                WhatsApp
+              </a>
+            </Button>
+          </div>
+
+          <ul className="mt-4 flex flex-wrap gap-2">
+            {trustPoints.map((point) => (
+              <li
+                key={point}
+                className="rounded-full border border-white/20 bg-white/5 px-3 py-1 text-xs text-slate-100"
+              >
+                {point}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="grid gap-3 sm:grid-cols-3">
+        {urgencyItems.map((item) => (
+          <article
+            key={item.label}
+            className="rounded-2xl border border-[#0EA5E9]/25 bg-[#0B0F14] p-4 text-white"
+          >
+            <p className="text-[11px] uppercase tracking-[0.2em] text-slate-300">{item.label}</p>
+            <p className="mt-2 text-2xl font-bold text-[#22d3ee]">{item.value}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="rounded-2xl border border-cyan-200 bg-gradient-to-r from-cyan-50 to-sky-50 p-5 sm:p-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.34em] text-cyan-700">
+              Precios y presupuesto
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-slate-900">
+              Revisá la lista de precios y pedí tu presupuesto
+            </h2>
+            <p className="mt-1 text-sm text-slate-600">Compará opciones y avanzá en minutos.</p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Button asChild variant="secondary">
+              <Link href="/presupuestador">🗺️ Ver lista de precios</Link>
+            </Button>
+            <Button asChild className="bg-red-600 hover:bg-red-700">
+              <Link href="/presupuestador?mode=PROJECT">Pedir presupuesto ahora</Link>
+            </Button>
           </div>
         </div>
       </section>
 
-      <section className="space-y-6">
-        <div className="max-w-2xl space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Qué hacemos</p>
-          <h2>Tipos de trabajo</h2>
+      <section className="space-y-5">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">
+            Servicios
+          </p>
+          <h2 className="text-2xl font-semibold sm:text-3xl">Qué resolvemos</h2>
         </div>
-        <div className="grid gap-4 lg:grid-cols-2">
-          {worlds.map((world) => (
-            <article key={world.title} className="rounded-2xl border border-border bg-white p-5">
-              <h3 className="text-lg font-semibold">{world.title}</h3>
-              <p className="mt-2 text-sm text-muted-foreground">{world.description}</p>
-              <Button variant="ghost" className="mt-4 px-0" asChild>
-                <a href={world.href}>Continuar</a>
-              </Button>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {services.map((service) => (
+            <article
+              key={service}
+              className="rounded-xl border border-border/80 bg-white px-4 py-3 text-sm font-medium shadow-sm transition-all hover:-translate-y-0.5 hover:border-red-300 hover:shadow-md"
+            >
+              {service}
             </article>
           ))}
         </div>
       </section>
 
-      <section className="grid gap-8 lg:grid-cols-[1fr_1.2fr] lg:items-start">
-        <div className="space-y-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Cómo trabajamos</p>
-          <h2>Proceso simple</h2>
-        </div>
-        <ul className="grid gap-3">
-          {workSteps.map((step) => (
-            <li key={step} className="rounded-2xl border border-border bg-muted/20 px-5 py-4 text-sm font-medium">
-              {step}
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      <section className="space-y-6">
-        <div className="max-w-2xl space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Casos</p>
-          <h2>Trabajos recientes</h2>
+      <section className="space-y-5">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">
+            Casos
+          </p>
+          <h2 className="text-2xl font-semibold sm:text-3xl">Trabajos recientes</h2>
         </div>
         <div className="grid gap-5 md:grid-cols-2">
           {caseStudies.slice(0, 2).map((cs) => (
-            <article key={cs.id} className="overflow-hidden rounded-2xl border border-border bg-white">
-              <div className="relative h-56 w-full">
-                <Image src={cs.fotos[0] ?? site.hero.backgroundImage} alt={cs.titulo} fill className="object-cover" />
+            <article
+              key={cs.id}
+              className="overflow-hidden rounded-2xl border border-border bg-white shadow-sm"
+            >
+              <div className="relative h-56 w-full sm:h-64">
+                <Image
+                  src={cs.fotos[0] ?? site.hero.backgroundImage}
+                  alt={cs.titulo}
+                  fill
+                  className="object-cover"
+                />
               </div>
-              <div className="space-y-3 p-5">
-                <h3 className="text-lg font-semibold">{cs.titulo}</h3>
+              <div className="space-y-2 p-5">
+                <h3 className="text-lg font-semibold text-slate-900">{cs.titulo}</h3>
                 <p className="text-sm text-muted-foreground">{cs.resumen}</p>
               </div>
             </article>
           ))}
         </div>
-        <Button variant="secondary" asChild>
-          <Link href="/obras">Ver casos</Link>
-        </Button>
       </section>
 
-      <section className="space-y-6 rounded-3xl border border-border bg-muted/30 p-6 sm:p-8">
-        <div className="max-w-2xl space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted-foreground">Cómo contratar</p>
-          <h2>Elegí una opción</h2>
-        </div>
-        <div className="grid gap-4 lg:grid-cols-2">
-          {hiringFlow.map((step) => (
-            <article key={step.title} className="rounded-2xl border border-border bg-white p-5">
-              <h3 className="font-semibold">{step.title}</h3>
-              <p className="mt-2 text-sm text-muted-foreground">{step.description}</p>
-              <Button variant="ghost" className="mt-4 px-0" asChild>
-                <a href={step.href}>Continuar</a>
-              </Button>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="rounded-3xl bg-[#0B0F14] px-6 py-10 text-white sm:px-8">
-        <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
-          <div className="space-y-2">
-            <p className="text-xs uppercase tracking-[0.35em] text-[#FBBF24]">Contacto</p>
-            <h2 className="text-white">¿Necesitás una cotización?</h2>
+      <section className="rounded-2xl border border-red-300 bg-gradient-to-r from-red-50 to-amber-50 p-6 sm:p-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.34em] text-red-700">
+              Últimos turnos de hoy
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-slate-900">
+              Pedí presupuesto y cerrá tu turno ahora
+            </h2>
+            <p className="mt-1 text-sm text-slate-600">
+              Te respondemos por WhatsApp y coordinamos rápido.
+            </p>
           </div>
-          <Button size="lg" asChild>
-            <Link href="/contacto">Contacto</Link>
+          <div className="flex flex-wrap gap-3">
+            <Button asChild className="bg-[#25D366] text-black hover:bg-[#1ebe5a]">
+              <a
+                href={whatsappHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-track="whatsapp"
+                data-content-name="WhatsApp cierre home"
+              >
+                Llamar / WhatsApp ahora
+              </a>
+            </Button>
+            <Button variant="secondary" asChild>
+              <Link href="/contacto">Enviar consulta</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <a
+        href={whatsappHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="fixed bottom-24 right-4 z-40 hidden rounded-full bg-[#25D366] px-4 py-3 text-sm font-bold text-black shadow-2xl hover:bg-[#1ebe5a] lg:inline-flex float-soft"
+        data-track="whatsapp"
+        data-content-name="WhatsApp flotante desktop"
+      >
+        WhatsApp inmediato
+      </a>
+
+      <div className="fixed inset-x-0 bottom-3 z-40 px-4 sm:hidden">
+        <div className="mx-auto grid max-w-md grid-cols-2 gap-2 rounded-2xl border border-border bg-white/95 p-2 shadow-xl backdrop-blur">
+          <Button asChild className="h-11 bg-[#25D366] text-black hover:bg-[#1ebe5a]">
+            <a
+              href={whatsappHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-track="whatsapp"
+              data-content-name="WhatsApp barra fija mobile"
+            >
+              WhatsApp ya
+            </a>
+          </Button>
+          <Button asChild className="h-11 bg-red-600 hover:bg-red-700">
+            <Link href="/presupuestador?mode=EXPRESS">Reservar turno</Link>
           </Button>
         </div>
-      </section>
+      </div>
     </div>
   )
 }

--- a/nerin-electric-site-v3-fixed/app/globals.css
+++ b/nerin-electric-site-v3-fixed/app/globals.css
@@ -27,7 +27,10 @@ body {
 }
 
 a {
-  transition: color 0.2s ease, opacity 0.2s ease, text-decoration-color 0.2s ease;
+  transition:
+    color 0.2s ease,
+    opacity 0.2s ease,
+    text-decoration-color 0.2s ease;
 }
 
 a:hover:not(.no-underline),
@@ -100,5 +103,51 @@ main {
   textarea,
   button {
     @apply text-base md:text-sm;
+  }
+}
+
+@keyframes marquee-left {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}
+
+@keyframes float-soft {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes pulse-ring {
+  0% {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(239, 68, 68, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0);
+  }
+}
+
+@layer utilities {
+  .marquee-track {
+    width: max-content;
+    animation: marquee-left 16s linear infinite;
+  }
+
+  .float-soft {
+    animation: float-soft 3.2s ease-in-out infinite;
+  }
+
+  .pulse-ring {
+    animation: pulse-ring 1.7s infinite;
   }
 }

--- a/nerin-electric-site-v3-fixed/components/Footer.tsx
+++ b/nerin-electric-site-v3-fixed/components/Footer.tsx
@@ -8,9 +8,9 @@ const legalLinks = [
 ] as const
 
 const quickLinks = [
-  { href: '/presupuestador', label: 'Iniciar cotización' },
-  { href: '/presupuesto', label: 'Solicitar relevamiento' },
-  { href: '/obras', label: 'Ver casos' },
+  { href: '/servicios', label: 'Servicios' },
+  { href: '/presupuestador?mode=PROJECT', label: 'Obras' },
+  { href: '/obras', label: 'Casos' },
   { href: '/contacto', label: 'Contacto' },
 ] as const
 
@@ -23,19 +23,52 @@ export function Footer({ site }: FooterProps) {
 
   return (
     <footer className="border-t border-border bg-white">
-      <div className="container grid gap-10 py-12 sm:py-14 md:grid-cols-2 lg:grid-cols-4">
+      <div className="border-b border-red-200 bg-red-50 py-3">
+        <div className="container flex flex-col gap-2 text-sm sm:flex-row sm:items-center sm:justify-between">
+          <p className="font-semibold text-red-700">
+            🔥 Últimos servicios del día: confirmá ahora por WhatsApp.
+          </p>
+          <a
+            href={whatsappHref}
+            className="inline-flex w-fit items-center rounded-full bg-red-600 px-4 py-1.5 text-xs font-bold uppercase tracking-wide text-white hover:bg-red-700 pulse-ring"
+            data-track="whatsapp"
+            data-content-name="WhatsApp promo footer"
+          >
+            Cerrar turno ahora
+          </a>
+        </div>
+      </div>
+
+      <div className="container grid gap-8 py-10 sm:py-12 lg:grid-cols-[1.25fr_1fr_1fr_1fr]">
         <div className="space-y-3">
-          <p className="text-sm uppercase tracking-[0.35em] text-muted-foreground">NERIN</p>
-          <p className="text-sm text-muted-foreground">Contratista eléctrico en CABA y GBA.</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">
+            NERIN
+          </p>
+          <p className="text-sm font-medium text-foreground">
+            Contratista eléctrico en CABA y GBA.
+          </p>
           <p className="text-sm text-muted-foreground">{site.contact.serviceArea}</p>
+          <div className="inline-flex items-center gap-2 rounded-full border border-red-200 bg-red-50 px-3 py-1 text-xs font-semibold text-red-700">
+            Agenda activa · Respuesta rápida
+          </div>
+          <a
+            href={whatsappHref}
+            className="inline-flex items-center rounded-full bg-[#25D366] px-4 py-2 text-sm font-semibold text-black transition hover:bg-[#1ebe5a]"
+            data-track="whatsapp"
+            data-content-name="WhatsApp footer principal"
+          >
+            WhatsApp directo
+          </a>
         </div>
 
         <div>
-          <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Accesos</h4>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">
+            Accesos
+          </h4>
           <ul className="mt-3 space-y-2 text-sm text-foreground">
             {quickLinks.map((item) => (
               <li key={item.href}>
-                <Link href={item.href} className="hover:text-foreground">
+                <Link href={item.href} className="transition-colors hover:text-foreground">
                   {item.label}
                 </Link>
               </li>
@@ -44,10 +77,17 @@ export function Footer({ site }: FooterProps) {
         </div>
 
         <div>
-          <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Contacto</h4>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">
+            Contacto
+          </h4>
           <ul className="mt-3 space-y-2 text-sm text-foreground">
             <li>
-              <a href={whatsappHref} className="hover:text-foreground" data-track="whatsapp" data-content-name="WhatsApp footer">
+              <a
+                href={whatsappHref}
+                className="hover:text-foreground"
+                data-track="whatsapp"
+                data-content-name="WhatsApp footer"
+              >
                 WhatsApp
               </a>
             </li>
@@ -60,7 +100,9 @@ export function Footer({ site }: FooterProps) {
         </div>
 
         <div>
-          <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Legales</h4>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">
+            Legales
+          </h4>
           <ul className="mt-3 space-y-2 text-sm text-foreground">
             {legalLinks.map((item) => (
               <li key={item.href}>
@@ -76,7 +118,10 @@ export function Footer({ site }: FooterProps) {
       <div className="border-t border-border bg-muted py-6">
         <div className="container flex flex-col gap-3 text-sm text-muted-foreground lg:flex-row lg:items-center lg:justify-between">
           <span>© {new Date().getFullYear()} NERIN Electric.</span>
-          <Link href="/admin" className="text-xs uppercase tracking-[0.3em] text-muted-foreground hover:text-foreground">
+          <Link
+            href="/admin"
+            className="text-xs uppercase tracking-[0.3em] text-muted-foreground hover:text-foreground"
+          >
             Panel admin
           </Link>
         </div>

--- a/nerin-electric-site-v3-fixed/components/Header.tsx
+++ b/nerin-electric-site-v3-fixed/components/Header.tsx
@@ -20,109 +20,175 @@ interface HeaderProps {
 
 const navigation = [
   { href: '/', label: 'Inicio' },
-  { href: '/presupuestador', label: 'Cotización' },
+  { href: '/servicios', label: 'Servicios' },
+  { href: '/presupuestador?mode=PROJECT', label: 'Obras' },
   { href: '/obras', label: 'Casos' },
-  { href: '/mantenimiento', label: 'Mantenimiento' },
   { href: '/contacto', label: 'Contacto' },
 ] as const
 
 const clientDashboardRoute = '/clientes' as const
+
+const marqueeMessages = [
+  '⚡ Turnos técnicos para hoy: limitados',
+  '📲 Atención prioritaria por WhatsApp',
+  '🛠️ Servicio puntual y obra eléctrica',
+  '🏙️ Cobertura CABA y GBA',
+]
 
 export function Header({ contact, logo }: HeaderProps) {
   const { data: session } = useSession()
   const [menuOpen, setMenuOpen] = useState(false)
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border/80 bg-white/95 backdrop-blur supports-[padding:env(safe-area-inset-top)]:pt-[env(safe-area-inset-top)]">
-      <div className="container flex items-center justify-between gap-3 py-2.5 sm:gap-4 sm:py-3">
-        <Logo title={logo.title} subtitle={logo.subtitle} imageUrl={logo.imageUrl} className="min-w-0" />
-
-        <nav className="hidden items-center gap-5 text-sm font-medium text-muted-foreground xl:flex">
-          {navigation.map((item) => (
-            <Link key={item.href} href={item.href} className="hover:text-foreground">
-              {item.label}
-            </Link>
+    <>
+      <div className="overflow-hidden border-b border-red-200 bg-red-600 text-white">
+        <div className="marquee-track flex gap-8 px-4 py-1.5 text-[11px] font-bold uppercase tracking-[0.18em]">
+          {[...marqueeMessages, ...marqueeMessages].map((message, idx) => (
+            <span key={`${message}-${idx}`}>{message}</span>
           ))}
-        </nav>
-
-        <div className="flex items-center gap-2 sm:gap-3">
-          <Button variant="outline" size="sm" asChild className="hidden border border-border bg-white text-foreground lg:inline-flex">
-            <a
-              href={contact.whatsappHref}
-              aria-label={contact.whatsappLabel}
-              title={contact.whatsappLabel}
-              target="_blank"
-              rel="noopener noreferrer"
-              data-track="whatsapp"
-              data-content-name="WhatsApp header"
-            >
-              WhatsApp
-            </a>
-          </Button>
-          <Button size="sm" asChild className="hidden lg:inline-flex">
-            <Link href="/presupuestador" data-track="lead" data-content-name="Cotización header">
-              Iniciar cotización
-            </Link>
-          </Button>
-
-          {!session?.user && (
-            <Button variant="secondary" size="sm" asChild className="hidden sm:inline-flex">
-              <Link href="/clientes/login">Ingresar</Link>
-            </Button>
-          )}
-          {session?.user && session.user.role !== 'admin' && (
-            <Button variant="secondary" size="sm" asChild className="hidden sm:inline-flex">
-              <Link href={clientDashboardRoute}>Portal clientes</Link>
-            </Button>
-          )}
-
-          <button
-            type="button"
-            onClick={() => setMenuOpen((prev) => !prev)}
-            className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-white text-foreground xl:hidden"
-            aria-expanded={menuOpen}
-            aria-label="Abrir menú de navegación"
-          >
-            <svg aria-hidden viewBox="0 0 24 24" className="h-5 w-5 stroke-current" fill="none" strokeWidth="1.8">
-              {menuOpen ? <path d="M6 6l12 12M18 6 6 18" /> : <path d="M4 7h16M4 12h16M4 17h16" />}
-            </svg>
-          </button>
         </div>
       </div>
 
-      {menuOpen && (
-        <div className="border-t border-border bg-white xl:hidden">
-          <div className="container space-y-5 py-4">
-            <nav className="grid gap-1 text-sm font-medium text-foreground">
-              {navigation.map((item) => (
-                <Link key={item.href} href={item.href} className="rounded-lg px-3 py-2 hover:bg-muted" onClick={() => setMenuOpen(false)}>
-                  {item.label}
-                </Link>
-              ))}
-            </nav>
-            <div className="grid gap-2 sm:grid-cols-2">
-              <Button asChild onClick={() => setMenuOpen(false)}>
-                <Link href="/presupuestador">Iniciar cotización</Link>
-              </Button>
-              <Button variant="outline" asChild>
-                <a href={contact.whatsappHref} target="_blank" rel="noopener noreferrer">
-                  WhatsApp
-                </a>
-              </Button>
-              {!session?.user && (
-                <Button variant="secondary" asChild className="sm:col-span-2" onClick={() => setMenuOpen(false)}>
-                  <Link href="/clientes/login">Ingresar</Link>
-                </Button>
-              )}
-              {session?.user && session.user.role !== 'admin' && (
-                <Button variant="secondary" asChild className="sm:col-span-2" onClick={() => setMenuOpen(false)}>
-                  <Link href={clientDashboardRoute}>Portal clientes</Link>
-                </Button>
-              )}
-            </div>
+      <header className="sticky top-0 z-50 border-b border-border/80 bg-white/95 backdrop-blur supports-[padding:env(safe-area-inset-top)]:pt-[env(safe-area-inset-top)]">
+        <div className="container flex items-center justify-between gap-3 py-2.5 sm:gap-4 sm:py-3">
+          <Logo
+            title={logo.title}
+            subtitle={logo.subtitle}
+            imageUrl={logo.imageUrl}
+            className="min-w-0"
+          />
+
+          <nav className="hidden items-center gap-5 text-sm font-medium text-muted-foreground xl:flex">
+            {navigation.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="transition-colors hover:text-foreground"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+
+          <div className="flex items-center gap-2 sm:gap-3">
+            <Button
+              size="sm"
+              asChild
+              className="hidden border-0 bg-[#25D366] font-semibold text-black hover:bg-[#1ebe5a] lg:inline-flex"
+            >
+              <a
+                href={contact.whatsappHref}
+                aria-label={contact.whatsappLabel}
+                title={contact.whatsappLabel}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-track="whatsapp"
+                data-content-name="WhatsApp header"
+              >
+                WhatsApp ya
+              </a>
+            </Button>
+            <Button
+              size="sm"
+              asChild
+              className="hidden bg-red-600 hover:bg-red-700 lg:inline-flex pulse-ring"
+            >
+              <Link
+                href="/presupuestador?mode=EXPRESS"
+                data-track="lead"
+                data-content-name="Servicio puntual header"
+              >
+                Reservar turno
+              </Link>
+            </Button>
+
+            <button
+              type="button"
+              onClick={() => setMenuOpen((prev) => !prev)}
+              className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-white text-foreground xl:hidden"
+              aria-expanded={menuOpen}
+              aria-label="Abrir menú de navegación"
+            >
+              <svg
+                aria-hidden
+                viewBox="0 0 24 24"
+                className="h-5 w-5 stroke-current"
+                fill="none"
+                strokeWidth="1.8"
+              >
+                {menuOpen ? (
+                  <path d="M6 6l12 12M18 6 6 18" />
+                ) : (
+                  <path d="M4 7h16M4 12h16M4 17h16" />
+                )}
+              </svg>
+            </button>
           </div>
         </div>
-      )}
-    </header>
+
+        {menuOpen && (
+          <div className="border-t border-border bg-white xl:hidden">
+            <div className="container space-y-5 py-4">
+              <nav className="grid gap-1 text-sm font-medium text-foreground">
+                {navigation.map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className="rounded-lg px-3 py-2 hover:bg-muted"
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+              </nav>
+
+              <div className="grid gap-2 sm:grid-cols-2">
+                <Button
+                  asChild
+                  className="bg-red-600 hover:bg-red-700"
+                  onClick={() => setMenuOpen(false)}
+                >
+                  <Link href="/presupuestador?mode=EXPRESS">Reservar turno</Link>
+                </Button>
+                <Button asChild className="bg-[#25D366] text-black hover:bg-[#1ebe5a]">
+                  <a href={contact.whatsappHref} target="_blank" rel="noopener noreferrer">
+                    WhatsApp ya
+                  </a>
+                </Button>
+                <Button
+                  variant="secondary"
+                  asChild
+                  className="sm:col-span-2"
+                  onClick={() => setMenuOpen(false)}
+                >
+                  <Link href="/contacto">Contacto</Link>
+                </Button>
+
+                {!session?.user && (
+                  <Button
+                    variant="outline"
+                    asChild
+                    className="sm:col-span-2"
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    <Link href="/clientes/login">Ingresar</Link>
+                  </Button>
+                )}
+                {session?.user && session.user.role !== 'admin' && (
+                  <Button
+                    variant="outline"
+                    asChild
+                    className="sm:col-span-2"
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    <Link href={clientDashboardRoute}>Portal clientes</Link>
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </header>
+    </>
   )
 }


### PR DESCRIPTION
### Motivation
- Improve lead conversion by surfacing urgent messaging and direct WhatsApp contact points across the site.
- Simplify and modernize homepage content to emphasize services, recent cases and fast booking options.
- Add lightweight motion and utility styles to enhance perceived responsiveness and visual hierarchy.

### Description
- Reworked the homepage (`app/(site)/page.tsx`) to replace previous sections with a hero promoting limited daily slots, urgency cards, a services grid, price/presupuesto callout, and floating/fixed WhatsApp CTAs, and wired `getWhatsappHref` from `@/lib/site-content` for all WhatsApp links.
- Updated header (`components/Header.tsx`) to add a top marquee, update navigation items, expose prominent `WhatsApp` and `Reservar turno` CTAs, and refactored the mobile menu actions and layout.
- Updated footer (`components/Footer.tsx`) to include a promotional strip with a WhatsApp CTA, reorganized quick links, and improved visual treatments and copy.
- Added CSS animations and utility classes in `app/globals.css` (`@keyframes marquee-left`, `float-soft`, `pulse-ring` and `.marquee-track`, `.float-soft`, `.pulse-ring`) and small accessibility/transition tweaks for anchors.

### Testing
- Ran a production build with `next build` which completed successfully.
- Ran TypeScript checks with `tsc --noEmit` which passed without type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6c57586f08331ada392289e6914fc)