### PR TITLE
Fix typedRoutes typing for home sales offer links

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(site)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/page.tsx
@@ -2,6 +2,7 @@ export const dynamic = 'force-dynamic'
 
 import Image from 'next/image'
 import Link from 'next/link'
+import type { Route } from 'next'
 import { getMarketingHomeData } from '@/lib/marketing-data'
 import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import { Button } from '@/components/ui/button'
@@ -57,8 +58,27 @@ const urgencyItems = [
   { label: 'Canal más rápido', value: 'WhatsApp' },
 ]
 
-const salesOffers = [
+type SalesOfferBase = {
+  title: string
+  oldPrice: string
+  newPrice: string
+  note: string
+  cta: string
+}
+
+type SalesOffer =
+  | (SalesOfferBase & {
+      kind: 'route'
+      href: Route
+    })
+  | (SalesOfferBase & {
+      kind: 'anchor'
+      href: `#${string}`
+    })
+
+const salesOffers: SalesOffer[] = [
   {
+    kind: 'route',
     title: 'Servicio puntual express',
     oldPrice: '$58.000',
     newPrice: '$49.000',
@@ -67,6 +87,7 @@ const salesOffers = [
     cta: 'Reservar express',
   },
   {
+    kind: 'route',
     title: 'Obra / reforma',
     oldPrice: '$220.000',
     newPrice: '$189.000',
@@ -75,6 +96,7 @@ const salesOffers = [
     cta: 'Pedir presupuesto',
   },
   {
+    kind: 'anchor',
     title: 'Urgencias por WhatsApp',
     oldPrice: '2 hs',
     newPrice: 'Hoy',
@@ -231,7 +253,11 @@ export default async function HomePage() {
               </div>
               <p className="mt-2 text-sm text-slate-600">{offer.note}</p>
               <Button asChild className="mt-4 w-full bg-red-600 hover:bg-red-700">
-                <Link href={offer.href}>{offer.cta}</Link>
+                {offer.kind === 'route' ? (
+                  <Link href={offer.href}>{offer.cta}</Link>
+                ) : (
+                  <a href={offer.href}>{offer.cta}</a>
+                )}
               </Button>
             </article>
           ))}


### PR DESCRIPTION
### Motivation
- The production build failed type-checking because `salesOffers` used `href: string` while `typedRoutes` requires stricter `Link` types, causing `Type 'string' is not assignable to type 'UrlObject | RouteImpl<string>'` when rendering `<Link href={offer.href}>`.
- The offers array mixes internal app routes and hash anchors (`#...`), so a single `string` type was insufficient and unsafe for `Link` usage.
- The goal was to fix typings and rendering without disabling `typedRoutes`, adding unsafe casts, or changing visual behavior.

### Description
- Imported `type Route` from `next` and introduced `SalesOfferBase` plus a discriminated union `SalesOffer` with `kind: 'route'` (`href: Route`) and `kind: 'anchor'` (`href: `#${string}``).
- Updated the `salesOffers` array to include `kind` for each item and typed the array as `SalesOffer[]` so TypeScript knows which `href` shape applies.
- Changed the offer render to conditionally use `<Link href={...}>` when `kind === 'route'` and `<a href={...}>` when `kind === 'anchor'`, preserving existing styles and behavior.

### Testing
- Ran `cd nerin-electric-site-v3-fixed && npm run build` and the build completed successfully with type-checking passing.
- Confirmed the original type-check error for `app/(site)/page.tsx` no longer appears and the offers render paths remain functional.
- Searched other `Link href={...}` occurrences and reviewed them; no other instances required the same discriminated-union change so only the home page was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7511e52dc8331b46ec7ff83643c60)