### PR TITLE
Restructure admin dashboard and refresh site content and CTAs

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/page.tsx
@@ -25,6 +25,29 @@ const AdminPacks = dynamicImport(() => import('./AdminPacks'), { ssr: false })
 
 export const revalidate = 0
 
+const moduleCards = [
+  {
+    title: 'Contenido del sitio',
+    description: 'Home, textos clave, contacto y estructura comercial.',
+    href: '#contenido',
+  },
+  {
+    title: 'Servicios y proyectos',
+    description: 'Actualizá catálogo, casos y material visual.',
+    href: '#servicios',
+  },
+  {
+    title: 'Precios y packs',
+    description: 'Mantené oferta comercial, adicionales y mantenimiento.',
+    href: '#precios',
+  },
+  {
+    title: 'Operaciones',
+    description: 'Consultas, proyectos, certificados y clientes.',
+    href: '#operaciones',
+  },
+]
+
 export default async function AdminPage() {
   if (!DB_ENABLED) {
     return (
@@ -46,99 +69,129 @@ export default async function AdminPage() {
   ])
 
   return (
-    <div className="space-y-12">
-      <header className="space-y-2">
-        <Badge>Panel administrativo</Badge>
-        <h1>Control total de contenido y operaciones</h1>
-        <p className="text-sm text-slate-600">
-          Diseñá la experiencia del sitio, gestioná marcas, blog, packs, planes de mantenimiento y certificados desde un solo
-          lugar. Cada cambio impacta en el sitio público, clientes y SEO.
-        </p>
-        <div className="flex flex-wrap gap-3 pt-2">
-          <Button variant="outline" asChild>
-            <Link href="/admin/noticias">Gestionar noticias</Link>
-          </Button>
-          <Button variant="outline" asChild>
-            <Link href="/admin/packs">Gestionar packs comerciales</Link>
-          </Button>
-          <Button variant="outline" asChild>
-            <Link href="/admin/ops">Admin operativo</Link>
-          </Button>
-          <Button variant="outline" asChild>
-            <Link href="/admin/operativo">Admin operativo (CAC/IVA)</Link>
-          </Button>
+    <div className="space-y-10">
+      <header className="rounded-3xl border border-border bg-white p-5 sm:p-7">
+        <div className="space-y-3">
+          <Badge>Centro admin NERIN</Badge>
+          <h1 className="text-2xl font-semibold text-slate-900 sm:text-3xl">
+            Admin reestructurado por módulos
+          </h1>
+          <p className="max-w-3xl text-sm text-slate-600 sm:text-base">
+            Todo está organizado para usarlo fácil: elegí un módulo, hacé el cambio y seguí al próximo.
+          </p>
+        </div>
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {moduleCards.map((item) => (
+            <a
+              key={item.title}
+              href={item.href}
+              className="rounded-2xl border border-border bg-slate-50 p-4 text-left transition hover:border-slate-300 hover:bg-white"
+            >
+              <p className="text-sm font-semibold text-slate-900">{item.title}</p>
+              <p className="mt-1 text-xs text-slate-600">{item.description}</p>
+            </a>
+          ))}
         </div>
       </header>
 
-      <SiteExperienceDesigner initialData={site} />
-
-      <section className="grid gap-6 lg:grid-cols-2">
-        <BrandManager initialBrands={brands} />
-        <BlogManager />
+      <section className="grid gap-4 md:grid-cols-4">
+        <StatCard label="Packs" value={packs.length} />
+        <StatCard label="Adicionales" value={adicionales.length} />
+        <StatCard label="Planes" value={plans.length} />
+        <StatCard label="Proyectos" value={projects.length} />
       </section>
 
-      <section className="grid gap-6 lg:grid-cols-2">
-        <ServicesManager />
-        <ProjectsManager />
+      <section id="contenido" className="space-y-4">
+        <h2 className="text-lg font-semibold text-foreground">Módulo 1 · Contenido del sitio</h2>
+        <SiteExperienceDesigner initialData={site} />
       </section>
 
-      <section className="grid gap-6 lg:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <CardTitle>Nuevo adicional</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <form action={createAdditional} className="grid gap-4">
-              <div className="grid gap-2">
-                <Label htmlFor="adicional-nombre">Nombre</Label>
-                <Input id="adicional-nombre" name="nombre" required />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="adicional-descripcion">Descripción</Label>
-                <Textarea id="adicional-descripcion" name="descripcion" required />
-              </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="adicional-unidad">Unidad</Label>
-                  <Input id="adicional-unidad" name="unidad" required />
+      <section id="servicios" className="space-y-4">
+        <h2 className="text-lg font-semibold text-foreground">Módulo 2 · Servicios, marcas y proyectos</h2>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <ServicesManager />
+          <ProjectsManager />
+          <BrandManager initialBrands={brands} />
+          <BlogManager />
+        </div>
+      </section>
+
+      <section id="precios" className="space-y-4">
+        <h2 className="text-lg font-semibold text-foreground">Módulo 3 · Precios y oferta comercial</h2>
+
+        <section className="space-y-3">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-500">Packs</h3>
+          <AdminPacks />
+        </section>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Agregar adicional</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form action={createAdditional} className="grid gap-4">
+                <div className="grid gap-2">
+                  <Label htmlFor="adicional-nombre">Nombre</Label>
+                  <Input id="adicional-nombre" name="nombre" required />
                 </div>
-                <div>
-                  <Label htmlFor="adicional-precio">Precio unitario mano de obra</Label>
-                  <Input id="adicional-precio" name="precioUnitarioManoObra" type="number" required />
+                <div className="grid gap-2">
+                  <Label htmlFor="adicional-descripcion">Descripción</Label>
+                  <Textarea id="adicional-descripcion" name="descripcion" required />
                 </div>
-              </div>
-              <Button type="submit">Agregar adicional</Button>
-            </form>
-          </CardContent>
-        </Card>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="adicional-unidad">Unidad</Label>
+                    <Input id="adicional-unidad" name="unidad" required />
+                  </div>
+                  <div>
+                    <Label htmlFor="adicional-precio">Precio mano de obra</Label>
+                    <Input id="adicional-precio" name="precioUnitarioManoObra" type="number" required />
+                  </div>
+                </div>
+                <Button type="submit">Guardar adicional</Button>
+              </form>
+            </CardContent>
+          </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Nuevo plan de mantenimiento</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <MaintenanceForm />
-          </CardContent>
-        </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Plan de mantenimiento</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <MaintenanceForm />
+            </CardContent>
+          </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Nuevo caso de éxito</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <CaseStudyForm />
-          </CardContent>
-        </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Caso real / obra destacada</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <CaseStudyForm />
+            </CardContent>
+          </Card>
+        </div>
       </section>
 
-      <section className="mt-10">
-        <AdminPacks />
-      </section>
+      <section id="operaciones" className="space-y-4">
+        <h2 className="text-lg font-semibold text-foreground">Módulo 4 · Operaciones y certificados</h2>
 
-      <section className="space-y-6">
+        <div className="flex flex-wrap gap-3">
+          <Button variant="outline" asChild>
+            <Link href="/admin/leads">Ver consultas nuevas</Link>
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href="/admin/ops">Ir al panel operativo</Link>
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href="/admin/ops/projects">Ver proyectos</Link>
+          </Button>
+        </div>
+
         <Card>
           <CardHeader>
-            <CardTitle>Certificados de avance</CardTitle>
+            <CardTitle>Crear certificado de avance</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <form action={createCertificate} className="grid gap-4">
@@ -173,26 +226,8 @@ export default async function AdminPage() {
               </label>
               <Button type="submit">Crear certificado</Button>
             </form>
-            <p className="text-xs text-slate-500">
-              Una vez creado, recordá generar el enlace de pago desde Mercado Pago y guardarlo en el certificado.
-            </p>
           </CardContent>
         </Card>
-      </section>
-
-      <section className="space-y-4">
-        <h2 className="text-lg font-semibold text-foreground">Resumen actual</h2>
-        <div className="grid gap-4 md:grid-cols-3">
-          <StatCard label="Packs publicados" value={packs.length} />
-          <StatCard label="Adicionales" value={adicionales.length} />
-          <StatCard label="Planes de mantenimiento" value={plans.length} />
-        </div>
-        <p className="text-sm text-slate-600">
-          Exportar datos →{' '}
-          <Link className="text-accent" href="/api/admin/export?resource=proyectos">
-            Descargar CSV de proyectos
-          </Link>
-        </p>
       </section>
     </div>
   )

--- a/nerin-electric-site-v3-fixed/app/(site)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/page.tsx
@@ -2,7 +2,6 @@ export const dynamic = 'force-dynamic'
 
 import Image from 'next/image'
 import Link from 'next/link'
-import type { Route } from 'next'
 import { getMarketingHomeData } from '@/lib/marketing-data'
 import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import { Button } from '@/components/ui/button'
@@ -12,9 +11,9 @@ export const revalidate = 60
 export async function generateMetadata() {
   const site = await getSiteContent()
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Contratista eléctrico en CABA y GBA | NERIN'
+  const title = 'Electricidad para hogares y obras en CABA y GBA | NERIN'
   const description =
-    'Servicios, mantenimiento y trabajos eléctricos para viviendas, comercios y obras.'
+    'Respuesta rápida, solicitud simple y ejecución prolija para hogares, comercios y proyectos de obra.'
 
   return {
     title,
@@ -38,87 +37,56 @@ export async function generateMetadata() {
   }
 }
 
-const services = [
-  'Diagnóstico eléctrico',
-  'Reparación de falla',
-  'Colocación de artefactos',
-  'Circuito para aire acondicionado',
-  'Tablero',
-  'Obra / reforma',
-  'Local / oficina',
-  'Vivienda',
-  'Edificio',
+const trustPoints = [
+  'Atención en CABA y GBA',
+  'Solicitud por WhatsApp o formulario',
+  'Ejecución prolija y seguimiento',
 ]
 
-const trustPoints = ['Atención en CABA y GBA', 'Respuesta rápida', 'Trabajo seguro y prolijo']
-
-const urgencyItems = [
-  { label: 'Turnos técnicos para hoy', value: '3' },
-  { label: 'Tiempo de respuesta', value: '< 10 min' },
-  { label: 'Canal más rápido', value: 'WhatsApp' },
-]
-
-type SalesOfferBase = {
-  title: string
-  oldPrice: string
-  newPrice: string
-  note: string
-  cta: string
-}
-
-type SalesOffer =
-  | (SalesOfferBase & {
-      kind: 'route'
-      href: Route
-    })
-  | (SalesOfferBase & {
-      kind: 'anchor'
-      href: `#${string}`
-    })
-
-const salesOffers: SalesOffer[] = [
+const systemSteps = [
   {
-    kind: 'route',
-    title: 'Servicio puntual express',
-    oldPrice: '$58.000',
-    newPrice: '$49.000',
-    note: 'Diagnóstico + solución en visita técnica',
+    title: '1) Enviás solicitud',
+    description: 'Nos contás qué necesitás por WhatsApp o formulario en menos de 2 minutos.',
+  },
+  {
+    title: '2) Ordenamos el trabajo',
+    description: 'Definimos alcance, prioridad y el mejor formato: puntual, instalación o proyecto.',
+  },
+  {
+    title: '3) Te confirmamos propuesta',
+    description: 'Recibís una propuesta clara para avanzar sin idas y vueltas.',
+  },
+  {
+    title: '4) Ejecutamos y cerramos',
+    description: 'Coordinamos, resolvemos y dejamos el trabajo terminado con seguimiento.',
+  },
+]
+
+const serviceCards = [
+  {
+    title: 'Servicio puntual en hogar',
+    description: 'Artefactos, lámparas, circuitos y fallas comunes resueltas con orden y rapidez.',
     href: '/presupuestador?mode=EXPRESS',
-    cta: 'Reservar express',
+    cta: 'Enviar solicitud puntual',
   },
   {
-    kind: 'route',
-    title: 'Obra / reforma',
-    oldPrice: '$220.000',
-    newPrice: '$189.000',
-    note: 'Presupuesto técnico + plan de ejecución',
+    title: 'Instalaciones y mejoras',
+    description: 'Tableros, circuitos dedicados, puesta a tierra y mejoras para trabajar con tranquilidad.',
+    href: '/servicios',
+    cta: 'Ver servicios',
+  },
+  {
+    title: 'Obras y reformas con presupuesto',
+    description: 'Proyectos de vivienda y obra con alcance claro y coordinación profesional.',
     href: '/presupuestador?mode=PROJECT',
-    cta: 'Pedir presupuesto',
-  },
-  {
-    kind: 'anchor',
-    title: 'Urgencias por WhatsApp',
-    oldPrice: '2 hs',
-    newPrice: 'Hoy',
-    note: 'Canal prioritario para respuesta inmediata',
-    href: '#whatsapp-directo',
-    cta: 'Escribir ahora',
+    cta: 'Iniciar cotización',
   },
 ]
 
-const quickAnswers = [
-  {
-    q: '¿En cuánto responden?',
-    a: 'Por WhatsApp respondemos rápido y coordinamos disponibilidad del día.',
-  },
-  {
-    q: '¿Pasan precio antes?',
-    a: 'Sí. Podés revisar lista de precios y pedir presupuesto en el momento.',
-  },
-  {
-    q: '¿Atienden CABA y GBA?',
-    a: 'Sí, trabajamos toda esa zona y coordinamos por tipo de trabajo.',
-  },
+const riskPoints = [
+  'Solicitud simple y respuesta ordenada para que no quedes esperando sin saber.',
+  'Alcance claro antes de avanzar, para evitar sorpresas innecesarias.',
+  'Seguimiento del trabajo hasta cierre, especialmente en proyectos grandes.',
 ]
 
 export default async function HomePage() {
@@ -128,70 +96,46 @@ export default async function HomePage() {
 
   return (
     <div className="space-y-10 pb-24 sm:space-y-14 sm:pb-0">
-      <section className="rounded-2xl border border-red-200 bg-gradient-to-r from-red-50 via-amber-50 to-red-50 px-4 py-3 text-sm sm:px-6">
+      <section className="rounded-2xl border border-cyan-200 bg-gradient-to-r from-cyan-50 to-sky-50 px-4 py-3 text-sm sm:px-6">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <p className="font-semibold text-red-700">
-            ⚠️ Hoy quedan pocos turnos. Confirmá por WhatsApp para entrar en agenda.
+          <p className="font-semibold text-cyan-900">
+            Agenda activa esta semana. Si querés resolverlo rápido, enviá tu solicitud ahora.
           </p>
           <a
             href={whatsappHref}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex w-fit items-center rounded-full bg-red-600 px-4 py-1.5 text-xs font-bold uppercase tracking-wide text-white hover:bg-red-700"
+            className="inline-flex w-fit items-center rounded-full bg-[#25D366] px-4 py-1.5 text-xs font-bold uppercase tracking-wide text-black hover:bg-[#1ebe5a]"
             data-track="whatsapp"
             data-content-name="WhatsApp urgencia home"
           >
-            Reservar ahora
+            Solicitar por WhatsApp
           </a>
         </div>
       </section>
 
       <section className="relative overflow-hidden rounded-3xl border border-border/70 text-white">
-        <Image
-          src={site.hero.backgroundImage}
-          alt={site.hero.caption}
-          fill
-          priority
-          className="object-cover"
-        />
+        <Image src={site.hero.backgroundImage} alt={site.hero.caption} fill priority className="object-cover" />
         <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(2,6,23,0.58)_0%,rgba(2,6,23,0.74)_55%,rgba(2,6,23,0.9)_100%)]" />
 
-        <div className="pointer-events-none absolute right-6 top-6 hidden rounded-xl border border-cyan-300/50 bg-slate-950/70 px-4 py-2 text-xs font-semibold text-cyan-200 shadow-lg float-soft lg:block">
-          ✅ 17 consultas recibidas hoy
-        </div>
-
-        <div className="pointer-events-none absolute bottom-24 right-6 hidden rounded-xl border border-red-300/50 bg-red-600/80 px-4 py-2 text-xs font-bold text-white shadow-lg animate-pulse lg:block">
-          Quedan 3 turnos
-        </div>
-
-        <div className="relative z-10 flex min-h-[74vh] flex-col justify-end p-6 sm:p-10">
+        <div className="relative z-10 flex min-h-[72vh] flex-col justify-end p-6 sm:p-10">
           <div className="max-w-3xl space-y-4">
-            <p className="inline-flex w-fit animate-pulse rounded-full border border-[#FBBF24]/50 bg-[#FBBF24]/15 px-3 py-1 text-xs font-bold uppercase tracking-[0.22em] text-[#FDE68A]">
-              Últimos cupos del día
+            <p className="inline-flex w-fit rounded-full border border-white/30 bg-white/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.22em] text-slate-100">
+              NERIN Electricidad
             </p>
             <h1 className="text-3xl font-semibold leading-[1.08] text-white sm:text-5xl">
-              Contratista eléctrico en CABA y GBA
+              Si necesitás resolver una falla, una instalación o una obra sin perder tiempo con
+              improvisados, hablá con nosotros.
             </h1>
             <p className="max-w-2xl text-base text-slate-100 sm:text-xl">
-              Servicios, mantenimiento y trabajos eléctricos para viviendas, comercios y obras.
+              Respuesta rápida, solicitud simple y ejecución prolija para hogares, comercios y proyectos
+              de obra en CABA y GBA.
             </p>
-            <p className="text-sm font-medium text-slate-200">
-              Zona de trabajo: {site.contact.serviceArea}
-            </p>
+            <p className="text-sm font-medium text-slate-200">Zona de trabajo: {site.contact.serviceArea}</p>
           </div>
 
-          <div className="mt-6 grid gap-3 sm:max-w-2xl sm:grid-cols-3">
-            <Button size="lg" asChild className="h-12 text-base">
-              <Link href="/presupuestador?mode=EXPRESS">Servicio puntual</Link>
-            </Button>
-            <Button size="lg" variant="secondary" asChild className="h-12 text-base">
-              <Link href="/presupuestador?mode=PROJECT">Obra o reforma</Link>
-            </Button>
-            <Button
-              size="lg"
-              asChild
-              className="h-12 bg-[#25D366] text-base font-bold text-black hover:bg-[#1ebe5a]"
-            >
+          <div className="mt-6 grid gap-3 sm:max-w-2xl sm:grid-cols-2">
+            <Button size="lg" asChild className="h-12 bg-[#25D366] text-base font-bold text-black hover:bg-[#1ebe5a]">
               <a
                 id="whatsapp-directo"
                 href={whatsappHref}
@@ -200,8 +144,11 @@ export default async function HomePage() {
                 data-track="whatsapp"
                 data-content-name="WhatsApp hero principal"
               >
-                WhatsApp
+                Hablar por WhatsApp
               </a>
+            </Button>
+            <Button size="lg" asChild className="h-12 bg-red-600 text-base hover:bg-red-700">
+              <Link href="/presupuestador">Enviar solicitud</Link>
             </Button>
           </div>
 
@@ -218,98 +165,46 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="grid gap-3 sm:grid-cols-3">
-        {urgencyItems.map((item) => (
-          <article
-            key={item.label}
-            className="rounded-2xl border border-[#0EA5E9]/25 bg-[#0B0F14] p-4 text-white"
-          >
-            <p className="text-[11px] uppercase tracking-[0.2em] text-slate-300">{item.label}</p>
-            <p className="mt-2 text-2xl font-bold text-[#22d3ee]">{item.value}</p>
-          </article>
-        ))}
+      <section className="space-y-5 rounded-2xl border border-border bg-white p-5 sm:p-6">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">Sistema</p>
+          <h2 className="text-2xl font-semibold text-slate-900">Cómo funciona NERIN</h2>
+          <p className="text-sm text-slate-600">Un proceso simple para que vos sepas qué pasa en cada etapa.</p>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2">
+          {systemSteps.map((step) => (
+            <article key={step.title} className="rounded-xl border border-border bg-muted/20 p-4">
+              <h3 className="text-base font-semibold text-slate-900">{step.title}</h3>
+              <p className="mt-1 text-sm text-slate-600">{step.description}</p>
+            </article>
+          ))}
+        </div>
       </section>
 
       <section className="space-y-5 rounded-2xl border border-red-200 bg-white p-5 sm:p-6">
         <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-red-700">
-            Ofertas del día
-          </p>
-          <h2 className="text-2xl font-semibold text-slate-900">Elegí y cerrá hoy</h2>
+          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-red-700">Servicios</p>
+          <h2 className="text-2xl font-semibold text-slate-900">Qué podés resolver con NERIN</h2>
         </div>
         <div className="grid gap-3 lg:grid-cols-3">
-          {salesOffers.map((offer) => (
+          {serviceCards.map((card) => (
             <article
-              key={offer.title}
+              key={card.title}
               className="rounded-xl border border-border bg-gradient-to-b from-white to-red-50/40 p-4 shadow-sm"
             >
-              <h3 className="text-lg font-semibold text-slate-900">{offer.title}</h3>
-              <p className="mt-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
-                Desde
-              </p>
-              <div className="mt-1 flex items-end gap-2">
-                <span className="text-sm text-slate-400 line-through">{offer.oldPrice}</span>
-                <span className="text-2xl font-bold text-red-600">{offer.newPrice}</span>
-              </div>
-              <p className="mt-2 text-sm text-slate-600">{offer.note}</p>
+              <h3 className="text-lg font-semibold text-slate-900">{card.title}</h3>
+              <p className="mt-2 text-sm text-slate-600">{card.description}</p>
               <Button asChild className="mt-4 w-full bg-red-600 hover:bg-red-700">
-                {offer.kind === 'route' ? (
-                  <Link href={offer.href}>{offer.cta}</Link>
-                ) : (
-                  <a href={offer.href}>{offer.cta}</a>
-                )}
+                <Link href={card.href}>{card.cta}</Link>
               </Button>
             </article>
           ))}
         </div>
       </section>
 
-      <section className="rounded-2xl border border-cyan-200 bg-gradient-to-r from-cyan-50 to-sky-50 p-5 sm:p-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.34em] text-cyan-700">
-              Precios y presupuesto
-            </p>
-            <h2 className="mt-2 text-2xl font-semibold text-slate-900">
-              Revisá la lista de precios y pedí tu presupuesto
-            </h2>
-            <p className="mt-1 text-sm text-slate-600">Compará opciones y avanzá en minutos.</p>
-          </div>
-          <div className="flex flex-wrap gap-3">
-            <Button asChild variant="secondary">
-              <Link href="/presupuestador">🗺️ Ver lista de precios</Link>
-            </Button>
-            <Button asChild className="bg-red-600 hover:bg-red-700">
-              <Link href="/presupuestador?mode=PROJECT">Pedir presupuesto ahora</Link>
-            </Button>
-          </div>
-        </div>
-      </section>
-
       <section className="space-y-5">
         <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">
-            Servicios
-          </p>
-          <h2 className="text-2xl font-semibold sm:text-3xl">Qué resolvemos</h2>
-        </div>
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {services.map((service) => (
-            <article
-              key={service}
-              className="rounded-xl border border-border/80 bg-white px-4 py-3 text-sm font-medium shadow-sm transition-all hover:-translate-y-0.5 hover:border-red-300 hover:shadow-md"
-            >
-              {service}
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="space-y-5">
-        <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">
-            Casos
-          </p>
+          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">Casos reales</p>
           <h2 className="text-2xl font-semibold sm:text-3xl">Trabajos recientes</h2>
         </div>
         <div className="grid gap-5 md:grid-cols-2">
@@ -336,12 +231,11 @@ export default async function HomePage() {
       </section>
 
       <section className="space-y-4 rounded-2xl border border-border bg-white p-5 sm:p-6">
-        <h2 className="text-2xl font-semibold">Respuestas rápidas antes de contratar</h2>
+        <h2 className="text-2xl font-semibold">Tranquilidad antes de contratar</h2>
         <div className="grid gap-3 md:grid-cols-3">
-          {quickAnswers.map((item) => (
-            <article key={item.q} className="rounded-xl border border-border bg-muted/20 p-4">
-              <h3 className="text-base font-semibold text-slate-900">{item.q}</h3>
-              <p className="mt-1 text-sm text-muted-foreground">{item.a}</p>
+          {riskPoints.map((item) => (
+            <article key={item} className="rounded-xl border border-border bg-muted/20 p-4">
+              <p className="text-sm text-muted-foreground">{item}</p>
             </article>
           ))}
         </div>
@@ -350,14 +244,12 @@ export default async function HomePage() {
       <section className="rounded-2xl border border-red-300 bg-gradient-to-r from-red-50 to-amber-50 p-6 sm:p-8">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.34em] text-red-700">
-              Últimos turnos de hoy
-            </p>
+            <p className="text-xs font-semibold uppercase tracking-[0.34em] text-red-700">Cierre rápido</p>
             <h2 className="mt-2 text-2xl font-semibold text-slate-900">
-              Pedí presupuesto y cerrá tu turno ahora
+              Enviá tu solicitud y seguí por el canal que te quede más cómodo
             </h2>
             <p className="mt-1 text-sm text-slate-600">
-              Te respondemos por WhatsApp y coordinamos rápido.
+              WhatsApp para velocidad. Formulario para dejar todo ordenado desde el inicio.
             </p>
           </div>
           <div className="flex flex-wrap gap-3">
@@ -369,11 +261,11 @@ export default async function HomePage() {
                 data-track="whatsapp"
                 data-content-name="WhatsApp cierre home"
               >
-                Llamar / WhatsApp ahora
+                Solicitar por WhatsApp
               </a>
             </Button>
             <Button variant="secondary" asChild>
-              <Link href="/contacto">Enviar consulta</Link>
+              <Link href="/presupuestador">Enviar solicitud</Link>
             </Button>
           </div>
         </div>
@@ -387,7 +279,7 @@ export default async function HomePage() {
         data-track="whatsapp"
         data-content-name="WhatsApp flotante desktop"
       >
-        WhatsApp inmediato
+        Solicitar por WhatsApp
       </a>
 
       <div className="fixed inset-x-0 bottom-3 z-40 px-4 sm:hidden">
@@ -400,11 +292,11 @@ export default async function HomePage() {
               data-track="whatsapp"
               data-content-name="WhatsApp barra fija mobile"
             >
-              WhatsApp ya
+              WhatsApp
             </a>
           </Button>
           <Button asChild className="h-11 bg-red-600 hover:bg-red-700">
-            <Link href="/presupuestador?mode=EXPRESS">Reservar turno</Link>
+            <Link href="/presupuestador">Solicitud</Link>
           </Button>
         </div>
       </div>

--- a/nerin-electric-site-v3-fixed/app/(site)/presupuestador/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/presupuestador/page.tsx
@@ -9,8 +9,9 @@ export const revalidate = 60
 
 export async function generateMetadata() {
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Cotización | NERIN'
-  const description = 'Elegí entre servicio puntual o obra / reforma / instalación.'
+  const title = 'Presupuestador y solicitud de servicios | NERIN'
+  const description =
+    'Elegí tipo de trabajo, enviá solicitud y avanzá con una propuesta clara para hogar, comercio u obra.'
 
   return {
     title,
@@ -35,15 +36,21 @@ export async function generateMetadata() {
 
 const doors = [
   {
-    title: 'Servicio puntual',
-    description: 'Para resolver un trabajo concreto y directo.',
+    title: 'Solicitud puntual',
+    description: 'Para resolver tareas concretas en vivienda, comercio u oficina.',
     href: '/presupuestador?mode=EXPRESS',
   },
   {
-    title: 'Obra / reforma / instalación',
-    description: 'Para trabajos grandes y variantes con plano o cantidades.',
+    title: 'Proyecto / obra / reforma',
+    description: 'Para trabajos de mayor escala con planificación y alcance definido.',
     href: '/presupuestador?mode=PROJECT',
   },
+]
+
+const howItWorks = [
+  'Completás datos clave de forma simple.',
+  'Definimos tipo de servicio y prioridad.',
+  'Recibís propuesta y continuás por el canal más cómodo.',
 ]
 
 export default async function PresupuestadorPage({
@@ -76,19 +83,33 @@ export default async function PresupuestadorPage({
 
   return (
     <div className="space-y-8 sm:space-y-10">
-      <header className="space-y-4">
-        <Badge>Cotización</Badge>
-        <h1>Elegí cómo querés avanzar</h1>
-        <p className="max-w-3xl text-lg text-slate-600">Dos caminos claros para cotizar sin confusión.</p>
+      <header className="space-y-4 rounded-3xl border border-border/70 bg-slate-950 p-6 text-white sm:p-8">
+        <Badge className="w-fit border-cyan-300/50 bg-cyan-500/20 text-cyan-100">Presupuestador</Badge>
+        <h1 className="text-3xl sm:text-4xl">Enviá solicitud y avanzá con una propuesta clara</h1>
+        <p className="max-w-3xl text-base text-slate-200 sm:text-lg">
+          Este flujo está pensado para que puedas resolver trabajos puntuales o proyectos de obra sin
+          complicarte.
+        </p>
       </header>
+
+      <section className="grid gap-3 sm:grid-cols-3">
+        {howItWorks.map((item) => (
+          <article key={item} className="rounded-2xl border border-border bg-white p-4">
+            <p className="text-sm text-slate-700">{item}</p>
+          </article>
+        ))}
+      </section>
 
       <section className="grid gap-4 md:grid-cols-2">
         {doors.map((door) => (
-          <article key={door.title} className="rounded-2xl border border-border bg-white p-5">
-            <h2 className="text-base font-semibold">{door.title}</h2>
-            <p className="mt-2 text-sm text-muted-foreground">{door.description}</p>
-            <Button variant="ghost" className="mt-4 px-0" asChild>
-              <a href={door.href}>Continuar</a>
+          <article
+            key={door.title}
+            className="rounded-2xl border border-border bg-gradient-to-b from-white to-cyan-50/40 p-5"
+          >
+            <h2 className="text-base font-semibold text-slate-900">{door.title}</h2>
+            <p className="mt-2 text-sm text-slate-700">{door.description}</p>
+            <Button className="mt-4 w-full bg-cyan-700 hover:bg-cyan-800" asChild>
+              <a href={door.href}>Elegir opción</a>
             </Button>
           </article>
         ))}

--- a/nerin-electric-site-v3-fixed/app/(site)/presupuesto/PresupuestoForm.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/presupuesto/PresupuestoForm.tsx
@@ -150,7 +150,7 @@ export function PresupuestoForm({ whatsappNumber, leadType, plan }: PresupuestoF
       <div className="space-y-5 rounded-3xl border border-border bg-white p-4 shadow-subtle sm:p-6 lg:p-8">
         <h2 className="text-2xl font-semibold text-foreground">¡Solicitud enviada!</h2>
         <p className="text-sm text-slate-600">
-          Recibimos tu pedido. Tu ID de solicitud es <strong>{leadId}</strong>. Te respondemos en 24–48 h.
+          Recibimos tu pedido. Tu ID de solicitud es <strong>{leadId}</strong>. Te respondemos para coordinar. En proyectos grandes, la cotización completa puede tomar 24–48 h.
         </p>
         <Button asChild size="lg">
           <a href={whatsappHref} target="_blank" rel="noreferrer" data-track="whatsapp" data-content-name="WhatsApp presupuesto">
@@ -164,6 +164,9 @@ export function PresupuestoForm({ whatsappNumber, leadType, plan }: PresupuestoF
   return (
     <form onSubmit={handleSubmit} className="space-y-5 rounded-3xl border border-border bg-white p-4 shadow-subtle sm:p-6 lg:p-8">
       <AttributionFields />
+      <div className="rounded-2xl border border-cyan-200 bg-cyan-50/60 p-3 text-sm text-cyan-900">
+        Completá lo básico y te contactamos para ordenar el trabajo. Si después querés, agregás más detalle.
+      </div>
       <div className="grid gap-4 md:grid-cols-2">
         <div>
           <Label htmlFor="nombre">Nombre y Apellido *</Label>
@@ -174,17 +177,16 @@ export function PresupuestoForm({ whatsappNumber, leadType, plan }: PresupuestoF
           <Input id="telefono" name="telefono" required placeholder="11 5555-5555" />
         </div>
         <div>
-          <Label htmlFor="email">Email *</Label>
-          <Input id="email" name="email" type="email" required placeholder="correo@empresa.com" />
+          <Label htmlFor="email">Email (opcional)</Label>
+          <Input id="email" name="email" type="email" placeholder="correo@empresa.com" />
         </div>
         <div>
-          <Label htmlFor="cliente">Tipo de cliente *</Label>
+          <Label htmlFor="cliente">Tipo de cliente</Label>
           <select
             id="cliente"
             name="cliente"
             defaultValue={defaultClientType}
             className="min-h-11 w-full rounded-xl border border-border bg-white px-4 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-            required
           >
             {clientTypes.map((option) => (
               <option key={option.value} value={option.value}>
@@ -220,7 +222,7 @@ export function PresupuestoForm({ whatsappNumber, leadType, plan }: PresupuestoF
           </select>
         </div>
         <div>
-          <Label htmlFor="urgencia">Urgencia *</Label>
+          <Label htmlFor="urgencia">Prioridad</Label>
           <select
             id="urgencia"
             name="urgencia"
@@ -237,7 +239,7 @@ export function PresupuestoForm({ whatsappNumber, leadType, plan }: PresupuestoF
         </div>
       </div>
       <div>
-        <Label htmlFor="detalle">Detalle del pedido *</Label>
+        <Label htmlFor="detalle">¿Qué necesitás resolver? *</Label>
         <Textarea
           id="detalle"
           name="detalle"
@@ -278,12 +280,12 @@ export function PresupuestoForm({ whatsappNumber, leadType, plan }: PresupuestoF
           required
           className="mt-1 h-5 w-5 rounded border-border text-accent focus-visible:ring-accent/40"
         />
-        Acepto contacto por WhatsApp/Email.
+        Acepto que me contacten para coordinar la solicitud.
       </label>
       {status === 'error' && <p className="text-sm text-red-600">{errorMessage}</p>}
-      {status === 'submitting' && <p className="text-sm text-slate-500">Enviando formulario y adjuntos, por favor esperá...</p>}
+      {status === 'submitting' && <p className="text-sm text-slate-500">Enviando solicitud...</p>}
       <Button type="submit" size="lg" disabled={status === 'submitting'} className="w-full sm:w-auto">
-        {status === 'submitting' ? 'Enviando...' : 'Enviar solicitud'}
+        {status === 'submitting' ? 'Enviando...' : 'Enviar solicitud y continuar por WhatsApp'}
       </Button>
     </form>
   )

--- a/nerin-electric-site-v3-fixed/app/(site)/servicios/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/servicios/page.tsx
@@ -1,4 +1,6 @@
+import Link from 'next/link'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { fetchPublicJson } from '@/lib/public-api'
 import { getSiteContent } from '@/lib/site-content'
@@ -9,11 +11,27 @@ type Service = {
   description: string
 }
 
+const serviceSystem = [
+  {
+    title: 'Solicitud simple',
+    description: 'Podés arrancar por WhatsApp o formulario según tu caso.',
+  },
+  {
+    title: 'Definición clara',
+    description: 'Ordenamos alcance y prioridad para que sepas cómo seguimos.',
+  },
+  {
+    title: 'Ejecución y seguimiento',
+    description: 'Coordinamos y cerramos el trabajo con comunicación ordenada.',
+  },
+]
+
 export async function generateMetadata() {
   const site = await getSiteContent()
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Servicios eléctricos | NERIN'
-  const description = 'Servicios eléctricos de punta a punta para obras, comercios y consorcios en CABA.'
+  const title = 'Servicios eléctricos en CABA y GBA | NERIN'
+  const description =
+    'Servicios para hogares, comercios y obras con solicitud simple, respuesta rápida y ejecución prolija.'
 
   return {
     title,
@@ -70,19 +88,54 @@ export default async function ServiciosPage() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(servicesSchema) }} />
       <div className="space-y-10">
-        <header className="space-y-4">
-          <Badge>Servicios</Badge>
-          <h1>{site.services.title}</h1>
-          <p className="max-w-3xl text-lg text-slate-600">{site.services.description}</p>
+        <header className="space-y-5 rounded-3xl border border-border/70 bg-slate-950 p-6 text-white sm:p-8">
+          <Badge className="w-fit border-cyan-300/50 bg-cyan-500/20 text-cyan-100">Servicios</Badge>
+          <h1 className="text-3xl font-semibold leading-tight sm:text-5xl">
+            Servicios eléctricos para clientes que valoran rapidez, orden y tranquilidad
+          </h1>
+          <p className="max-w-3xl text-base text-slate-200 sm:text-lg">
+            Desde trabajos puntuales en vivienda hasta proyectos de obra. El objetivo es uno: que
+            avances rápido y sepas siempre qué sigue.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Button className="bg-[#25D366] font-bold text-black hover:bg-[#1ebe5a]" asChild>
+              <Link href="/presupuestador">Enviar solicitud</Link>
+            </Button>
+            <Button className="bg-red-600 font-bold hover:bg-red-700" asChild>
+              <Link href="/presupuestador?mode=PROJECT">Cotización para obra</Link>
+            </Button>
+          </div>
         </header>
+
+        <section className="space-y-4 rounded-2xl border border-border bg-white p-5 sm:p-6">
+          <h2 className="text-2xl font-semibold text-slate-900">Sistema de trabajo</h2>
+          <div className="grid gap-3 md:grid-cols-3">
+            {serviceSystem.map((item) => (
+              <article key={item.title} className="rounded-xl border border-border bg-muted/20 p-4">
+                <h3 className="text-base font-semibold text-slate-900">{item.title}</h3>
+                <p className="mt-1 text-sm text-slate-600">{item.description}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
         <section className="grid gap-6 md:grid-cols-2">
           {services.map((service) => (
-            <Card key={service.id ?? service.title} className="space-y-4">
+            <Card
+              key={service.id ?? service.title}
+              className="space-y-4 border-cyan-100 bg-gradient-to-b from-white to-cyan-50/30"
+            >
               <CardHeader>
                 <CardTitle>{service.title}</CardTitle>
               </CardHeader>
-              <CardContent className="space-y-3 text-sm text-slate-600">
+              <CardContent className="space-y-3 text-sm text-slate-700">
                 <p>{service.description}</p>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-700">
+                  Solicitud clara + ejecución prolija + seguimiento
+                </p>
+                <Button variant="secondary" asChild className="w-full">
+                  <Link href="/presupuestador">Solicitar este servicio</Link>
+                </Button>
               </CardContent>
             </Card>
           ))}

--- a/nerin-electric-site-v3-fixed/components/admin/AdminSidebar.tsx
+++ b/nerin-electric-site-v3-fixed/components/admin/AdminSidebar.tsx
@@ -15,8 +15,9 @@ export function AdminSidebar({ onNavigate, className }: AdminSidebarProps) {
 
   return (
     <aside className={cn('flex h-full w-72 flex-col gap-6 border-r border-border bg-white px-4 py-6', className)}>
-      <div className="flex items-center gap-2 px-2 text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">
-        Admin Nerin
+      <div className="px-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">NERIN</p>
+        <p className="text-sm font-semibold text-slate-700">Centro de control</p>
       </div>
       <nav className="flex flex-1 flex-col gap-5 text-sm">
         {adminNav.map((section) => (
@@ -47,7 +48,7 @@ export function AdminSidebar({ onNavigate, className }: AdminSidebarProps) {
         ))}
       </nav>
       <div className="rounded-2xl border border-border/60 bg-slate-50 px-3 py-2 text-xs text-slate-500">
-        Panel unificado · version admin
+        Flujo recomendado: Inicio admin → editar contenido → revisar consultas.
       </div>
     </aside>
   )

--- a/nerin-electric-site-v3-fixed/components/admin/AdminTopbar.tsx
+++ b/nerin-electric-site-v3-fixed/components/admin/AdminTopbar.tsx
@@ -12,7 +12,7 @@ export function AdminTopbar({ onToggleSidebar }: AdminTopbarProps) {
   const pathname = usePathname()
   const match = findAdminNavMatch(pathname)
   const sectionLabel = match?.sectionLabel ?? adminNav[0]?.label ?? 'Admin'
-  const title = match?.title ?? 'Panel administrativo'
+  const title = match?.title ?? 'Inicio admin'
 
   return (
     <div className="sticky top-0 z-20 border-b border-border bg-white/95 px-4 py-3 backdrop-blur sm:px-6 sm:py-4">
@@ -33,10 +33,19 @@ export function AdminTopbar({ onToggleSidebar }: AdminTopbarProps) {
             <h1 className="text-lg font-semibold text-foreground sm:text-xl">{title}</h1>
           </div>
         </div>
-        <div className="flex items-center gap-3">
-          <div className="hidden items-center gap-2 rounded-full border border-border bg-slate-50 px-3 py-2 text-xs text-slate-500 md:flex">
-            Buscar (próximamente)
-          </div>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/admin"
+            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+          >
+            Centro admin
+          </Link>
+          <Link
+            href="/admin/leads"
+            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+          >
+            Consultas
+          </Link>
           <Link
             href="/"
             className="rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"

--- a/nerin-electric-site-v3-fixed/components/admin/nav.ts
+++ b/nerin-electric-site-v3-fixed/components/admin/nav.ts
@@ -12,39 +12,32 @@ export type AdminNavSection = {
 
 export const adminNav: AdminNavSection[] = [
   {
-    label: 'Dashboard',
+    label: 'Centro de control',
     items: [
-      { title: 'Dashboard', href: '/admin' as Route },
-      { title: 'Leads', href: '/admin/leads' as Route },
+      { title: 'Inicio admin', href: '/admin' as Route },
+      { title: 'Consultas (leads)', href: '/admin/leads' as Route },
     ],
   },
   {
-    label: 'Operaciones (Ops)',
+    label: 'Gestión comercial',
     items: [
-      { title: 'Panel Ops', href: '/admin/ops' as Route },
-      { title: 'Proyectos', href: '/admin/ops/projects' as Route },
-      { title: 'Certificados', href: '/admin/ops/certificates' as Route },
-      { title: 'Adicionales', href: '/admin/ops/projects?tab=adicionales' as Route },
-      { title: 'Clientes', href: '/admin/ops/clients' as Route },
-    ],
-  },
-  {
-    label: 'Packs',
-    items: [{ title: 'Packs comerciales', href: '/admin/packs' as Route }],
-  },
-  {
-    label: 'Contenido',
-    items: [
-      { title: 'Textos del sitio', href: '/admin' as Route },
+      { title: 'Packs y precios', href: '/admin/packs' as Route },
       { title: 'Noticias', href: '/admin/noticias' as Route },
     ],
   },
   {
-    label: 'Ajustes',
+    label: 'Operaciones',
     items: [
-      { title: 'Config general', href: '/admin/ajustes' as Route },
-      { title: 'CAC/IVA operativo', href: '/admin/operativo' as Route },
+      { title: 'Panel operativo', href: '/admin/ops' as Route },
+      { title: 'Proyectos', href: '/admin/ops/projects' as Route },
+      { title: 'Certificados', href: '/admin/ops/certificates' as Route },
+      { title: 'Clientes', href: '/admin/ops/clients' as Route },
+      { title: 'CAC / IVA', href: '/admin/operativo' as Route },
     ],
+  },
+  {
+    label: 'Sistema',
+    items: [{ title: 'Ajustes generales', href: '/admin/ajustes' as Route }],
   },
 ]
 

--- a/nerin-electric-site-v3-fixed/components/configurator/ConfiguratorWizard.tsx
+++ b/nerin-electric-site-v3-fixed/components/configurator/ConfiguratorWizard.tsx
@@ -34,12 +34,12 @@ const modeCards: Array<{ mode: WizardSummary['mode']; title: string; description
   {
     mode: 'EXPRESS',
     title: 'Servicio puntual',
-    description: 'Para resolver un trabajo concreto y directo.',
+    description: 'Para trabajos puntuales con una solicitud simple y resolución ordenada.',
   },
   {
     mode: 'PROJECT',
     title: 'Obra / reforma / instalación',
-    description: 'Para trabajos de mayor alcance que requieren definición técnica.',
+    description: 'Para obras y reformas con alcance definido, etapas y seguimiento.',
   },
 ]
 
@@ -225,7 +225,10 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
       <section className="grid gap-5 lg:grid-cols-[1.35fr_0.9fr] xl:gap-6">
         <Card>
           <CardHeader>
-            <CardTitle>Completá tu solicitud</CardTitle>
+            <CardTitle>Armá tu solicitud y recibí propuesta</CardTitle>
+            <p className="text-sm text-slate-600">
+              Completá estos datos para que podamos ordenar tu caso y darte una propuesta clara.
+            </p>
           </CardHeader>
           <CardContent className="space-y-5">
             <div className="grid gap-3">
@@ -254,7 +257,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
 
             <div className="grid gap-4 md:grid-cols-2">
               <div>
-                <Label>Unidades</Label>
+                <Label>Unidades (estimación rápida)</Label>
                 <Input
                   type="number"
                   min={1}
@@ -263,7 +266,7 @@ export function ConfiguratorWizard({ packs, adicionales, defaultPackId, initialM
                 />
               </div>
               <div>
-                <Label>Urgencia</Label>
+                <Label>Prioridad</Label>
                 <select
                   className="h-11 w-full rounded-xl border border-border bg-white px-4 text-sm"
                   value={summary.urgencyMultiplier}


### PR DESCRIPTION
### Motivation
- Reorganize the admin area into modular sections to make content, pricing and operations easier to find and manage.
- Refresh public site copy and CTAs to emphasize a simpler request flow, WhatsApp-first contact and clearer service/process descriptions.
- Improve the presupuestador/configurator and lead flow wording to reduce friction when users request quotes or report works.
- Harmonize admin navigation and topbar/sidebar labels to match the new modular admin layout.

### Description
- Reworked the admin dashboard page to introduce `moduleCards`, a modular header, stat cards and distinct sections (`#contenido`, `#servicios`, `#precios`, `#operaciones`) and adjusted forms and cards for packs, adicionales, maintenance and certificates in `app/(admin)/admin/(shell)/(dashboard)/page.tsx`.
- Updated public homepage copy, metadata and hero CTAs to emphasize process clarity and WhatsApp contact, replaced pricing/offers UI with a step-based system (`systemSteps`) and refreshed service cards in `app/(site)/page.tsx`.
- Changed the presupuestador page metadata and UI, restyled header, added a short "how it works" block and updated CTA styles in `app/(site)/presupuestador/page.tsx`.
- Improved the Presupuesto form messaging and field behavior, made email optional, softened some required labels, added a cyan hint banner and updated submit text in `app/(site)/presupuesto/PresupuestoForm.tsx`.
- Enhanced the Servicios page with updated metadata, a new header, a "system of work" section and per-service CTAs in `app/(site)/servicios/page.tsx`.
- Adjusted admin UI components and navigation: `AdminSidebar.tsx`, `AdminTopbar.tsx` and `nav.ts` were updated for new labels, section names and quick links to match the reorganized admin experience.
- Small copy and UX tweaks in the configurator (`components/configurator/ConfiguratorWizard.tsx`) such as updated card titles/descriptions, labels for units/priority and supplemental explanatory text.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7544a6c5883318ccd14ab8c1b89bc)