### PR TITLE
Fix Next.js typedRoutes typing for homepage service card links

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(site)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/page.tsx
@@ -2,6 +2,7 @@ export const dynamic = 'force-dynamic'
 
 import Image from 'next/image'
 import Link from 'next/link'
+import type { Route } from 'next'
 import { getMarketingHomeData } from '@/lib/marketing-data'
 import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import { Button } from '@/components/ui/button'
@@ -81,7 +82,12 @@ const serviceCards = [
     href: '/presupuestador?mode=PROJECT',
     cta: 'Iniciar cotización',
   },
-]
+] as const satisfies ReadonlyArray<{
+  title: string
+  description: string
+  href: Route
+  cta: string
+}>
 
 const riskPoints = [
   'Solicitud simple y respuesta ordenada para que no quedes esperando sin saber.',


### PR DESCRIPTION
### Motivation
- Fix a build-time TypeScript error where `Link` received a `string`-typed `href` while `typedRoutes` requires a `Route`-typed value. 
- Keep `typedRoutes` enabled and avoid `any`/`ts-ignore`/per-link casts while preserving existing internal href values and navigation.

### Description
- Import `Route` from `next` with `import type { Route } from 'next'` in `app/(site)/page.tsx`.
- Type `serviceCards` using `as const satisfies ReadonlyArray<{ title: string; description: string; href: Route; cta: string }>` so `card.href` is compatible with `<Link href={card.href}>` without changing href strings.
- Performed a quick scan for other `Link href={...}` patterns to catch similar issues and found no additional build-blocking typedRoutes problems.

### Testing
- Ran a search for `Link href` usages with `rg "<Link href=\{[^}]+\}" -n` to inspect variable-based links, which completed successfully.
- Ran the production build with `npm run build`, which completed successfully and reported only existing lint warnings and runtime DB warnings from missing local tables, with no TypeScript/typedRoutes errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8641b5b3c83318d976ec96804ed09)