### PR TITLE
Rediseñar experiencia pública y admin de NERIN Electricidad

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/page.tsx
@@ -1,233 +1,159 @@
 export const dynamic = 'force-dynamic'
 
 import Link from 'next/link'
-import dynamicImport from 'next/dynamic'
 import { prisma } from '@/lib/db'
-import { getSiteContent } from '@/lib/site-content'
 import { DB_ENABLED } from '@/lib/dbMode'
-import { createAdditional, createCertificate } from '../../actions'
 import { Badge } from '@/components/ui/badge'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Textarea } from '@/components/ui/textarea'
-import { StatCard } from '@/components/admin/ui/StatCard'
-import { CaseStudyForm } from './case-study-form'
-import { MaintenanceForm } from './maintenance-form'
-import { SiteExperienceDesigner } from './SiteExperienceDesigner'
-import { BrandManager } from './BrandManager'
-import { BlogManager } from './BlogManager'
-import { ServicesManager } from './ServicesManager'
-import { ProjectsManager } from './ProjectsManager'
 
-const AdminPacks = dynamicImport(() => import('./AdminPacks'), { ssr: false })
-
-export const revalidate = 0
-
-const moduleCards = [
-  {
-    title: 'Contenido del sitio',
-    description: 'Home, textos clave, contacto y estructura comercial.',
-    href: '#contenido',
-  },
-  {
-    title: 'Servicios y proyectos',
-    description: 'Actualizá catálogo, casos y material visual.',
-    href: '#servicios',
-  },
-  {
-    title: 'Precios y packs',
-    description: 'Mantené oferta comercial, adicionales y mantenimiento.',
-    href: '#precios',
-  },
-  {
-    title: 'Operaciones',
-    description: 'Consultas, proyectos, certificados y clientes.',
-    href: '#operaciones',
-  },
+const pipeline = [
+  'Nuevo',
+  'Contactado',
+  'Esperando fotos',
+  'Presupuesto pendiente',
+  'Presupuesto enviado',
+  'Negociando',
+  'Ganado',
+  'Perdido',
 ]
+
+const alerts = [
+  'Revisar leads nuevos antes de terminar el dia.',
+  'Separar siempre materiales de mano de obra en presupuestos.',
+  'No publicar datos legales, matriculas o responsables hasta cargarlos oficialmente.',
+]
+
+function Stat({ label, value, detail }: { label: string; value: string | number; detail?: string }) {
+  return (
+    <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{label}</p>
+      <p className="mt-3 text-3xl font-semibold text-slate-950">{value}</p>
+      {detail ? <p className="mt-1 text-sm text-slate-500">{detail}</p> : null}
+    </article>
+  )
+}
 
 export default async function AdminPage() {
   if (!DB_ENABLED) {
     return (
       <div className="space-y-4">
         <Badge>Panel administrativo</Badge>
-        <h1>Panel no configurado</h1>
-        <p className="text-sm text-slate-600">La base de datos está deshabilitada. Activala para gestionar contenido.</p>
+        <h1 className="text-3xl font-semibold text-slate-950">Panel no configurado</h1>
+        <p className="text-sm text-slate-600">La base de datos esta deshabilitada. Activala para gestionar contenido y leads.</p>
       </div>
     )
   }
 
-  const site = await getSiteContent()
-  const [packs, adicionales, plans, projects, brands] = await Promise.all([
-    prisma.pack.findMany({ orderBy: { createdAt: 'desc' } }),
-    prisma.additionalItem.findMany({ orderBy: { createdAt: 'desc' } }),
-    prisma.maintenancePlan.findMany({ orderBy: { createdAt: 'desc' } }),
-    prisma.project.findMany({ orderBy: { createdAt: 'desc' } }),
-    prisma.brand.findMany({ orderBy: { nombre: 'asc' } }),
+  const [leads, packs, plans, projects, clients, certificates] = await Promise.all([
+    prisma.lead.findMany({ orderBy: { createdAt: 'desc' }, take: 8 }),
+    prisma.pack.count(),
+    prisma.maintenancePlan.count(),
+    prisma.project.count(),
+    prisma.opsClient.count().catch(() => 0),
+    prisma.opsProgressCertificate.count().catch(() => 0),
   ])
 
+  const currentMonth = new Date().toLocaleDateString('es-AR', { month: 'long', year: 'numeric' })
+
   return (
-    <div className="space-y-10">
-      <header className="rounded-3xl border border-border bg-white p-5 sm:p-7">
-        <div className="space-y-3">
-          <Badge>Centro admin NERIN</Badge>
-          <h1 className="text-2xl font-semibold text-slate-900 sm:text-3xl">
-            Admin reestructurado por módulos
-          </h1>
-          <p className="max-w-3xl text-sm text-slate-600 sm:text-base">
-            Todo está organizado para usarlo fácil: elegí un módulo, hacé el cambio y seguí al próximo.
-          </p>
-        </div>
-        <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          {moduleCards.map((item) => (
-            <a
-              key={item.title}
-              href={item.href}
-              className="rounded-2xl border border-border bg-slate-50 p-4 text-left transition hover:border-slate-300 hover:bg-white"
-            >
-              <p className="text-sm font-semibold text-slate-900">{item.title}</p>
-              <p className="mt-1 text-xs text-slate-600">{item.description}</p>
-            </a>
-          ))}
+    <div className="space-y-8">
+      <header className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <Badge>Centro de control NERIN Electricidad</Badge>
+        <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold text-slate-950">Dashboard comercial, operativo y financiero</h1>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+              Admin interno para controlar leads, presupuestos, obras, certificados, mantenimiento, ingresos, gastos y contenido web.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button asChild className="bg-slate-950 hover:bg-slate-800">
+              <Link href="/admin/leads">Ver leads</Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/admin/packs">Servicios y packs</Link>
+            </Button>
+          </div>
         </div>
       </header>
 
-      <section className="grid gap-4 md:grid-cols-4">
-        <StatCard label="Packs" value={packs.length} />
-        <StatCard label="Adicionales" value={adicionales.length} />
-        <StatCard label="Planes" value={plans.length} />
-        <StatCard label="Proyectos" value={projects.length} />
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <Stat label="Leads nuevos" value={leads.length} detail="ultimos registros visibles" />
+        <Stat label="Presupuestos pendientes" value="0" detail="preparado para Quote" />
+        <Stat label="Obras activas" value={projects} detail="proyectos actuales" />
+        <Stat label="Mantenimientos activos" value={plans} detail="planes configurados" />
+        <Stat label="Ingresos del mes" value="$0" detail={currentMonth} />
+        <Stat label="Gastos del mes" value="$0" detail="categorias listas" />
+        <Stat label="Clientes" value={clients} detail="base operativa" />
+        <Stat label="Certificados" value={certificates} detail="avance y cobro" />
       </section>
 
-      <section id="contenido" className="space-y-4">
-        <h2 className="text-lg font-semibold text-foreground">Módulo 1 · Contenido del sitio</h2>
-        <SiteExperienceDesigner initialData={site} />
-      </section>
-
-      <section id="servicios" className="space-y-4">
-        <h2 className="text-lg font-semibold text-foreground">Módulo 2 · Servicios, marcas y proyectos</h2>
-        <div className="grid gap-6 lg:grid-cols-2">
-          <ServicesManager />
-          <ProjectsManager />
-          <BrandManager initialBrands={brands} />
-          <BlogManager />
-        </div>
-      </section>
-
-      <section id="precios" className="space-y-4">
-        <h2 className="text-lg font-semibold text-foreground">Módulo 3 · Precios y oferta comercial</h2>
-
-        <section className="space-y-3">
-          <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-500">Packs</h3>
-          <AdminPacks />
-        </section>
-
-        <div className="grid gap-6 lg:grid-cols-2">
-          <Card>
-            <CardHeader>
-              <CardTitle>Agregar adicional</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <form action={createAdditional} className="grid gap-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="adicional-nombre">Nombre</Label>
-                  <Input id="adicional-nombre" name="nombre" required />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="adicional-descripcion">Descripción</Label>
-                  <Textarea id="adicional-descripcion" name="descripcion" required />
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label htmlFor="adicional-unidad">Unidad</Label>
-                    <Input id="adicional-unidad" name="unidad" required />
-                  </div>
-                  <div>
-                    <Label htmlFor="adicional-precio">Precio mano de obra</Label>
-                    <Input id="adicional-precio" name="precioUnitarioManoObra" type="number" required />
-                  </div>
-                </div>
-                <Button type="submit">Guardar adicional</Button>
-              </form>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Plan de mantenimiento</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <MaintenanceForm />
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Caso real / obra destacada</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <CaseStudyForm />
-            </CardContent>
-          </Card>
-        </div>
-      </section>
-
-      <section id="operaciones" className="space-y-4">
-        <h2 className="text-lg font-semibold text-foreground">Módulo 4 · Operaciones y certificados</h2>
-
-        <div className="flex flex-wrap gap-3">
-          <Button variant="outline" asChild>
-            <Link href="/admin/leads">Ver consultas nuevas</Link>
-          </Button>
-          <Button variant="outline" asChild>
-            <Link href="/admin/ops">Ir al panel operativo</Link>
-          </Button>
-          <Button variant="outline" asChild>
-            <Link href="/admin/ops/projects">Ver proyectos</Link>
-          </Button>
-        </div>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Crear certificado de avance</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <form action={createCertificate} className="grid gap-4">
-              <div className="grid gap-2">
-                <Label htmlFor="projectId">Proyecto</Label>
-                <select
-                  id="projectId"
-                  name="projectId"
-                  className="h-11 w-full rounded-xl border border-border bg-white px-4 text-sm"
-                  required
-                >
-                  {projects.map((project) => (
-                    <option key={project.id} value={project.id}>
-                      {project.nombre}
-                    </option>
-                  ))}
-                </select>
+      <section className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-xl font-semibold text-slate-950">Pipeline comercial</h2>
+              <p className="mt-1 text-sm text-slate-500">Estados recomendados para convertir consultas en trabajos.</p>
+            </div>
+            <Link href="/admin/leads" className="text-sm font-semibold text-slate-950">
+              Abrir leads
+            </Link>
+          </div>
+          <div className="mt-5 grid gap-3 md:grid-cols-4">
+            {pipeline.map((state) => (
+              <div key={state} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                <p className="text-sm font-semibold text-slate-950">{state}</p>
+                <p className="mt-2 text-2xl font-semibold text-slate-400">0</p>
               </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="porcentaje">Porcentaje</Label>
-                  <Input id="porcentaje" name="porcentaje" type="number" required />
-                </div>
-                <div>
-                  <Label htmlFor="cacActual">CAC actual</Label>
-                  <Input id="cacActual" name="cacActual" type="number" step="0.01" required />
-                </div>
-              </div>
-              <label className="flex items-center gap-2 text-sm text-slate-600">
-                <input type="checkbox" name="aplicaIVA" defaultChecked />
-                Aplicar IVA
-              </label>
-              <Button type="submit">Crear certificado</Button>
-            </form>
-          </CardContent>
-        </Card>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-slate-200 bg-slate-950 p-5 text-white shadow-sm">
+          <h2 className="text-xl font-semibold text-white">Alertas criticas</h2>
+          <div className="mt-4 space-y-3">
+            {alerts.map((alert) => (
+              <p key={alert} className="rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-slate-200">
+                {alert}
+              </p>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-xl font-semibold text-slate-950">Ultimos leads</h2>
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full min-w-[720px] text-left text-sm">
+            <thead className="text-xs uppercase tracking-[0.16em] text-slate-500">
+              <tr>
+                <th className="border-b border-slate-200 py-3">Cliente</th>
+                <th className="border-b border-slate-200 py-3">Trabajo</th>
+                <th className="border-b border-slate-200 py-3">Urgencia</th>
+                <th className="border-b border-slate-200 py-3">Zona</th>
+                <th className="border-b border-slate-200 py-3">Fecha</th>
+              </tr>
+            </thead>
+            <tbody>
+              {leads.map((lead) => (
+                <tr key={lead.id} className="border-b border-slate-100">
+                  <td className="py-3 font-medium text-slate-950">{lead.name}</td>
+                  <td className="py-3 text-slate-600">{lead.workType}</td>
+                  <td className="py-3 text-slate-600">{lead.urgency}</td>
+                  <td className="py-3 text-slate-600">{lead.location}</td>
+                  <td className="py-3 text-slate-600">{lead.createdAt.toLocaleDateString('es-AR')}</td>
+                </tr>
+              ))}
+              {leads.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="py-6 text-center text-slate-500">
+                    Todavia no hay leads registrados.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
       </section>
     </div>
   )

--- a/nerin-electric-site-v3-fixed/app/(site)/contacto/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/contacto/page.tsx
@@ -1,186 +1,38 @@
-import { redirect } from 'next/navigation'
-import { submitContact } from './actions'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
-import { Label } from '@/components/ui/label'
 import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
-import { AttributionFields } from '@/components/tracking/AttributionFields'
-import { TrackEventOnLoad } from '@/components/tracking/TrackEventOnLoad'
+import { LeadWizard } from '@/components/LeadWizard'
 
-export const revalidate = 60
-export const dynamic = 'force-dynamic'
-
-export async function generateMetadata() {
-  const site = await getSiteContent()
-  const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Contacto | NERIN'
-  const description = 'Coordiná tu obra eléctrica con un técnico senior. Respuesta en 24 horas hábiles.'
-
-  return {
-    title,
-    description,
-    alternates: {
-      canonical: '/contacto',
-    },
-    openGraph: {
-      title,
-      description,
-      url: `${siteUrl}/contacto`,
-      siteName: site.name,
-      images: [{ url: '/nerin/og-cover.png', width: 1200, height: 630, alt: 'NERIN Electric' }],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title,
-      description,
-      images: ['/nerin/og-cover.png'],
-    },
-  }
+export const metadata = {
+  title: 'Contacto y presupuesto electrico | NERIN',
+  description: 'Solicita presupuesto para fallas, tableros, instalaciones, mantenimiento y obras electricas en CABA/GBA.',
 }
 
-export default async function ContactoPage({
-  searchParams,
-}: {
-  searchParams?: { enviado?: string; motivo?: string }
-}) {
+export default async function ContactoPage() {
   const site = await getSiteContent()
   const whatsappHref = getWhatsappHref(site)
-  const motivo = searchParams?.motivo ?? ''
-
-  async function action(formData: FormData) {
-    'use server'
-    await submitContact(formData)
-    redirect('/contacto?enviado=1')
-  }
 
   return (
-    <div className="grid gap-16 lg:grid-cols-[1.2fr_1fr]">
-      <div className="space-y-8">
-        <Badge>Contacto</Badge>
-        <h1>{site.contactPage.introTitle}</h1>
-        <p className="text-lg text-slate-600">{site.contactPage.introDescription}</p>
-        {searchParams?.enviado === '1' && (
-          <>
-            <TrackEventOnLoad
-              eventName="generate_lead"
-              payload={{ content_name: 'Contacto', content_type: 'form', channel: 'contact' }}
-            />
-            <p className="rounded-2xl border border-accent/30 bg-accent/10 p-4 text-sm text-slate-700">
-              ¡Listo! Recibimos tu consulta. Te contactamos por mail dentro de las próximas 24 horas hábiles.
-            </p>
-          </>
-        )}
-        <form action={action} className="space-y-6 rounded-3xl border border-border bg-white p-8 shadow-subtle">
-          <AttributionFields />
-          <input type="hidden" name="reason" value={motivo} />
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div>
-              <Label htmlFor="nombre">Nombre y apellido *</Label>
-              <Input name="nombre" id="nombre" required placeholder="Ej: Florencia Gómez" />
-            </div>
-            <div>
-              <Label htmlFor="empresa">Empresa / Consorcio</Label>
-              <Input name="empresa" id="empresa" placeholder="Ej: Consorcio Lavalle 1200" />
-            </div>
-            <div>
-              <Label htmlFor="email">Email *</Label>
-              <Input name="email" id="email" type="email" required placeholder="correo@empresa.com" />
-            </div>
-            <div>
-              <Label htmlFor="telefono">Teléfono *</Label>
-              <Input name="telefono" id="telefono" required placeholder="11 5555-5555" />
-            </div>
-            <div>
-              <Label htmlFor="cuit">CUIT</Label>
-              <Input name="cuit" id="cuit" placeholder="30-XXXXXXXX-X" />
-            </div>
-            <div>
-              <Label htmlFor="direccion">Dirección de la obra</Label>
-              <Input name="direccion" id="direccion" placeholder="Calle, número, ciudad" />
-            </div>
-          </div>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div>
-              <Label htmlFor="servicio">Servicio requerido</Label>
-              <Input name="servicio" id="servicio" defaultValue={motivo} placeholder="Ej: Tableros + CCTV" required />
-            </div>
-            <div>
-              <Label htmlFor="urgencia">Urgencia</Label>
-              <select
-                className="h-11 w-full rounded-xl border border-border bg-white px-4 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-                name="urgencia"
-                id="urgencia"
-                defaultValue="planificado"
-                required
-              >
-                <option value="48hs">48 hs</option>
-                <option value="7dias">Dentro de 7 días</option>
-                <option value="planificado">Planificado (más de 7 días)</option>
-              </select>
-            </div>
-          </div>
-          <div>
-            <Label htmlFor="mensaje">Detalle adicional</Label>
-            <Textarea
-              name="mensaje"
-              id="mensaje"
-              placeholder="Adjuntá datos de potencia, planos o comentarios relevantes."
-            />
-          </div>
-          <Button type="submit" size="lg">
-            Enviar consulta
-          </Button>
-          <p className="text-xs text-slate-500">
-            También podés usar nuestro{' '}
-            <a
-              className="underline"
-              href={site.contactPage.typeformUrl}
-              target="_blank"
-              rel="noreferrer"
-            >
-              Typeform
-            </a>{' '}
-            si preferís completar desde el celular.
+    <div className="bg-slate-50">
+      <section className="border-b border-slate-200 bg-white py-14">
+        <div className="container max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Contacto</p>
+          <h1 className="mt-3 text-4xl font-semibold text-slate-950 sm:text-5xl">Pedi presupuesto claro para resolver bien.</h1>
+          <p className="mt-4 text-lg leading-8 text-slate-600">
+            Envia tipo de trabajo, zona, urgencia y fotos si tenes. Si el problema puede escalar, conviene pedir visita tecnica.
           </p>
-        </form>
-      </div>
-      <aside className="space-y-6 rounded-3xl border border-border bg-white p-8 shadow-subtle">
-        <h2>¿Por qué elegir NERIN?</h2>
-        <ul className="space-y-3 text-sm text-slate-600">
-          {site.contactPage.highlightBullets.map((item) => (
-            <li key={item}>• {item}</li>
-          ))}
-        </ul>
-        <div className="rounded-2xl bg-muted p-6 text-sm text-slate-600">
-          <p className="font-semibold text-foreground">WhatsApp directo</p>
-          <p>{site.contact.whatsappNumber}</p>
-          <p className="mt-3 font-semibold text-foreground">Correo</p>
-          <p>{site.contact.email}</p>
-          <p className="mt-3 font-semibold text-foreground">Oficina técnica</p>
-          <p>{site.contact.address}</p>
-          <p className="mt-3 font-semibold text-foreground">Horarios</p>
-          <p>{site.contact.schedule}</p>
-          <p className="mt-3 font-semibold text-foreground">Área de cobertura</p>
-          <p>{site.contact.serviceArea}</p>
-          {site.contact.secondaryPhones.length > 0 && (
-            <div className="mt-3">
-              <p className="font-semibold text-foreground">Teléfonos alternativos</p>
-              <ul className="mt-1 space-y-1">
-                {site.contact.secondaryPhones.map((phone) => (
-                  <li key={phone}>{phone}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-          <Button asChild size="sm" variant="secondary" className="mt-4">
-            <a href={whatsappHref} target="_blank" rel="noreferrer" data-track="whatsapp" data-content-name="WhatsApp contacto">
-              Iniciar conversación
-            </a>
-          </Button>
         </div>
-      </aside>
+      </section>
+      <section className="container grid gap-8 py-14 lg:grid-cols-[0.75fr_1.25fr]">
+        <aside className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-2xl font-semibold text-slate-950">Que priorizamos</h2>
+          <ul className="mt-4 space-y-3 text-sm text-slate-700">
+            <li>Fallas con corte total o parcial.</li>
+            <li>Tableros con olor, temperatura, chispazos o disparos frecuentes.</li>
+            <li>Locales, oficinas y edificios con operacion afectada.</li>
+            <li>Obras proximas a iniciar con alcance definido.</li>
+          </ul>
+        </aside>
+        <LeadWizard whatsappHref={whatsappHref} />
+      </section>
     </div>
   )
 }

--- a/nerin-electric-site-v3-fixed/app/(site)/empresa/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/empresa/page.tsx
@@ -1,76 +1,37 @@
-export const dynamic = 'force-dynamic'
-import Image from 'next/image'
-import { Badge } from '@/components/ui/badge'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { getTechniciansForMarketing } from '@/lib/marketing-data'
-import { getSiteContent } from '@/lib/site-content'
+import { CheckCircle2 } from 'lucide-react'
 
-export const revalidate = 60
+const process = ['Relevamiento', 'Diagnostico', 'Presupuesto claro', 'Ejecucion prolija', 'Seguimiento y cierre']
 
-export default async function EmpresaPage() {
-  const technicians = await getTechniciansForMarketing()
-  const site = await getSiteContent()
+export const metadata = {
+  title: 'Empresa de electricidad en CABA y GBA | NERIN',
+  description: 'NERIN Electricidad, empresa de servicios electricos para hogares, comercios, edificios, empresas y obras.',
+}
 
+export default function EmpresaPage() {
   return (
-    <div className="space-y-12">
-      <header className="space-y-4">
-        <Badge>Empresa</Badge>
-        <h1>{site.company.introTitle}</h1>
-        <p className="max-w-3xl text-lg text-slate-600">{site.company.introDescription}</p>
-        <p className="max-w-2xl text-sm text-slate-500">{site.company.mission}</p>
-      </header>
-
-      <section className="grid gap-6 md:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <CardTitle>{site.company.protocolsTitle}</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm text-slate-600">
-            <p>Planificamos cada obra con cronograma, responsables y controles de calidad.</p>
-            <ul className="space-y-2">
-              {site.company.protocols.map((item) => (
-                <li key={item}>• {item}</li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>{site.company.complianceTitle}</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm text-slate-600">
-            <ul className="space-y-2">
-              {site.company.compliance.map((item) => (
-                <li key={item}>• {item}</li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
+    <div className="bg-white">
+      <section className="border-b border-slate-200 bg-slate-50 py-14">
+        <div className="container max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Empresa</p>
+          <h1 className="mt-3 text-4xl font-semibold text-slate-950 sm:text-5xl">Electricidad profesional sin improvisar.</h1>
+          <p className="mt-4 text-lg leading-8 text-slate-600">
+            NERIN trabaja sobre fallas, tableros, instalaciones, mantenimiento y obras. La web esta preparada para cargar datos oficiales reales cuando correspondan, sin mostrar datos falsos.
+          </p>
+        </div>
       </section>
-
-      <section className="space-y-4">
-        <h2 className="text-2xl font-semibold text-foreground">{site.company.teamTitle}</h2>
-        <div className="grid gap-6 md:grid-cols-3">
-          {technicians.map((tech) => (
-            <Card key={tech.id} className="space-y-3">
-              <CardHeader>
-                <CardTitle>{tech.nombre}</CardTitle>
-                <p className="text-sm text-slate-500">{tech.credenciales.join(' · ')}</p>
-              </CardHeader>
-              {tech.fotoUrl ? (
-                <Image
-                  src={tech.fotoUrl}
-                  width={400}
-                  height={300}
-                  alt={`Técnico NERIN ${tech.nombre}`}
-                  className="h-40 w-full rounded-2xl object-cover"
-                />
-              ) : (
-                <div className="flex h-40 items-center justify-center rounded-2xl bg-muted text-sm text-slate-500">
-                  Foto pendiente
-                </div>
-              )}
-            </Card>
+      <section className="container grid gap-8 py-14 lg:grid-cols-[0.8fr_1.2fr]">
+        <div>
+          <h2 className="text-3xl font-semibold text-slate-950">Como trabajamos</h2>
+          <p className="mt-3 text-sm leading-6 text-slate-600">
+            La prioridad es que entiendas el problema, el costo y el alcance antes de aprobar. Materiales y mano de obra se separan para evitar confusiones.
+          </p>
+        </div>
+        <div className="grid gap-3">
+          {process.map((item) => (
+            <div key={item} className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-sm">
+              <CheckCircle2 className="h-5 w-5 text-emerald-600" />
+              <span className="font-semibold text-slate-900">{item}</span>
+            </div>
           ))}
         </div>
       </section>

--- a/nerin-electric-site-v3-fixed/app/(site)/layout.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/layout.tsx
@@ -121,13 +121,13 @@ export default async function SiteLayout({ children }: { children: ReactNode }) 
           imageUrl: site.logo.imageUrl,
         }}
       />
-      <main className="container pb-20 pt-8 sm:pt-10 lg:pt-12">{children}</main>
+      <main className="pb-20">{children}</main>
       <Footer site={site} />
       <a
         className="no-underline fixed bottom-4 right-4 z-40 inline-flex h-12 w-12 items-center justify-center rounded-full border border-transparent bg-[#0B0F14] text-white shadow-subtle transition hover:border-[#FBBF24] hover:text-[#FBBF24] focus-visible:ring-2 focus-visible:ring-[#FBBF24]/60 sm:bottom-5 sm:right-5"
         href={whatsappHref}
-        target="_blank"
-        rel="noreferrer"
+        target={whatsappHref.startsWith('http') ? '_blank' : undefined}
+        rel={whatsappHref.startsWith('http') ? 'noreferrer' : undefined}
         aria-label="Hablar con NERIN por WhatsApp"
         title="WhatsApp"
         data-track="whatsapp"

--- a/nerin-electric-site-v3-fixed/app/(site)/mantenimiento/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/mantenimiento/page.tsx
@@ -1,93 +1,43 @@
-export const dynamic = 'force-dynamic'
-
 import Link from 'next/link'
-import { getMaintenancePlansForMarketing } from '@/lib/marketing-data'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { getSiteContent } from '@/lib/site-content'
+import { CheckCircle2 } from 'lucide-react'
+import { maintenancePlans } from '@/lib/nerin-electricidad'
 
-export const revalidate = 60
-
-export async function generateMetadata() {
-  const site = await getSiteContent()
-  const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Mantenimiento eléctrico | NERIN'
-  const description = 'Planes de mantenimiento con visitas y tareas definidas.'
-
-  return {
-    title,
-    description,
-    alternates: {
-      canonical: '/mantenimiento',
-    },
-    openGraph: {
-      title,
-      description,
-      url: `${siteUrl}/mantenimiento`,
-      siteName: site.name,
-      images: [{ url: '/nerin/og-cover.png', width: 1200, height: 630, alt: 'NERIN Electric' }],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title,
-      description,
-      images: ['/nerin/og-cover.png'],
-    },
-  }
+export const metadata = {
+  title: 'Mantenimiento electrico mensual | NERIN',
+  description: 'Planes BASIC, PRO y ENTERPRISE para locales, oficinas, edificios, comercios activos y clientes criticos.',
 }
 
-export default async function MantenimientoPage() {
-  const plans = await getMaintenancePlansForMarketing()
-  const site = await getSiteContent()
-
+export default function MantenimientoPage() {
   return (
-    <div className="space-y-10 sm:space-y-12">
-      <header className="space-y-4">
-        <Badge>Mantenimiento</Badge>
-        <h1>{site.maintenancePage.introTitle}</h1>
-        <p className="max-w-3xl text-lg text-slate-600">{site.maintenancePage.introDescription}</p>
-      </header>
-
-      <section className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-        {plans.map((plan) => (
-          <Card key={plan.id} className="flex flex-col justify-between">
-            <CardHeader>
-              <Badge className="bg-muted text-slate-500">{plan.slug.toUpperCase()}</Badge>
-              <CardTitle>{plan.nombre}</CardTitle>
-              <p className="text-sm text-slate-500">${Number(plan.precioMensual).toLocaleString('es-AR')} / mes</p>
-            </CardHeader>
-            <CardContent className="space-y-4 text-sm text-slate-600">
-              <p className="font-medium text-foreground">Incluye:</p>
-              <ul className="space-y-2">
-                {plan.incluyeTareasFijas.map((task) => (
-                  <li key={task}>• {task}</li>
-                ))}
-              </ul>
-              <p>{plan.visitasMes} visita(s) por mes.</p>
-              <div className="flex flex-col gap-2">
-                <Button asChild>
-                  <Link href={`/presupuesto?tipo=mantenimiento&plan=${plan.slug}`}>Solicitar plan</Link>
-                </Button>
-                <Button asChild variant="secondary">
-                  <Link href="/contacto">Contacto</Link>
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </section>
-
-      <section className="rounded-3xl border border-border bg-white p-5 shadow-subtle sm:p-8 lg:p-10">
-        <h2 className="text-2xl font-semibold text-foreground">Alcance</h2>
-        <div className="mt-6 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
-          {site.maintenancePage.cards.map((card) => (
-            <div key={card.title}>
-              <h3 className="text-lg font-semibold text-foreground">{card.title}</h3>
-              <p className="text-sm text-slate-600">{card.description}</p>
-            </div>
-          ))}
+    <div className="bg-white">
+      <section className="border-b border-slate-200 bg-slate-50 py-14">
+        <div className="container max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Mantenimiento mensual</p>
+          <h1 className="mt-3 text-4xl font-semibold text-slate-950 sm:text-5xl">Menos cortes, menos urgencias y mas control.</h1>
+          <p className="mt-4 text-lg leading-8 text-slate-600">
+            Para comercios, edificios y empresas donde una falla electrica frena operacion, genera reclamos o termina saliendo mas cara.
+          </p>
         </div>
+      </section>
+      <section className="container grid gap-5 py-14 lg:grid-cols-3">
+        {maintenancePlans.map((plan) => (
+          <article key={plan.name} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-2xl font-semibold text-slate-950">{plan.name}</h2>
+            <p className="mt-2 text-2xl font-semibold text-slate-950">{plan.price}</p>
+            <p className="mt-3 text-sm leading-6 text-slate-600">{plan.fit}</p>
+            <ul className="mt-5 space-y-2">
+              {plan.bullets.map((item) => (
+                <li key={item} className="flex items-center gap-2 text-sm text-slate-700">
+                  <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                  {item}
+                </li>
+              ))}
+            </ul>
+            <Link href={`/presupuestador?tipo=Mantenimiento ${plan.name}`} className="mt-6 inline-flex rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white">
+              Solicitar plan
+            </Link>
+          </article>
+        ))}
       </section>
     </div>
   )

--- a/nerin-electric-site-v3-fixed/app/(site)/obras/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/obras/page.tsx
@@ -1,56 +1,45 @@
-export const dynamic = 'force-dynamic'
-import { Badge } from '@/components/ui/badge'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { getSiteContent } from '@/lib/site-content'
-import { fetchPublicJson } from '@/lib/public-api'
+import Link from 'next/link'
+import { ArrowRight } from 'lucide-react'
+import { featuredExperience } from '@/lib/nerin-electricidad'
 
-type Project = {
-  id?: string
-  title: string
-  description: string
-  tags?: string[]
-  locationText?: string | null
+export const metadata = {
+  title: 'Obras electricas y experiencia | NERIN',
+  description: 'Experiencia en locales comerciales, gimnasios, supermercados y edificios residenciales sin inventar datos especificos.',
 }
 
-export const revalidate = 60
-
-export default async function ObrasPage() {
-  const site = await getSiteContent()
-  let projects: Project[] = []
-  try {
-    projects = await fetchPublicJson<Project[]>('/api/public/projects')
-  } catch (error) {
-    projects = []
-  }
-
+export default function ObrasPage() {
   return (
-    <div className="space-y-8">
-      <header className="space-y-4">
-        <Badge>Obras destacadas</Badge>
-        <h1>{site.works.introTitle}</h1>
-        <p className="text-lg text-slate-600">{site.works.introDescription}</p>
-      </header>
-      <section className="grid gap-6 md:grid-cols-2">
-        {projects.map((project) => (
-          <Card key={project.id ?? project.title} className="flex flex-col">
-            <CardHeader>
-              <CardTitle>{project.title}</CardTitle>
-              <p className="text-sm text-slate-500">{project.locationText ?? ''}</p>
-            </CardHeader>
-            <CardContent className="mt-auto space-y-3 text-sm text-slate-600">
-              <p>{project.description}</p>
-              {project.tags && project.tags.length > 0 ? (
-                <div className="flex flex-wrap gap-2 text-xs text-slate-500">
-                  {project.tags.map((tag) => (
-                    <span key={tag} className="rounded-full bg-muted px-2 py-1">
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-              ) : null}
-            </CardContent>
-          </Card>
+    <div className="bg-white">
+      <section className="border-b border-slate-200 bg-slate-950 py-14 text-white">
+        <div className="container max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-amber-300">Obras y experiencia</p>
+          <h1 className="mt-3 text-4xl font-semibold text-white sm:text-5xl">Instalaciones electricas para obra, comercio y edificios.</h1>
+          <p className="mt-4 text-lg leading-8 text-slate-300">
+            Se muestran referencias profesionales sin inventar metros, montos, fechas ni responsables. Los detalles reales se cargan desde admin cuando esten disponibles.
+          </p>
+        </div>
+      </section>
+      <section className="container grid gap-5 py-14 md:grid-cols-2">
+        {featuredExperience.map((name) => (
+          <article key={name} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-2xl font-semibold text-slate-950">{name}</h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              Experiencia en instalaciones electricas para locales comerciales, gimnasios, supermercados y edificios residenciales.
+            </p>
+          </article>
         ))}
+      </section>
+      <section className="border-t border-slate-200 bg-slate-50 py-12">
+        <div className="container flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-950">Tenes una obra proxima a iniciar?</h2>
+            <p className="mt-1 text-sm text-slate-600">Pedi una visita tecnica y ordena alcance, etapas, materiales y certificados.</p>
+          </div>
+          <Link href="/presupuestador?tipo=Obra electrica" className="inline-flex items-center rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-white">
+            Iniciar solicitud
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Link>
+        </div>
       </section>
     </div>
   )

--- a/nerin-electric-site-v3-fixed/app/(site)/packs/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/packs/page.tsx
@@ -1,79 +1,43 @@
-export const dynamic = 'force-dynamic'
-
 import Link from 'next/link'
-import { getPacksForMarketing } from '@/lib/marketing-data'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
-import { getSiteContent } from '@/lib/site-content'
+import { ArrowRight, CheckCircle2 } from 'lucide-react'
+import { packs } from '@/lib/nerin-electricidad'
 
-export const revalidate = 60
-
-export async function generateMetadata() {
-  const site = await getSiteContent()
-  const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Packs técnicos | NERIN'
-  const description = 'Referencia de bases de mano de obra.'
-
-  return {
-    title,
-    description,
-    alternates: {
-      canonical: '/packs',
-    },
-    openGraph: {
-      title,
-      description,
-      url: `${siteUrl}/packs`,
-      siteName: site.name,
-      images: [{ url: '/nerin/og-cover.png', width: 1200, height: 630, alt: 'NERIN Electric' }],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title,
-      description,
-      images: ['/nerin/og-cover.png'],
-    },
-  }
+export const metadata = {
+  title: 'Packs electricos con precios desde | NERIN',
+  description: 'Packs de mano de obra para vivienda estandar, casa country 1 y casa country 2.',
 }
 
-export default async function PacksPage() {
-  const packs = await getPacksForMarketing()
-
+export default function PacksPage() {
   return (
-    <div className="space-y-10">
-      <header className="space-y-4 rounded-2xl border border-border bg-muted/20 p-6">
-        <Badge>Packs técnicos</Badge>
-        <h1>Bases de mano de obra</h1>
-        <p className="max-w-3xl text-base text-slate-600">Esta página es una referencia técnica.</p>
-        <Button asChild>
-          <Link href="/presupuestador">Iniciar cotización</Link>
-        </Button>
-      </header>
-
-      <section className="grid gap-5">
+    <div className="bg-white">
+      <section className="border-b border-slate-200 bg-slate-950 py-14 text-white">
+        <div className="container max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-amber-300">Packs electricos</p>
+          <h1 className="mt-3 text-4xl font-semibold text-white sm:text-5xl">Mano de obra con precio desde, alcance y condiciones claras.</h1>
+          <p className="mt-4 text-lg leading-8 text-slate-300">
+            Valores orientativos de mano de obra. Materiales, artefactos y proyecto electrico se cotizan por separado.
+          </p>
+        </div>
+      </section>
+      <section className="container grid gap-5 py-14 lg:grid-cols-3">
         {packs.map((pack) => (
-          <Card key={pack.id} id={pack.slug} className="scroll-mt-32">
-            <CardHeader>
-              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                <div>
-                  <CardTitle>{pack.name}</CardTitle>
-                  <p className="text-sm text-slate-500">{pack.description}</p>
-                </div>
-                <p className="text-xl font-semibold text-foreground">
-                  Base ${Number(pack.basePrice).toLocaleString('es-AR')}
-                </p>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-slate-600">
-              <p>{pack.scope}</p>
-              <ul className="grid gap-2 sm:grid-cols-2">
-                {pack.features.slice(0, 4).map((item) => (
-                  <li key={item}>• {item}</li>
-                ))}
-              </ul>
-            </CardContent>
-          </Card>
+          <article key={pack.name} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-2xl font-semibold text-slate-950">{pack.name}</h2>
+            <p className="mt-3 text-3xl font-semibold text-slate-950">{pack.price}</p>
+            <p className="mt-3 text-sm leading-6 text-slate-600">{pack.description}</p>
+            <ul className="mt-5 space-y-2">
+              {pack.bullets.map((item) => (
+                <li key={item} className="flex items-center gap-2 text-sm text-slate-700">
+                  <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                  {item}
+                </li>
+              ))}
+            </ul>
+            <Link href={`/presupuestador?tipo=${encodeURIComponent(pack.name)}`} className="mt-6 inline-flex items-center text-sm font-semibold text-slate-950">
+              Cotizar pack
+              <ArrowRight className="ml-1 h-4 w-4" />
+            </Link>
+          </article>
         ))}
       </section>
     </div>

--- a/nerin-electric-site-v3-fixed/app/(site)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/page.tsx
@@ -1,311 +1,210 @@
-export const dynamic = 'force-dynamic'
-
-import Image from 'next/image'
 import Link from 'next/link'
-import type { Route } from 'next'
-import { getMarketingHomeData } from '@/lib/marketing-data'
+import { AlertTriangle, ArrowRight, CheckCircle2, MessageCircle, ShieldCheck, Zap } from 'lucide-react'
 import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
+import { featuredExperience, maintenancePlans, packs, serviceCards, trustItems } from '@/lib/nerin-electricidad'
+import { LeadWizard } from '@/components/LeadWizard'
 import { Button } from '@/components/ui/button'
 
 export const revalidate = 60
 
 export async function generateMetadata() {
-  const site = await getSiteContent()
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Electricidad para hogares y obras en CABA y GBA | NERIN'
+  const title = 'Instalaciones electricas profesionales en CABA y GBA | NERIN'
   const description =
-    'Respuesta rápida, solicitud simple y ejecución prolija para hogares, comercios y proyectos de obra.'
+    'Fallas, tableros, obras, mantenimiento y packs electricos con presupuesto claro, respuesta rapida y seguimiento por WhatsApp.'
 
   return {
     title,
     description,
-    alternates: {
-      canonical: '/',
-    },
+    alternates: { canonical: '/' },
     openGraph: {
       title,
       description,
       url: siteUrl,
-      siteName: site.name,
-      images: [{ url: '/nerin/og-cover.png', width: 1200, height: 630, alt: 'NERIN Electric' }],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title,
-      description,
-      images: ['/nerin/og-cover.png'],
+      images: [{ url: '/nerin/og-cover.png', width: 1200, height: 630, alt: 'NERIN Electricidad' }],
     },
   }
 }
 
-const trustPoints = [
-  'Atención en CABA y GBA',
-  'Solicitud por WhatsApp o formulario',
-  'Ejecución prolija y seguimiento',
-]
-
-const systemSteps = [
-  {
-    title: '1) Enviás solicitud',
-    description: 'Nos contás qué necesitás por WhatsApp o formulario en menos de 2 minutos.',
-  },
-  {
-    title: '2) Ordenamos el trabajo',
-    description: 'Definimos alcance, prioridad y el mejor formato: puntual, instalación o proyecto.',
-  },
-  {
-    title: '3) Te confirmamos propuesta',
-    description: 'Recibís una propuesta clara para avanzar sin idas y vueltas.',
-  },
-  {
-    title: '4) Ejecutamos y cerramos',
-    description: 'Coordinamos, resolvemos y dejamos el trabajo terminado con seguimiento.',
-  },
-]
-
-const serviceCards = [
-  {
-    title: 'Servicio puntual en hogar',
-    description: 'Artefactos, lámparas, circuitos y fallas comunes resueltas con orden y rapidez.',
-    href: '/presupuestador?mode=EXPRESS',
-    cta: 'Enviar solicitud puntual',
-  },
-  {
-    title: 'Instalaciones y mejoras',
-    description: 'Tableros, circuitos dedicados, puesta a tierra y mejoras para trabajar con tranquilidad.',
-    href: '/servicios',
-    cta: 'Ver servicios',
-  },
-  {
-    title: 'Obras y reformas con presupuesto',
-    description: 'Proyectos de vivienda y obra con alcance claro y coordinación profesional.',
-    href: '/presupuestador?mode=PROJECT',
-    cta: 'Iniciar cotización',
-  },
-] as const satisfies ReadonlyArray<{
-  title: string
-  description: string
-  href: Route
-  cta: string
-}>
-
-const riskPoints = [
-  'Solicitud simple y respuesta ordenada para que no quedes esperando sin saber.',
-  'Alcance claro antes de avanzar, para evitar sorpresas innecesarias.',
-  'Seguimiento del trabajo hasta cierre, especialmente en proyectos grandes.',
-]
-
 export default async function HomePage() {
-  const { caseStudies } = await getMarketingHomeData()
   const site = await getSiteContent()
   const whatsappHref = getWhatsappHref(site)
+  const isWhatsappExternal = whatsappHref.startsWith('http')
 
   return (
-    <div className="space-y-10 pb-24 sm:space-y-14 sm:pb-0">
-      <section className="rounded-2xl border border-cyan-200 bg-gradient-to-r from-cyan-50 to-sky-50 px-4 py-3 text-sm sm:px-6">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <p className="font-semibold text-cyan-900">
-            Agenda activa esta semana. Si querés resolverlo rápido, enviá tu solicitud ahora.
-          </p>
-          <a
-            href={whatsappHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex w-fit items-center rounded-full bg-[#25D366] px-4 py-1.5 text-xs font-bold uppercase tracking-wide text-black hover:bg-[#1ebe5a]"
-            data-track="whatsapp"
-            data-content-name="WhatsApp urgencia home"
-          >
-            Solicitar por WhatsApp
-          </a>
-        </div>
-      </section>
-
-      <section className="relative overflow-hidden rounded-3xl border border-border/70 text-white">
-        <Image src={site.hero.backgroundImage} alt={site.hero.caption} fill priority className="object-cover" />
-        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(2,6,23,0.58)_0%,rgba(2,6,23,0.74)_55%,rgba(2,6,23,0.9)_100%)]" />
-
-        <div className="relative z-10 flex min-h-[72vh] flex-col justify-end p-6 sm:p-10">
-          <div className="max-w-3xl space-y-4">
-            <p className="inline-flex w-fit rounded-full border border-white/30 bg-white/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.22em] text-slate-100">
-              NERIN Electricidad
-            </p>
-            <h1 className="text-3xl font-semibold leading-[1.08] text-white sm:text-5xl">
-              Si necesitás resolver una falla, una instalación o una obra sin perder tiempo con
-              improvisados, hablá con nosotros.
-            </h1>
-            <p className="max-w-2xl text-base text-slate-100 sm:text-xl">
-              Respuesta rápida, solicitud simple y ejecución prolija para hogares, comercios y proyectos
-              de obra en CABA y GBA.
-            </p>
-            <p className="text-sm font-medium text-slate-200">Zona de trabajo: {site.contact.serviceArea}</p>
-          </div>
-
-          <div className="mt-6 grid gap-3 sm:max-w-2xl sm:grid-cols-2">
-            <Button size="lg" asChild className="h-12 bg-[#25D366] text-base font-bold text-black hover:bg-[#1ebe5a]">
-              <a
-                id="whatsapp-directo"
-                href={whatsappHref}
-                target="_blank"
-                rel="noopener noreferrer"
-                data-track="whatsapp"
-                data-content-name="WhatsApp hero principal"
-              >
-                Hablar por WhatsApp
-              </a>
-            </Button>
-            <Button size="lg" asChild className="h-12 bg-red-600 text-base hover:bg-red-700">
-              <Link href="/presupuestador">Enviar solicitud</Link>
-            </Button>
-          </div>
-
-          <ul className="mt-4 flex flex-wrap gap-2">
-            {trustPoints.map((point) => (
-              <li
-                key={point}
-                className="rounded-full border border-white/20 bg-white/5 px-3 py-1 text-xs text-slate-100"
-              >
-                {point}
-              </li>
-            ))}
-          </ul>
-        </div>
-      </section>
-
-      <section className="space-y-5 rounded-2xl border border-border bg-white p-5 sm:p-6">
-        <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">Sistema</p>
-          <h2 className="text-2xl font-semibold text-slate-900">Cómo funciona NERIN</h2>
-          <p className="text-sm text-slate-600">Un proceso simple para que vos sepas qué pasa en cada etapa.</p>
-        </div>
-        <div className="grid gap-3 md:grid-cols-2">
-          {systemSteps.map((step) => (
-            <article key={step.title} className="rounded-xl border border-border bg-muted/20 p-4">
-              <h3 className="text-base font-semibold text-slate-900">{step.title}</h3>
-              <p className="mt-1 text-sm text-slate-600">{step.description}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="space-y-5 rounded-2xl border border-red-200 bg-white p-5 sm:p-6">
-        <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-red-700">Servicios</p>
-          <h2 className="text-2xl font-semibold text-slate-900">Qué podés resolver con NERIN</h2>
-        </div>
-        <div className="grid gap-3 lg:grid-cols-3">
-          {serviceCards.map((card) => (
-            <article
-              key={card.title}
-              className="rounded-xl border border-border bg-gradient-to-b from-white to-red-50/40 p-4 shadow-sm"
-            >
-              <h3 className="text-lg font-semibold text-slate-900">{card.title}</h3>
-              <p className="mt-2 text-sm text-slate-600">{card.description}</p>
-              <Button asChild className="mt-4 w-full bg-red-600 hover:bg-red-700">
-                <Link href={card.href}>{card.cta}</Link>
+    <div className="bg-white">
+      <section className="border-b border-slate-200 bg-[linear-gradient(180deg,#fff_0%,#f8fafc_100%)]">
+        <div className="container grid min-h-[calc(100vh-7rem)] gap-10 py-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center lg:py-16">
+          <div className="space-y-7">
+            <div className="inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-bold uppercase tracking-[0.18em] text-slate-900">
+              <Zap className="h-4 w-4 text-amber-500" />
+              Respuesta prioritaria en CABA y GBA
+            </div>
+            <div className="space-y-5">
+              <h1 className="max-w-4xl text-4xl font-semibold leading-[1.03] tracking-tight text-slate-950 sm:text-6xl">
+                Instalaciones electricas profesionales en CABA y GBA
+              </h1>
+              <p className="max-w-2xl text-lg leading-8 text-slate-600">
+                Fallas, tableros, obras, mantenimiento y packs electricos para viviendas, comercios, edificios y
+                empresas. Presupuesto claro, ejecucion prolija y respuesta rapida.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:flex">
+              <Button asChild size="lg" className="h-12 bg-[#25D366] px-6 text-base font-bold text-black hover:bg-[#1ebe5a]">
+                <a href={whatsappHref} target={isWhatsappExternal ? '_blank' : undefined} rel={isWhatsappExternal ? 'noopener noreferrer' : undefined}>
+                  <MessageCircle className="mr-2 h-5 w-5" />
+                  Pedir presupuesto por WhatsApp
+                </a>
               </Button>
+              <Button asChild size="lg" variant="outline" className="h-12 px-6 text-base">
+                <Link href="/servicios">
+                  Ver servicios y precios
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {['Respuesta prioritaria', 'Visita tecnica disponible', 'Presupuesto claro antes de avanzar', 'Evita fallas, cortes y riesgos electricos'].map((item) => (
+                <div key={item} className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm">
+                  <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                  {item}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="rounded-2xl bg-slate-950 p-6 text-white">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-amber-300">Diagnostico primero</p>
+              <h2 className="mt-4 text-3xl font-semibold text-white">Una falla electrica no se deja para despues.</h2>
+              <p className="mt-4 text-sm leading-6 text-slate-300">
+                Un tablero mal armado puede quemar equipos. Una instalacion improvisada termina costando mas. En
+                comercios y edificios, cada corte implica tiempo perdido y plata parada.
+              </p>
+            </div>
+            <div className="mt-4 grid gap-3">
+              {['Revisar', 'Diagnosticar', 'Presupuestar', 'Ejecutar bien'].map((item) => (
+                <div key={item} className="flex items-center justify-between rounded-2xl border border-slate-200 px-4 py-3">
+                  <span className="font-semibold text-slate-900">{item}</span>
+                  <ShieldCheck className="h-5 w-5 text-slate-500" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="container py-14">
+        <div className="mb-8 max-w-2xl">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Servicios principales</p>
+          <h2 className="mt-2 text-3xl font-semibold text-slate-950">Precio desde, alcance claro y CTA directo.</h2>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {serviceCards.map((service) => (
+            <article key={service.title} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+              <h3 className="text-lg font-semibold text-slate-950">{service.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-slate-600">{service.description}</p>
+              <p className="mt-4 text-sm font-bold text-slate-950">{service.price}</p>
+              <Link href={service.href} className="mt-4 inline-flex items-center text-sm font-semibold text-slate-950">
+                Consultar
+                <ArrowRight className="ml-1 h-4 w-4" />
+              </Link>
             </article>
           ))}
         </div>
       </section>
 
-      <section className="space-y-5">
-        <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">Casos reales</p>
-          <h2 className="text-2xl font-semibold sm:text-3xl">Trabajos recientes</h2>
-        </div>
-        <div className="grid gap-5 md:grid-cols-2">
-          {caseStudies.slice(0, 2).map((cs) => (
-            <article
-              key={cs.id}
-              className="overflow-hidden rounded-2xl border border-border bg-white shadow-sm"
-            >
-              <div className="relative h-56 w-full sm:h-64">
-                <Image
-                  src={cs.fotos[0] ?? site.hero.backgroundImage}
-                  alt={cs.titulo}
-                  fill
-                  className="object-cover"
-                />
-              </div>
-              <div className="space-y-2 p-5">
-                <h3 className="text-lg font-semibold text-slate-900">{cs.titulo}</h3>
-                <p className="text-sm text-muted-foreground">{cs.resumen}</p>
-              </div>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="space-y-4 rounded-2xl border border-border bg-white p-5 sm:p-6">
-        <h2 className="text-2xl font-semibold">Tranquilidad antes de contratar</h2>
-        <div className="grid gap-3 md:grid-cols-3">
-          {riskPoints.map((item) => (
-            <article key={item} className="rounded-xl border border-border bg-muted/20 p-4">
-              <p className="text-sm text-muted-foreground">{item}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="rounded-2xl border border-red-300 bg-gradient-to-r from-red-50 to-amber-50 p-6 sm:p-8">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <section className="border-y border-slate-200 bg-slate-50 py-14">
+        <div className="container grid gap-8 lg:grid-cols-[0.9fr_1.1fr]">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.34em] text-red-700">Cierre rápido</p>
-            <h2 className="mt-2 text-2xl font-semibold text-slate-900">
-              Enviá tu solicitud y seguí por el canal que te quede más cómodo
-            </h2>
-            <p className="mt-1 text-sm text-slate-600">
-              WhatsApp para velocidad. Formulario para dejar todo ordenado desde el inicio.
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Packs electricos</p>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-950">Mano de obra clara desde el principio.</h2>
+            <p className="mt-4 text-sm leading-6 text-slate-600">
+              Valores orientativos de mano de obra. Materiales, artefactos y proyecto electrico se cotizan por separado.
             </p>
           </div>
-          <div className="flex flex-wrap gap-3">
-            <Button asChild className="bg-[#25D366] text-black hover:bg-[#1ebe5a]">
-              <a
-                href={whatsappHref}
-                target="_blank"
-                rel="noopener noreferrer"
-                data-track="whatsapp"
-                data-content-name="WhatsApp cierre home"
-              >
-                Solicitar por WhatsApp
-              </a>
-            </Button>
-            <Button variant="secondary" asChild>
-              <Link href="/presupuestador">Enviar solicitud</Link>
-            </Button>
+          <div className="grid gap-4 md:grid-cols-3">
+            {packs.map((pack) => (
+              <article key={pack.name} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+                <h3 className="text-xl font-semibold text-slate-950">{pack.name}</h3>
+                <p className="mt-2 text-2xl font-semibold text-slate-950">{pack.price}</p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">{pack.description}</p>
+              </article>
+            ))}
           </div>
         </div>
       </section>
 
-      <a
-        href={whatsappHref}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="fixed bottom-24 right-4 z-40 hidden rounded-full bg-[#25D366] px-4 py-3 text-sm font-bold text-black shadow-2xl hover:bg-[#1ebe5a] lg:inline-flex float-soft"
-        data-track="whatsapp"
-        data-content-name="WhatsApp flotante desktop"
-      >
-        Solicitar por WhatsApp
-      </a>
-
-      <div className="fixed inset-x-0 bottom-3 z-40 px-4 sm:hidden">
-        <div className="mx-auto grid max-w-md grid-cols-2 gap-2 rounded-2xl border border-border bg-white/95 p-2 shadow-xl backdrop-blur">
-          <Button asChild className="h-11 bg-[#25D366] text-black hover:bg-[#1ebe5a]">
-            <a
-              href={whatsappHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              data-track="whatsapp"
-              data-content-name="WhatsApp barra fija mobile"
-            >
-              WhatsApp
-            </a>
-          </Button>
-          <Button asChild className="h-11 bg-red-600 hover:bg-red-700">
-            <Link href="/presupuestador">Solicitud</Link>
-          </Button>
+      <section className="container py-14">
+        <div className="grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Mantenimiento mensual</p>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-950">Prevenir sale menos que apagar incendios.</h2>
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            {maintenancePlans.map((plan) => (
+              <article key={plan.name} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+                <h3 className="text-lg font-semibold text-slate-950">{plan.name}</h3>
+                <p className="mt-1 font-bold text-slate-950">{plan.price}</p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">{plan.fit}</p>
+              </article>
+            ))}
+          </div>
         </div>
-      </div>
+      </section>
+
+      <section className="border-y border-slate-200 bg-slate-950 py-14 text-white">
+        <div className="container grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-amber-300">Experiencia</p>
+            <h2 className="mt-2 text-3xl font-semibold text-white">Obras, locales y edificios con criterio profesional.</h2>
+            <p className="mt-4 text-sm leading-6 text-slate-300">
+              Experiencia en instalaciones electricas para locales comerciales, gimnasios, supermercados y edificios residenciales.
+            </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {featuredExperience.map((item) => (
+              <article key={item} className="rounded-2xl border border-white/10 bg-white/5 p-5">
+                <h3 className="text-xl font-semibold text-white">{item}</h3>
+                <p className="mt-2 text-sm text-slate-300">Referencia de experiencia por tipo de obra. Datos especificos editables cuando se carguen.</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="container py-14">
+        <div className="grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Confianza</p>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-950">Seriedad visual, proceso claro y seguimiento real.</h2>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {trustItems.map((item) => (
+              <div key={item} className="flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-800 shadow-sm">
+                <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                {item}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-slate-200 bg-slate-50 py-14">
+        <div className="container grid gap-8 lg:grid-cols-[0.75fr_1.25fr]">
+          <div>
+            <p className="inline-flex items-center gap-2 rounded-full border border-red-200 bg-red-50 px-3 py-2 text-xs font-bold uppercase tracking-[0.18em] text-red-700">
+              <AlertTriangle className="h-4 w-4" />
+              Solicitud rapida
+            </p>
+            <h2 className="mt-4 text-3xl font-semibold text-slate-950">Contanos el problema y priorizamos la respuesta.</h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              Menos vueltas, mas claridad: tipo de trabajo, zona, urgencia, fotos si tenes y WhatsApp para avanzar.
+            </p>
+          </div>
+          <LeadWizard whatsappHref={whatsappHref} />
+        </div>
+      </section>
     </div>
   )
 }

--- a/nerin-electric-site-v3-fixed/app/(site)/presupuestador/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/presupuestador/page.tsx
@@ -1,121 +1,29 @@
-export const dynamic = 'force-dynamic'
+import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
+import { LeadWizard } from '@/components/LeadWizard'
 
-import { getConfiguratorData } from '@/lib/marketing-data'
-import { Badge } from '@/components/ui/badge'
-import { ConfiguratorWizard } from '@/components/configurator/ConfiguratorWizard'
-import { Button } from '@/components/ui/button'
-
-export const revalidate = 60
-
-export async function generateMetadata() {
-  const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Presupuestador y solicitud de servicios | NERIN'
-  const description =
-    'Elegí tipo de trabajo, enviá solicitud y avanzá con una propuesta clara para hogar, comercio u obra.'
-
-  return {
-    title,
-    description,
-    alternates: {
-      canonical: '/presupuestador',
-    },
-    openGraph: {
-      title,
-      description,
-      url: `${siteUrl}/presupuestador`,
-      images: [{ url: '/nerin/og-cover.png', width: 1200, height: 630, alt: 'NERIN Electric' }],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title,
-      description,
-      images: ['/nerin/og-cover.png'],
-    },
-  }
+export const metadata = {
+  title: 'Presupuestador electrico simple | NERIN',
+  description: 'Solicita presupuesto electrico en 4 pasos: necesidad, zona, urgencia, detalle y fotos.',
 }
 
-const howItWorks = [
-  'Paso 1 · Elegí modalidad y tipo de trabajo en segundos.',
-  'Paso 2 · Revisá alcance, precio estimado y cobertura en la misma pantalla.',
-  'Paso 3 · Enviá datos y reservá el avance comercial sin fricción.',
-]
-
-export default async function PresupuestadorPage({
-  searchParams,
-}: {
-  searchParams: { pack?: string; mode?: 'EXPRESS' | 'PROJECT' }
-}) {
-  const { packs, adicionales } = await getConfiguratorData()
-  const defaultPack = searchParams.pack ? packs.find((pack) => pack.slug === searchParams.pack)?.id : undefined
-
-  const wizardPacks = packs.map((pack) => ({
-    id: pack.id,
-    slug: pack.slug,
-    name: pack.name,
-    description: pack.description,
-    scope: pack.scope,
-    features: pack.features,
-    basePrice: pack.basePrice,
-    advancePrice: pack.advancePrice,
-  }))
-  const wizardAdicionales = adicionales.map((item) => ({
-    id: item.id,
-    nombre: item.nombre,
-    descripcion: item.descripcion,
-    unidad: item.unidad,
-    precioUnitarioManoObra: item.precioUnitarioManoObra,
-    reglasCompatibilidad: item.reglasCompatibilidad ?? null,
-    packId: item.packId,
-  }))
+export default async function PresupuestadorPage({ searchParams }: { searchParams: { tipo?: string } }) {
+  const site = await getSiteContent()
+  const whatsappHref = getWhatsappHref(site)
 
   return (
-    <div className="space-y-10 bg-slate-50/80 p-1 sm:space-y-12">
-      <header className="grid gap-6 rounded-[2rem] border border-slate-200 bg-white p-7 shadow-sm sm:grid-cols-[1.25fr_0.75fr] sm:p-10">
-        <div className="space-y-6">
-          <Badge className="w-fit border-slate-300 bg-slate-100 text-slate-700">Configurador NERIN</Badge>
-          <div className="space-y-3">
-            <h1 className="text-4xl font-semibold leading-tight tracking-tight text-slate-900 sm:text-5xl">
-              Cotizalo
-            </h1>
-            <p className="max-w-3xl text-lg leading-relaxed text-slate-600 sm:text-xl">
-              Elegí servicio, completá datos y recibí una propuesta clara para avanzar.
-            </p>
-          </div>
-          <Button asChild className="h-12 bg-slate-900 px-7 text-base font-semibold text-white hover:bg-slate-800">
-            <a href="#configurador-nerin">Comenzar ahora</a>
-          </Button>
+    <div className="bg-slate-50">
+      <section className="border-b border-slate-200 bg-white py-14">
+        <div className="container max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Presupuestador</p>
+          <h1 className="mt-3 text-4xl font-semibold text-slate-950 sm:text-5xl">Cuatro pasos y una solicitud clara.</h1>
+          <p className="mt-4 text-lg leading-8 text-slate-600">
+            No es una herramienta tecnica pesada. Es una forma rapida de entender que necesitas, donde es, que urgencia tiene y como contactarte.
+          </p>
         </div>
-
-        <aside className="rounded-2xl border border-slate-200 bg-slate-50 p-5">
-          <p className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-500">Qué vas a definir</p>
-          <div className="mt-4 space-y-3 text-sm text-slate-700">
-            <p className="rounded-xl border border-slate-200 bg-white px-3 py-2">Modalidad del trabajo (puntual u obra).</p>
-            <p className="rounded-xl border border-slate-200 bg-white px-3 py-2">Servicio exacto con vista previa de alcance.</p>
-            <p className="rounded-xl border border-slate-200 bg-white px-3 py-2">Prioridad, cobertura y datos para reservar.</p>
-          </div>
-          <div className="mt-4 grid gap-2 text-xs font-medium text-slate-600">
-            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-center">Decisión guiada</span>
-            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-center">Precio estimado visible</span>
-          </div>
-        </aside>
-      </header>
-
-      <section className="grid gap-4 sm:grid-cols-3">
-        {howItWorks.map((item) => (
-          <article key={item} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-            <p className="text-base font-medium text-slate-700">{item}</p>
-          </article>
-        ))}
       </section>
-
-      <div id="configurador-nerin">
-        <ConfiguratorWizard
-          packs={wizardPacks}
-          adicionales={wizardAdicionales}
-          defaultPackId={defaultPack}
-          initialMode={searchParams.mode}
-        />
-      </div>
+      <section className="container py-14">
+        <LeadWizard whatsappHref={whatsappHref} initialWorkType={searchParams.tipo} />
+      </section>
     </div>
   )
 }

--- a/nerin-electric-site-v3-fixed/app/(site)/servicios/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/servicios/page.tsx
@@ -1,146 +1,50 @@
 import Link from 'next/link'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { fetchPublicJson } from '@/lib/public-api'
-import { getSiteContent } from '@/lib/site-content'
+import { ArrowRight, CheckCircle2 } from 'lucide-react'
+import { serviceCards, trustItems } from '@/lib/nerin-electricidad'
 
-type Service = {
-  id?: string
-  title: string
-  description: string
+export const metadata = {
+  title: 'Servicios electricos en CABA y GBA | NERIN',
+  description: 'Fallas, tableros, instalaciones, comercios, edificios, mantenimiento y circuitos dedicados con precio desde.',
 }
 
-const serviceSystem = [
-  {
-    title: 'Solicitud simple',
-    description: 'Podés arrancar por WhatsApp o formulario según tu caso.',
-  },
-  {
-    title: 'Definición clara',
-    description: 'Ordenamos alcance y prioridad para que sepas cómo seguimos.',
-  },
-  {
-    title: 'Ejecución y seguimiento',
-    description: 'Coordinamos y cerramos el trabajo con comunicación ordenada.',
-  },
-]
-
-export async function generateMetadata() {
-  const site = await getSiteContent()
-  const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  const title = 'Servicios eléctricos en CABA y GBA | NERIN'
-  const description =
-    'Servicios para hogares, comercios y obras con solicitud simple, respuesta rápida y ejecución prolija.'
-
-  return {
-    title,
-    description,
-    alternates: {
-      canonical: '/servicios',
-    },
-    openGraph: {
-      title,
-      description,
-      url: `${siteUrl}/servicios`,
-      siteName: site.name,
-      images: [{ url: '/nerin/og-cover.png', width: 1200, height: 630, alt: 'NERIN Electric' }],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title,
-      description,
-      images: ['/nerin/og-cover.png'],
-    },
-  }
-}
-
-export default async function ServiciosPage() {
-  const site = await getSiteContent()
-  const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
-  let services: Service[] = []
-  try {
-    services = await fetchPublicJson<Service[]>('/api/public/services')
-  } catch (error) {
-    services = site.services.items.map((item) => ({
-      title: item.title,
-      description: item.description,
-    }))
-  }
-
-  const servicesSchema = {
-    '@context': 'https://schema.org',
-    '@graph': services.map((service) => ({
-      '@type': 'Service',
-      name: service.title,
-      description: service.description,
-      provider: {
-        '@type': 'LocalBusiness',
-        name: site.name,
-        url: siteUrl,
-      },
-      areaServed: site.contact.serviceArea,
-      serviceType: service.title,
-    })),
-  }
-
+export default function ServiciosPage() {
   return (
-    <>
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(servicesSchema) }} />
-      <div className="space-y-10">
-        <header className="space-y-5 rounded-3xl border border-border/70 bg-slate-950 p-6 text-white sm:p-8">
-          <Badge className="w-fit border-cyan-300/50 bg-cyan-500/20 text-cyan-100">Servicios</Badge>
-          <h1 className="text-3xl font-semibold leading-tight sm:text-5xl">
-            Servicios eléctricos para clientes que valoran rapidez, orden y tranquilidad
-          </h1>
-          <p className="max-w-3xl text-base text-slate-200 sm:text-lg">
-            Desde trabajos puntuales en vivienda hasta proyectos de obra. El objetivo es uno: que
-            avances rápido y sepas siempre qué sigue.
+    <div className="bg-white">
+      <section className="border-b border-slate-200 bg-slate-50 py-14">
+        <div className="container max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Servicios</p>
+          <h1 className="mt-3 text-4xl font-semibold text-slate-950 sm:text-5xl">Resolucion electrica clara, sin esconder precios.</h1>
+          <p className="mt-4 text-lg leading-8 text-slate-600">
+            Elegi el problema, revisa el precio desde y envia la solicitud. Si el alcance cambia, se presupuestan materiales,
+            adicionales y obra antes de avanzar.
           </p>
-          <div className="flex flex-wrap gap-3">
-            <Button className="bg-[#25D366] font-bold text-black hover:bg-[#1ebe5a]" asChild>
-              <Link href="/presupuestador">Enviar solicitud</Link>
-            </Button>
-            <Button className="bg-red-600 font-bold hover:bg-red-700" asChild>
-              <Link href="/presupuestador?mode=PROJECT">Cotización para obra</Link>
-            </Button>
-          </div>
-        </header>
-
-        <section className="space-y-4 rounded-2xl border border-border bg-white p-5 sm:p-6">
-          <h2 className="text-2xl font-semibold text-slate-900">Sistema de trabajo</h2>
-          <div className="grid gap-3 md:grid-cols-3">
-            {serviceSystem.map((item) => (
-              <article key={item.title} className="rounded-xl border border-border bg-muted/20 p-4">
-                <h3 className="text-base font-semibold text-slate-900">{item.title}</h3>
-                <p className="mt-1 text-sm text-slate-600">{item.description}</p>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section className="grid gap-6 md:grid-cols-2">
-          {services.map((service) => (
-            <Card
-              key={service.id ?? service.title}
-              className="space-y-4 border-cyan-100 bg-gradient-to-b from-white to-cyan-50/30"
-            >
-              <CardHeader>
-                <CardTitle>{service.title}</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3 text-sm text-slate-700">
-                <p>{service.description}</p>
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-700">
-                  Solicitud clara + ejecución prolija + seguimiento
-                </p>
-                <Button variant="secondary" asChild className="w-full">
-                  <Link href="/presupuestador">Solicitar este servicio</Link>
-                </Button>
-              </CardContent>
-            </Card>
+        </div>
+      </section>
+      <section className="container py-14">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {serviceCards.map((service) => (
+            <article key={service.title} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+              <h2 className="text-xl font-semibold text-slate-950">{service.title}</h2>
+              <p className="mt-2 text-sm leading-6 text-slate-600">{service.description}</p>
+              <p className="mt-4 text-sm font-bold text-slate-950">{service.price}</p>
+              <Link href={service.href} className="mt-4 inline-flex items-center text-sm font-semibold text-slate-950">
+                Pedir presupuesto
+                <ArrowRight className="ml-1 h-4 w-4" />
+              </Link>
+            </article>
           ))}
-        </section>
-      </div>
-    </>
+        </div>
+      </section>
+      <section className="border-t border-slate-200 bg-slate-50 py-14">
+        <div className="container grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {trustItems.map((item) => (
+            <div key={item} className="flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-800">
+              <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+              {item}
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
   )
 }

--- a/nerin-electric-site-v3-fixed/app/api/leads/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/leads/route.ts
@@ -7,7 +7,7 @@ import { storeMediaFile } from '@/lib/media'
 const LeadSchema = z.object({
   name: z.string().min(2),
   phone: z.string().min(6),
-  email: z.string().email(),
+  email: z.string().email().optional().or(z.literal('')),
   clientType: z.string().min(1),
   location: z.string().min(2),
   address: z.string().optional().or(z.literal('')),
@@ -108,7 +108,7 @@ export async function POST(request: Request) {
     const lead = await store.createLead({
       name: parsed.data.name,
       phone: parsed.data.phone,
-      email: parsed.data.email,
+      email: parsed.data.email || '',
       clientType: parsed.data.clientType,
       location: parsed.data.location,
       address: parsed.data.address || null,
@@ -180,7 +180,7 @@ export async function POST(request: Request) {
       console.info('[LEADS] SALES_TO_EMAIL not configured, lead stored', { id: lead.id })
     }
 
-    if (lead.email) {
+    if (lead.email && lead.email.includes('@')) {
       await sendTransactionalEmail({
         to: lead.email,
         subject: 'Recibimos tu solicitud de presupuesto',

--- a/nerin-electric-site-v3-fixed/components/Footer.tsx
+++ b/nerin-electric-site-v3-fixed/components/Footer.tsx
@@ -2,16 +2,17 @@ import Link from 'next/link'
 import type { SiteExperience } from '@/types/site'
 import { getWhatsappHref } from '@/lib/site-content'
 
-const legalLinks = [
-  { href: '/terminos', label: 'Términos y condiciones' },
-  { href: '/privacidad', label: 'Política de privacidad' },
-] as const
-
 const quickLinks = [
   { href: '/servicios', label: 'Servicios' },
-  { href: '/presupuestador?mode=PROJECT', label: 'Obras' },
-  { href: '/obras', label: 'Casos' },
+  { href: '/packs', label: 'Packs' },
+  { href: '/mantenimiento', label: 'Mantenimiento' },
+  { href: '/obras', label: 'Obras' },
   { href: '/contacto', label: 'Contacto' },
+] as const
+
+const legalLinks = [
+  { href: '/terminos', label: 'Terminos y condiciones' },
+  { href: '/privacidad', label: 'Politica de privacidad' },
 ] as const
 
 interface FooterProps {
@@ -20,110 +21,93 @@ interface FooterProps {
 
 export function Footer({ site }: FooterProps) {
   const whatsappHref = getWhatsappHref(site)
+  const isWhatsappExternal = whatsappHref.startsWith('http')
 
   return (
-    <footer className="border-t border-border bg-white">
-      <div className="border-b border-red-200 bg-red-50 py-3">
-        <div className="container flex flex-col gap-2 text-sm sm:flex-row sm:items-center sm:justify-between">
-          <p className="font-semibold text-red-700">
-            🔥 Últimos servicios del día: confirmá ahora por WhatsApp.
+    <footer className="border-t border-slate-200 bg-white">
+      <div className="border-b border-slate-200 bg-slate-950 py-4 text-white">
+        <div className="container flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm font-semibold text-white">
+            Una instalacion mal resuelta puede salir mas cara despues. Pedi diagnostico y presupuesto claro.
           </p>
           <a
             href={whatsappHref}
-            className="inline-flex w-fit items-center rounded-full bg-red-600 px-4 py-1.5 text-xs font-bold uppercase tracking-wide text-white hover:bg-red-700 pulse-ring"
+            target={isWhatsappExternal ? '_blank' : undefined}
+            rel={isWhatsappExternal ? 'noopener noreferrer' : undefined}
+            className="inline-flex w-fit items-center rounded-full bg-[#25D366] px-4 py-2 text-xs font-bold uppercase tracking-wide text-black hover:bg-[#1ebe5a]"
             data-track="whatsapp"
-            data-content-name="WhatsApp promo footer"
+            data-content-name="WhatsApp footer"
           >
-            Cerrar turno ahora
+            Pedir presupuesto
           </a>
         </div>
       </div>
 
-      <div className="container grid gap-8 py-10 sm:py-12 lg:grid-cols-[1.25fr_1fr_1fr_1fr]">
+      <div className="container grid gap-8 py-10 sm:py-12 lg:grid-cols-[1.4fr_1fr_1fr_1fr]">
         <div className="space-y-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">
-            NERIN
+          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-slate-500">NERIN Electricidad</p>
+          <p className="max-w-sm text-sm font-medium text-slate-900">
+            Servicios electricos para viviendas, comercios, edificios, empresas y obras en CABA/GBA.
           </p>
-          <p className="text-sm font-medium text-foreground">
-            Contratista eléctrico en CABA y GBA.
+          <p className="text-sm text-slate-600">{site.contact.serviceArea}</p>
+          <p className="text-xs text-slate-500">
+            Datos legales, responsables tecnicos y matriculas se muestran cuando esten cargados en configuracion.
           </p>
-          <p className="text-sm text-muted-foreground">{site.contact.serviceArea}</p>
-          <div className="inline-flex items-center gap-2 rounded-full border border-red-200 bg-red-50 px-3 py-1 text-xs font-semibold text-red-700">
-            Agenda activa · Respuesta rápida
-          </div>
-          <a
-            href={whatsappHref}
-            className="inline-flex items-center rounded-full bg-[#25D366] px-4 py-2 text-sm font-semibold text-black transition hover:bg-[#1ebe5a]"
-            data-track="whatsapp"
-            data-content-name="WhatsApp footer principal"
-          >
-            WhatsApp directo
-          </a>
         </div>
 
         <div>
-          <h4 className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">
-            Accesos
-          </h4>
-          <ul className="mt-3 space-y-2 text-sm text-foreground">
+          <h4 className="text-xs font-semibold uppercase tracking-[0.34em] text-slate-500">Accesos</h4>
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
             {quickLinks.map((item) => (
               <li key={item.href}>
-                <Link href={item.href} className="transition-colors hover:text-foreground">
-                  {item.label}
-                </Link>
+                <Link href={item.href}>{item.label}</Link>
               </li>
             ))}
           </ul>
         </div>
 
         <div>
-          <h4 className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">
-            Contacto
-          </h4>
-          <ul className="mt-3 space-y-2 text-sm text-foreground">
+          <h4 className="text-xs font-semibold uppercase tracking-[0.34em] text-slate-500">Contacto</h4>
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
             <li>
               <a
                 href={whatsappHref}
-                className="hover:text-foreground"
+                target={isWhatsappExternal ? '_blank' : undefined}
+                rel={isWhatsappExternal ? 'noopener noreferrer' : undefined}
                 data-track="whatsapp"
-                data-content-name="WhatsApp footer"
+                data-content-name="WhatsApp footer link"
               >
                 WhatsApp
               </a>
             </li>
-            <li>
-              <a href={`mailto:${site.contact.email}`} className="hover:text-foreground break-all">
-                {site.contact.email}
-              </a>
-            </li>
+            {site.contact.email ? (
+              <li>
+                <a href={`mailto:${site.contact.email}`} className="break-all">
+                  {site.contact.email}
+                </a>
+              </li>
+            ) : null}
           </ul>
         </div>
 
         <div>
-          <h4 className="text-xs font-semibold uppercase tracking-[0.34em] text-muted-foreground">
-            Legales
-          </h4>
-          <ul className="mt-3 space-y-2 text-sm text-foreground">
+          <h4 className="text-xs font-semibold uppercase tracking-[0.34em] text-slate-500">Sistema</h4>
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
             {legalLinks.map((item) => (
               <li key={item.href}>
-                <Link className="hover:text-foreground" href={item.href}>
-                  {item.label}
-                </Link>
+                <Link href={item.href}>{item.label}</Link>
               </li>
             ))}
+            <li>
+              <Link href="/admin">Panel admin</Link>
+            </li>
           </ul>
         </div>
       </div>
 
-      <div className="border-t border-border bg-muted py-6">
-        <div className="container flex flex-col gap-3 text-sm text-muted-foreground lg:flex-row lg:items-center lg:justify-between">
-          <span>© {new Date().getFullYear()} NERIN Electric.</span>
-          <Link
-            href="/admin"
-            className="text-xs uppercase tracking-[0.3em] text-muted-foreground hover:text-foreground"
-          >
-            Panel admin
-          </Link>
+      <div className="border-t border-slate-200 bg-slate-50 py-5">
+        <div className="container text-sm text-slate-500">
+          <span>© {new Date().getFullYear()} NERIN Electricidad.</span>
         </div>
       </div>
     </footer>

--- a/nerin-electric-site-v3-fixed/components/Header.tsx
+++ b/nerin-electric-site-v3-fixed/components/Header.tsx
@@ -2,9 +2,9 @@
 
 import Link from 'next/link'
 import { useState } from 'react'
+import { Menu, MessageCircle, X, Zap } from 'lucide-react'
 import { Logo } from './Logo'
 import { Button } from './ui/button'
-import { useSession } from 'next-auth/react'
 
 interface HeaderProps {
   contact: {
@@ -21,84 +21,67 @@ interface HeaderProps {
 const navigation = [
   { href: '/', label: 'Inicio' },
   { href: '/servicios', label: 'Servicios' },
-  { href: '/presupuestador?mode=PROJECT', label: 'Obras' },
-  { href: '/obras', label: 'Casos' },
+  { href: '/packs', label: 'Packs' },
+  { href: '/mantenimiento', label: 'Mantenimiento' },
+  { href: '/obras', label: 'Obras' },
+  { href: '/empresa', label: 'Empresa' },
   { href: '/contacto', label: 'Contacto' },
 ] as const
 
-const clientDashboardRoute = '/clientes' as const
-
 const marqueeMessages = [
-  '⚡ Turnos técnicos para hoy: limitados',
-  '📲 Atención prioritaria por WhatsApp',
-  '🛠️ Servicio puntual y obra eléctrica',
-  '🏙️ Cobertura CABA y GBA',
+  'Respuesta prioritaria para fallas electricas',
+  'Presupuesto claro antes de avanzar',
+  'Materiales separados de la mano de obra',
+  'CABA y GBA',
 ]
 
 export function Header({ contact, logo }: HeaderProps) {
-  const { data: session } = useSession()
   const [menuOpen, setMenuOpen] = useState(false)
+  const isWhatsappExternal = contact.whatsappHref.startsWith('http')
 
   return (
     <>
-      <div className="overflow-hidden border-b border-red-200 bg-red-600 text-white">
-        <div className="marquee-track flex gap-8 px-4 py-1.5 text-[11px] font-bold uppercase tracking-[0.18em]">
+      <div className="overflow-hidden border-b border-slate-200 bg-slate-950 text-white">
+        <div className="marquee-track flex gap-10 px-4 py-2 text-[11px] font-bold uppercase tracking-[0.18em]">
           {[...marqueeMessages, ...marqueeMessages].map((message, idx) => (
-            <span key={`${message}-${idx}`}>{message}</span>
+            <span key={`${message}-${idx}`} className="inline-flex items-center gap-2">
+              <Zap className="h-3 w-3 text-amber-300" />
+              {message}
+            </span>
           ))}
         </div>
       </div>
 
       <header className="sticky top-0 z-50 border-b border-border/80 bg-white/95 backdrop-blur supports-[padding:env(safe-area-inset-top)]:pt-[env(safe-area-inset-top)]">
         <div className="container flex items-center justify-between gap-3 py-2.5 sm:gap-4 sm:py-3">
-          <Logo
-            title={logo.title}
-            subtitle={logo.subtitle}
-            imageUrl={logo.imageUrl}
-            className="min-w-0"
-          />
+          <Logo title={logo.title} subtitle={logo.subtitle} imageUrl={logo.imageUrl} className="min-w-0" />
 
-          <nav className="hidden items-center gap-5 text-sm font-medium text-muted-foreground xl:flex">
+          <nav className="hidden items-center gap-5 text-sm font-medium text-slate-600 xl:flex">
             {navigation.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className="transition-colors hover:text-foreground"
-              >
+              <Link key={item.href} href={item.href} className="transition-colors hover:text-slate-950">
                 {item.label}
               </Link>
             ))}
           </nav>
 
           <div className="flex items-center gap-2 sm:gap-3">
-            <Button
-              size="sm"
-              asChild
-              className="hidden border-0 bg-[#25D366] font-semibold text-black hover:bg-[#1ebe5a] lg:inline-flex"
-            >
+            <Button size="sm" asChild className="hidden border-0 bg-[#25D366] font-semibold text-black hover:bg-[#1ebe5a] lg:inline-flex">
               <a
                 href={contact.whatsappHref}
                 aria-label={contact.whatsappLabel}
                 title={contact.whatsappLabel}
-                target="_blank"
-                rel="noopener noreferrer"
+                target={isWhatsappExternal ? '_blank' : undefined}
+                rel={isWhatsappExternal ? 'noopener noreferrer' : undefined}
                 data-track="whatsapp"
                 data-content-name="WhatsApp header"
               >
-                WhatsApp ya
+                <MessageCircle className="mr-2 h-4 w-4" />
+                WhatsApp
               </a>
             </Button>
-            <Button
-              size="sm"
-              asChild
-              className="hidden bg-red-600 hover:bg-red-700 lg:inline-flex pulse-ring"
-            >
-              <Link
-                href="/presupuestador?mode=EXPRESS"
-                data-track="lead"
-                data-content-name="Servicio puntual header"
-              >
-                Reservar turno
+            <Button size="sm" asChild className="hidden bg-slate-950 hover:bg-slate-800 lg:inline-flex">
+              <Link href="/presupuestador" data-track="lead" data-content-name="Presupuesto header">
+                Pedir presupuesto
               </Link>
             </Button>
 
@@ -107,21 +90,9 @@ export function Header({ contact, logo }: HeaderProps) {
               onClick={() => setMenuOpen((prev) => !prev)}
               className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-white text-foreground xl:hidden"
               aria-expanded={menuOpen}
-              aria-label="Abrir menú de navegación"
+              aria-label="Abrir menu de navegacion"
             >
-              <svg
-                aria-hidden
-                viewBox="0 0 24 24"
-                className="h-5 w-5 stroke-current"
-                fill="none"
-                strokeWidth="1.8"
-              >
-                {menuOpen ? (
-                  <path d="M6 6l12 12M18 6 6 18" />
-                ) : (
-                  <path d="M4 7h16M4 12h16M4 17h16" />
-                )}
-              </svg>
+              {menuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
             </button>
           </div>
         </div>
@@ -143,47 +114,18 @@ export function Header({ contact, logo }: HeaderProps) {
               </nav>
 
               <div className="grid gap-2 sm:grid-cols-2">
-                <Button
-                  asChild
-                  className="bg-red-600 hover:bg-red-700"
-                  onClick={() => setMenuOpen(false)}
-                >
-                  <Link href="/presupuestador?mode=EXPRESS">Reservar turno</Link>
+                <Button asChild className="bg-slate-950 hover:bg-slate-800" onClick={() => setMenuOpen(false)}>
+                  <Link href="/presupuestador">Pedir presupuesto</Link>
                 </Button>
                 <Button asChild className="bg-[#25D366] text-black hover:bg-[#1ebe5a]">
-                  <a href={contact.whatsappHref} target="_blank" rel="noopener noreferrer">
-                    WhatsApp ya
+                  <a
+                    href={contact.whatsappHref}
+                    target={isWhatsappExternal ? '_blank' : undefined}
+                    rel={isWhatsappExternal ? 'noopener noreferrer' : undefined}
+                  >
+                    WhatsApp
                   </a>
                 </Button>
-                <Button
-                  variant="secondary"
-                  asChild
-                  className="sm:col-span-2"
-                  onClick={() => setMenuOpen(false)}
-                >
-                  <Link href="/contacto">Contacto</Link>
-                </Button>
-
-                {!session?.user && (
-                  <Button
-                    variant="outline"
-                    asChild
-                    className="sm:col-span-2"
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    <Link href="/clientes/login">Ingresar</Link>
-                  </Button>
-                )}
-                {session?.user && session.user.role !== 'admin' && (
-                  <Button
-                    variant="outline"
-                    asChild
-                    className="sm:col-span-2"
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    <Link href={clientDashboardRoute}>Portal clientes</Link>
-                  </Button>
-                )}
               </div>
             </div>
           </div>

--- a/nerin-electric-site-v3-fixed/components/LeadWizard.tsx
+++ b/nerin-electric-site-v3-fixed/components/LeadWizard.tsx
@@ -1,0 +1,235 @@
+'use client'
+
+import { FormEvent, useMemo, useState } from 'react'
+import { CheckCircle2, Loader2, MessageCircle } from 'lucide-react'
+import { leadWorkTypes, propertyTypes, urgencyOptions } from '@/lib/nerin-electricidad'
+import { Button } from '@/components/ui/button'
+
+type LeadWizardProps = {
+  whatsappHref: string
+  initialWorkType?: string
+}
+
+const zones = ['CABA', 'GBA'] as const
+
+export function LeadWizard({ whatsappHref, initialWorkType }: LeadWizardProps) {
+  const [form, setForm] = useState({
+    workType: initialWorkType || leadWorkTypes[0],
+    zone: 'CABA',
+    location: '',
+    propertyType: propertyTypes[0],
+    urgency: urgencyOptions[0],
+    details: '',
+    phone: '',
+    name: '',
+    email: '',
+    consent: true,
+  })
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
+  const [message, setMessage] = useState('')
+  const isWhatsappExternal = whatsappHref.startsWith('http')
+
+  const summary = useMemo(
+    () => [form.workType, form.zone, form.location || 'localidad a confirmar', form.urgency].join(' · '),
+    [form.location, form.urgency, form.workType, form.zone],
+  )
+
+  const update = (key: keyof typeof form, value: string | boolean) => {
+    setForm((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setStatus('submitting')
+    setMessage('')
+
+    const formData = new FormData(event.currentTarget)
+    formData.set('clientType', form.propertyType)
+    formData.set('location', `${form.zone} - ${form.location}`)
+    formData.set('address', form.location)
+    formData.set('leadType', 'public-wizard')
+    formData.set('reason', form.urgency)
+    formData.set('consent', form.consent ? 'true' : 'false')
+
+    try {
+      const response = await fetch('/api/leads', {
+        method: 'POST',
+        body: formData,
+      })
+      const payload = (await response.json().catch(() => ({}))) as { error?: string }
+      if (!response.ok) throw new Error(payload.error || 'No pudimos enviar la solicitud.')
+      setStatus('success')
+      setMessage('Solicitud recibida. Si es urgente, reforzala por WhatsApp para priorizar la respuesta.')
+    } catch (error) {
+      setStatus('error')
+      setMessage(error instanceof Error ? error.message : 'No pudimos enviar la solicitud.')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="grid gap-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
+      <div className="grid gap-4 lg:grid-cols-2">
+        <fieldset className="space-y-3">
+          <legend className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">1. Que necesitas</legend>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {leadWorkTypes.map((item) => (
+              <label key={item} className="flex cursor-pointer items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 has-[:checked]:border-slate-950 has-[:checked]:bg-slate-950 has-[:checked]:text-white">
+                <input
+                  className="sr-only"
+                  type="radio"
+                  name="workType"
+                  value={item}
+                  checked={form.workType === item}
+                  onChange={(event) => update('workType', event.target.value)}
+                />
+                {item}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <fieldset className="space-y-3">
+          <legend className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">2. Donde es</legend>
+          <div className="grid gap-3">
+            <div className="grid grid-cols-2 gap-2">
+              {zones.map((zone) => (
+                <label key={zone} className="flex cursor-pointer items-center justify-center rounded-xl border border-slate-200 px-3 py-2 text-sm font-semibold has-[:checked]:border-slate-950 has-[:checked]:bg-slate-950 has-[:checked]:text-white">
+                  <input
+                    className="sr-only"
+                    type="radio"
+                    name="zone"
+                    value={zone}
+                    checked={form.zone === zone}
+                    onChange={(event) => update('zone', event.target.value)}
+                  />
+                  {zone}
+                </label>
+              ))}
+            </div>
+            <input
+              name="locationInput"
+              value={form.location}
+              onChange={(event) => update('location', event.target.value)}
+              placeholder="Barrio o localidad"
+              className="h-11 rounded-xl border border-slate-200 px-3 text-sm outline-none focus:border-slate-950"
+              required
+            />
+            <select
+              name="propertyType"
+              value={form.propertyType}
+              onChange={(event) => update('propertyType', event.target.value)}
+              className="h-11 rounded-xl border border-slate-200 px-3 text-sm outline-none focus:border-slate-950"
+            >
+              {propertyTypes.map((item) => (
+                <option key={item}>{item}</option>
+              ))}
+            </select>
+          </div>
+        </fieldset>
+      </div>
+
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">3. Urgencia</legend>
+        <div className="grid gap-2 sm:grid-cols-4">
+          {urgencyOptions.map((item) => (
+            <label key={item} className="flex cursor-pointer items-center justify-center rounded-xl border border-slate-200 px-3 py-2 text-center text-sm font-semibold has-[:checked]:border-amber-400 has-[:checked]:bg-amber-50">
+              <input
+                className="sr-only"
+                type="radio"
+                name="urgency"
+                value={item}
+                checked={form.urgency === item}
+                onChange={(event) => update('urgency', event.target.value)}
+              />
+              {item}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">4. Detalle y contacto</legend>
+        <div className="grid gap-3 lg:grid-cols-2">
+          <textarea
+            name="details"
+            value={form.details}
+            onChange={(event) => update('details', event.target.value)}
+            placeholder="Contanos que pasa, desde cuando, si hay cortes, olor, chispazos, tablero, obra o mantenimiento."
+            className="min-h-32 rounded-xl border border-slate-200 px-3 py-3 text-sm outline-none focus:border-slate-950 lg:col-span-2"
+            required
+          />
+          <input
+            name="name"
+            value={form.name}
+            onChange={(event) => update('name', event.target.value)}
+            placeholder="Nombre"
+            className="h-11 rounded-xl border border-slate-200 px-3 text-sm outline-none focus:border-slate-950"
+            required
+          />
+          <input
+            name="phone"
+            value={form.phone}
+            onChange={(event) => update('phone', event.target.value)}
+            placeholder="WhatsApp"
+            className="h-11 rounded-xl border border-slate-200 px-3 text-sm outline-none focus:border-slate-950"
+            required
+          />
+          <input
+            name="email"
+            type="email"
+            value={form.email}
+            onChange={(event) => update('email', event.target.value)}
+            placeholder="Email opcional"
+            className="h-11 rounded-xl border border-slate-200 px-3 text-sm outline-none focus:border-slate-950"
+          />
+          <input
+            name="adjuntos"
+            type="file"
+            multiple
+            accept="image/*,.pdf"
+            className="h-11 rounded-xl border border-slate-200 px-3 py-2 text-sm"
+          />
+        </div>
+      </fieldset>
+
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4">
+        <p className="text-sm font-semibold text-slate-950">Resumen: {summary}</p>
+        <p className="mt-1 text-sm text-slate-700">
+          Si hay riesgo, corte o tablero comprometido, conviene diagnosticar antes de que el problema escale.
+        </p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-center">
+        <label className="flex items-start gap-2 text-xs text-slate-500">
+          <input
+            name="consent"
+            type="checkbox"
+            checked={form.consent}
+            onChange={(event) => update('consent', event.target.checked)}
+            className="mt-1"
+            required
+          />
+          Acepto que NERIN me contacte por esta solicitud.
+        </label>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Button type="submit" disabled={status === 'submitting'} className="bg-slate-950 hover:bg-slate-800">
+            {status === 'submitting' ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-2 h-4 w-4" />}
+            Enviar solicitud
+          </Button>
+          <Button asChild className="bg-[#25D366] text-black hover:bg-[#1ebe5a]">
+            <a href={whatsappHref} target={isWhatsappExternal ? '_blank' : undefined} rel={isWhatsappExternal ? 'noopener noreferrer' : undefined}>
+              <MessageCircle className="mr-2 h-4 w-4" />
+              WhatsApp
+            </a>
+          </Button>
+        </div>
+      </div>
+
+      {message ? (
+        <p className={status === 'error' ? 'text-sm font-medium text-red-700' : 'text-sm font-medium text-emerald-700'}>
+          {message}
+        </p>
+      ) : null}
+    </form>
+  )
+}

--- a/nerin-electric-site-v3-fixed/components/admin/nav.ts
+++ b/nerin-electric-site-v3-fixed/components/admin/nav.ts
@@ -14,30 +14,35 @@ export const adminNav: AdminNavSection[] = [
   {
     label: 'Centro de control',
     items: [
-      { title: 'Inicio admin', href: '/admin' as Route },
-      { title: 'Consultas (leads)', href: '/admin/leads' as Route },
-    ],
-  },
-  {
-    label: 'Gestión comercial',
-    items: [
-      { title: 'Packs y precios', href: '/admin/packs' as Route },
-      { title: 'Noticias', href: '/admin/noticias' as Route },
-    ],
-  },
-  {
-    label: 'Operaciones',
-    items: [
-      { title: 'Panel operativo', href: '/admin/ops' as Route },
-      { title: 'Proyectos', href: '/admin/ops/projects' as Route },
-      { title: 'Certificados', href: '/admin/ops/certificates' as Route },
+      { title: 'Dashboard', href: '/admin' as Route },
+      { title: 'Leads', href: '/admin/leads' as Route },
       { title: 'Clientes', href: '/admin/ops/clients' as Route },
-      { title: 'CAC / IVA', href: '/admin/operativo' as Route },
+      { title: 'Presupuestos', href: '/admin/ops' as Route },
     ],
   },
   {
-    label: 'Sistema',
-    items: [{ title: 'Ajustes generales', href: '/admin/ajustes' as Route }],
+    label: 'Operacion',
+    items: [
+      { title: 'Obras', href: '/admin/ops/projects' as Route },
+      { title: 'Certificados', href: '/admin/ops/certificates' as Route },
+      { title: 'Mantenimiento', href: '/admin/operativo' as Route },
+      { title: 'Visitas tecnicas', href: '/admin/ops' as Route },
+    ],
+  },
+  {
+    label: 'Finanzas',
+    items: [
+      { title: 'Ingresos', href: '/admin/ops' as Route },
+      { title: 'Gastos', href: '/admin/ops' as Route },
+    ],
+  },
+  {
+    label: 'Contenido y oferta',
+    items: [
+      { title: 'Servicios y packs', href: '/admin/packs' as Route },
+      { title: 'Contenido web', href: '/admin' as Route },
+      { title: 'Configuracion', href: '/admin/ajustes' as Route },
+    ],
   },
 ]
 

--- a/nerin-electric-site-v3-fixed/docs/PLAN_REDISENO_NERIN_ELECTRICIDAD.md
+++ b/nerin-electric-site-v3-fixed/docs/PLAN_REDISENO_NERIN_ELECTRICIDAD.md
@@ -1,0 +1,65 @@
+# Plan de rediseno NERIN Electricidad
+
+## 1. Diagnostico actual
+- Framework: Next.js 14 App Router con TypeScript, Tailwind, Prisma, SQLite, NextAuth, Resend, Mercado Pago, Vitest y Playwright.
+- Root real para Render: `nerin-electric-site-v3-fixed`.
+- Rutas publicas existentes: home, servicios, packs, mantenimiento, obras, empresa, contacto, presupuestador, clientes, blog, terminos, privacidad y FAQ.
+- Admin existente: login, dashboard modular, leads, packs, operativo, proyectos, certificados, clientes, noticias y ajustes.
+- Datos: Prisma ya incluye usuarios, clientes, proyectos, packs, adicionales, planes de mantenimiento, leads, adjuntos, certificados, contenido CMS, posts y modelos operativos.
+- Integraciones: Resend para emails, Mercado Pago para checkout/webhook, NextAuth/admin credentials, almacenamiento local de medios y tracking.
+
+## 2. Problemas UX, comerciales y de conversion
+- La home comunica servicio electrico, pero no tiene suficiente claridad de precio, urgencia ni diferenciacion premium.
+- La navegacion mezcla "casos", "obras", "presupuestador" y rutas tecnicas, lo que reduce decision rapida.
+- El presupuestador parece mas configurador tecnico que captador comercial liviano.
+- El admin esta orientado a modulos existentes, pero no se siente como centro de control comercial/operativo de una empresa de servicios.
+- Hay placeholders beta visibles en defaults de configuracion; deben quedar preparados sin mostrarse como datos oficiales falsos.
+
+## 3. Nueva arquitectura propuesta
+- Publico: landing comercial + catalogo de servicios + packs + mantenimiento + obras/experiencia + empresa + contacto + captador simple.
+- Conversion: WhatsApp persistente, CTA principal visible, precios "desde", formulario corto y copy de urgencia profesional.
+- Admin: sidebar unico con dashboard, pipeline de leads, clientes, presupuestos, obras, certificados, mantenimiento, visitas, ingresos, gastos, servicios/packs, contenido web y configuracion.
+- Datos: extender Prisma con entidades de CRM/ERP de servicios sin romper los modelos actuales.
+
+## 4. Nueva estructura publica
+- Inicio: hero premium, urgencia, servicios, packs, mantenimiento, experiencia, confianza y formulario final.
+- Servicios: catalogo claro por problema, precio desde y CTA.
+- Packs: tres packs de mano de obra con aclaracion de materiales/proyecto por separado.
+- Mantenimiento: BASIC, PRO y ENTERPRISE con fit comercial.
+- Obras: experiencia profesional sin inventar datos especificos.
+- Empresa: posicionamiento, proceso y beta controlada para datos oficiales futuros.
+- Contacto: formulario simple, WhatsApp y criterios de prioridad.
+
+## 5. Nueva estructura admin
+- Dashboard con metricas comerciales, finanzas, operaciones y alertas.
+- Leads con estados de pipeline: Nuevo, Contactado, Esperando fotos, Presupuesto pendiente, Presupuesto enviado, Negociando, Ganado, Perdido.
+- Secciones previstas: Clientes, Presupuestos, Obras, Certificados, Mantenimiento, Visitas tecnicas, Ingresos, Gastos, Servicios y packs, Contenido web y Configuracion.
+- Mantener auth existente y no romper rutas operativas ya implementadas.
+
+## 6. Modelo de datos propuesto
+- Nuevos modelos seguros: `Customer`, `Quote`, `QuoteItem`, `Job`, `ProgressCertificate` existente como base operativa, `MaintenanceContract`, `TechnicalVisit`, `Income`, `Expense`, `Service`, `WebsiteContent`, `CompanySettings`.
+- Usar estados como strings para compatibilidad y evolucion futura.
+- Todos los modelos nuevos deben tener `createdAt` y `updatedAt`.
+- No borrar modelos existentes; extender de forma incremental.
+
+## 7. Riesgos tecnicos
+- El repo no esta disponible localmente con `git`; los cambios deben publicarse con API de GitHub.
+- `next lint` puede fallar si la version de Next no soporta el comando en el entorno instalado.
+- Prisma `db push` aplicara cambios en Render al arrancar; por eso los campos nuevos deben usar defaults o ser opcionales.
+- Datos reales de empresa, CUIT, matriculas, responsables y telefono definitivo no deben inventarse.
+
+## 8. Plan de implementacion
+- Crear capa de contenido comercial compartida.
+- Redisenar header, footer, layout publico y CTA mobile.
+- Rehacer home, servicios, packs, mantenimiento, obras, empresa, contacto y presupuestador.
+- Redisenar admin dashboard y navegacion como centro de control de servicios electricos.
+- Extender Prisma con modelos CRM/ERP seguros.
+- Mantener APIs `/api/leads`, Resend, Mercado Pago, auth y modelos existentes.
+
+## 9. Checklist final de pruebas
+- `npm run build`
+- `npm run test`
+- Revisar carga de home, servicios, packs, mantenimiento, obras, empresa, contacto, presupuestador y admin.
+- Verificar que el formulario crea lead o falla con mensaje claro.
+- Verificar que no se muestran telefono, CUIT, matricula o responsables falsos como datos oficiales.
+- Verificar mobile: header, CTA sticky, cards, formularios y admin sidebar.

--- a/nerin-electric-site-v3-fixed/lib/nerin-electricidad.ts
+++ b/nerin-electric-site-v3-fixed/lib/nerin-electricidad.ts
@@ -1,0 +1,147 @@
+export const whatsappFallbackNumber = '54911'
+
+export const serviceCards = [
+  {
+    title: 'Fallas electricas',
+    description: 'Cortes, termicas que saltan, falsos contactos, sectores sin energia y diagnostico rapido.',
+    price: 'Visita tecnica desde $45.000',
+    href: '/presupuestador?tipo=falla-electrica',
+  },
+  {
+    title: 'Tableros electricos',
+    description: 'Ordenamiento, protecciones, termicas, disyuntores, circuitos y adecuaciones.',
+    price: 'Revision desde $55.000',
+    href: '/presupuestador?tipo=tablero-electrico',
+  },
+  {
+    title: 'Instalaciones para viviendas',
+    description: 'Instalaciones nuevas, reformas, ampliaciones, tomas, iluminacion y circuitos dedicados.',
+    price: 'Mano de obra desde $180.000',
+    href: '/packs',
+  },
+  {
+    title: 'Locales y oficinas',
+    description: 'Puesta en marcha, reformas comerciales, iluminacion, tableros y mantenimiento preventivo.',
+    price: 'Diagnostico comercial desde $65.000',
+    href: '/servicios',
+  },
+  {
+    title: 'Edificios y consorcios',
+    description: 'Tableros, espacios comunes, bombas, iluminacion, urgencias y mantenimiento mensual.',
+    price: 'Relevamiento desde $85.000',
+    href: '/mantenimiento',
+  },
+  {
+    title: 'Mantenimiento electrico',
+    description: 'Planes mensuales para prevenir cortes, ordenar reclamos y bajar riesgos operativos.',
+    price: 'Planes desde $180.000/mes',
+    href: '/mantenimiento',
+  },
+  {
+    title: 'Aires y circuitos dedicados',
+    description: 'Lineas independientes, protecciones correctas y preparacion para equipos de consumo alto.',
+    price: 'Circuito desde $95.000',
+    href: '/presupuestador?tipo=aire-circuito',
+  },
+  {
+    title: 'Puesta a tierra y protecciones',
+    description: 'Revision de seguridad, protecciones diferenciales y mejoras para instalaciones existentes.',
+    price: 'Revision desde $55.000',
+    href: '/presupuestador?tipo=protecciones',
+  },
+] as const
+
+export const packs = [
+  {
+    name: 'Vivienda Estandar',
+    price: 'Desde $1.850.000',
+    description: 'Base de mano de obra para una vivienda tipo con circuitos, bocas y tablero definidos.',
+    bullets: ['Instalacion ordenada por ambientes', 'Tablero y protecciones definidos', 'Avance por etapas'],
+  },
+  {
+    name: 'Casa Country 1',
+    price: 'Desde $3.950.000',
+    description: 'Para casas medianas con mayor cantidad de bocas, exteriores y circuitos especiales.',
+    bullets: ['Circuitos por uso', 'Prevision para exteriores', 'Coordinacion con obra'],
+  },
+  {
+    name: 'Casa Country 2',
+    price: 'Desde $6.800.000',
+    description: 'Para obras grandes con mas ambientes, mayor criticidad y seguimiento tecnico.',
+    bullets: ['Plan por etapas', 'Certificados de avance', 'Control de adicionales'],
+  },
+] as const
+
+export const maintenancePlans = [
+  {
+    name: 'BASIC',
+    price: 'Desde $180.000/mes',
+    fit: 'Locales chicos, oficinas pequenas y departamentos grandes.',
+    bullets: ['Revision mensual', 'Prioridad ante fallas', 'Reporte basico por WhatsApp'],
+  },
+  {
+    name: 'PRO',
+    price: 'Desde $320.000/mes',
+    fit: 'Edificios, oficinas medianas y comercios activos.',
+    bullets: ['Visitas programadas', 'Checklist preventivo', 'Seguimiento de pendientes'],
+  },
+  {
+    name: 'ENTERPRISE',
+    price: 'A medida',
+    fit: 'Cadenas, edificios grandes y clientes con alta criticidad.',
+    bullets: ['SLA acordado', 'Plan por sedes', 'Reportes y certificados'],
+  },
+] as const
+
+export const featuredExperience = [
+  'KFC',
+  'Smart Fit',
+  'Supermercados DIA',
+  'Edificios residenciales',
+] as const
+
+export const trustItems = [
+  'Presupuesto claro',
+  'Mano de obra prolija',
+  'Seguimiento por WhatsApp',
+  'Materiales separados',
+  'Documentacion tecnica',
+  'Certificados de avance',
+  'Experiencia en obra',
+  'Atencion para hogares, comercios y empresas',
+] as const
+
+export const leadWorkTypes = [
+  'Falla electrica',
+  'Tablero electrico',
+  'Instalacion electrica vivienda',
+  'Local / oficina',
+  'Edificio / consorcio',
+  'Aire acondicionado / circuito dedicado',
+  'Mantenimiento mensual',
+  'Otro',
+] as const
+
+export const urgencyOptions = [
+  'Hoy',
+  'Esta semana',
+  'Estoy comparando presupuestos',
+  'Obra proxima a iniciar',
+] as const
+
+export const propertyTypes = [
+  'Vivienda',
+  'Local comercial',
+  'Oficina',
+  'Edificio / consorcio',
+  'Empresa',
+  'Obra en curso',
+] as const
+
+export function moneyLabel(value: number) {
+  return new Intl.NumberFormat('es-AR', {
+    style: 'currency',
+    currency: 'ARS',
+    maximumFractionDigits: 0,
+  }).format(value)
+}

--- a/nerin-electric-site-v3-fixed/lib/site-content.ts
+++ b/nerin-electric-site-v3-fixed/lib/site-content.ts
@@ -77,5 +77,9 @@ export async function saveSiteContent(payload: SiteExperience) {
 }
 
 export function getWhatsappHref(site: SiteExperience): string {
-  return `https://wa.me/${site.contact.whatsappNumber}?text=${encodeURIComponent(site.contact.whatsappMessage)}`
+  const normalized = site.contact.whatsappNumber.replace(/\D/g, '')
+  if (!normalized || /0{6,}$/.test(normalized)) {
+    return '/contacto'
+  }
+  return `https://wa.me/${normalized}?text=${encodeURIComponent(site.contact.whatsappMessage)}`
 }

--- a/nerin-electric-site-v3-fixed/prisma/schema.prisma
+++ b/nerin-electric-site-v3-fixed/prisma/schema.prisma
@@ -530,3 +530,188 @@ model PaymentEvent {
 
   @@unique([provider, externalId])
 }
+
+model Customer {
+  id             String   @id @default(cuid())
+  name           String
+  type           String   @default("particular")
+  whatsapp       String?
+  email          String?
+  address        String?
+  cuit           String?
+  status         String   @default("activo")
+  internalNotes  String   @default("")
+  potentialValue Int      @default(0)
+  leadSource     String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  quotes         Quote[]
+  jobs           Job[]
+  visits         TechnicalVisit[]
+  maintenance    MaintenanceContract[]
+  incomes        Income[]
+  expenses       Expense[]
+}
+
+model Quote {
+  id              String      @id @default(cuid())
+  customerId      String?
+  serviceType     String
+  laborAmount     Int         @default(0)
+  materialsAmount Int         @default(0)
+  additionalAmount Int        @default(0)
+  discountAmount  Int         @default(0)
+  estimatedMargin Int         @default(0)
+  totalAmount     Int         @default(0)
+  status          String      @default("borrador")
+  expiresAt       DateTime?
+  observations    String      @default("")
+  createdAt       DateTime    @default(now())
+  updatedAt       DateTime    @updatedAt
+  customer        Customer?   @relation(fields: [customerId], references: [id], onDelete: SetNull)
+  items           QuoteItem[]
+  jobs            Job[]
+  incomes         Income[]
+}
+
+model QuoteItem {
+  id          String   @id @default(cuid())
+  quoteId     String
+  description String
+  quantity    Float    @default(1)
+  unitPrice   Int      @default(0)
+  subtotal    Int      @default(0)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  quote       Quote    @relation(fields: [quoteId], references: [id], onDelete: Cascade)
+}
+
+model Job {
+  id              String   @id @default(cuid())
+  customerId      String?
+  quoteId         String?
+  title           String
+  address         String?
+  jobType         String   @default("obra electrica")
+  status          String   @default("pendiente")
+  startsAt        DateTime?
+  estimatedEndsAt DateTime?
+  responsible     String?
+  progressPercent Int      @default(0)
+  notes           String   @default("")
+  photos          String   @default("[]")
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  customer        Customer? @relation(fields: [customerId], references: [id], onDelete: SetNull)
+  quote           Quote?   @relation(fields: [quoteId], references: [id], onDelete: SetNull)
+  incomes         Income[]
+  expenses        Expense[]
+}
+
+model MaintenanceContract {
+  id           String   @id @default(cuid())
+  customerId   String?
+  plan         String   @default("BASIC")
+  monthlyAmount Int     @default(0)
+  frequency    String   @default("mensual")
+  nextVisitAt  DateTime?
+  paymentStatus String  @default("pendiente")
+  status       String   @default("activo")
+  visitHistory String   @default("[]")
+  observations String   @default("")
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  customer     Customer? @relation(fields: [customerId], references: [id], onDelete: SetNull)
+}
+
+model TechnicalVisit {
+  id             String   @id @default(cuid())
+  customerId     String?
+  address        String?
+  scheduledAt    DateTime?
+  timeWindow     String?
+  reason         String
+  assignedTo     String?
+  status         String   @default("pendiente")
+  visitCost      Int      @default(0)
+  result         String   @default("")
+  convertedQuoteId String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  customer       Customer? @relation(fields: [customerId], references: [id], onDelete: SetNull)
+}
+
+model Income {
+  id          String   @id @default(cuid())
+  customerId  String?
+  quoteId     String?
+  jobId       String?
+  date        DateTime @default(now())
+  concept     String
+  amount      Int      @default(0)
+  paymentMethod String?
+  status      String   @default("pendiente")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  customer    Customer? @relation(fields: [customerId], references: [id], onDelete: SetNull)
+  quote       Quote?    @relation(fields: [quoteId], references: [id], onDelete: SetNull)
+  job         Job?      @relation(fields: [jobId], references: [id], onDelete: SetNull)
+}
+
+model Expense {
+  id          String   @id @default(cuid())
+  customerId  String?
+  jobId       String?
+  date        DateTime @default(now())
+  category    String   @default("Otros")
+  provider    String?
+  concept     String
+  amount      Int      @default(0)
+  paymentMethod String?
+  receiptUrl  String?
+  status      String   @default("pendiente")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  customer    Customer? @relation(fields: [customerId], references: [id], onDelete: SetNull)
+  job         Job?      @relation(fields: [jobId], references: [id], onDelete: SetNull)
+}
+
+model Service {
+  id          String   @id @default(cuid())
+  title       String
+  description String
+  priceFrom   Int      @default(0)
+  benefits    String   @default("[]")
+  visible     Boolean  @default(true)
+  sortOrder   Int      @default(0)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model WebsiteContent {
+  id          String   @id @default(cuid())
+  key         String   @unique
+  title       String?
+  content     String   @default("{}")
+  visible     Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model CompanySettings {
+  id                    String   @id @default(cuid())
+  tradeName             String   @default("NERIN Electricidad")
+  legalName             String?
+  cuit                  String?
+  address               String?
+  whatsapp              String?
+  email                 String?
+  instagram             String?
+  linkedin              String?
+  technicalLicenses     String   @default("[]")
+  logoUrl               String?
+  fiscalData            String   @default("{}")
+  legalTexts            String   @default("{}")
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+}


### PR DESCRIPTION
## Resumen ejecutivo
Rediseña la experiencia pública y el admin interno de NERIN Electricidad desde una postura de servicios eléctricos premium, clara y orientada a conversión. El root de Render sigue siendo `nerin-electric-site-v3-fixed`.

## Qué se rediseñó
- Home pública con hero comercial, urgencia profesional, servicios, packs, mantenimiento, experiencia, confianza y captador final.
- Navegación pública final: Inicio, Servicios, Packs, Mantenimiento, Obras, Empresa y Contacto.
- Presupuestador simplificado a un flujo de lead en 4 pasos, conectado a `/api/leads`.
- Admin dashboard como centro de control comercial, operativo y financiero.
- Navegación admin orientada a servicios eléctricos, no e-commerce.

## Cambios en web pública
- Copy comercial directo, argentino neutro profesional, con precios “desde”.
- CTAs a WhatsApp y presupuesto sin exponer teléfonos falsos si WhatsApp real no está configurado.
- Páginas rediseñadas: `/`, `/servicios`, `/packs`, `/mantenimiento`, `/obras`, `/empresa`, `/contacto`, `/presupuestador`.
- Experiencia/obras muestra referencias genéricas sin inventar metros, fechas, responsables ni certificaciones.

## Cambios en admin
- Dashboard con métricas de leads, presupuestos, obras, mantenimiento, ingresos, gastos, clientes, certificados y alertas.
- Pipeline comercial con estados recomendados.
- Menú admin reordenado: Dashboard, Leads, Clientes, Presupuestos, Obras, Certificados, Mantenimiento, Visitas técnicas, Ingresos, Gastos, Servicios y packs, Contenido web, Configuración.

## Nuevos modelos / APIs
- Se extendió Prisma con modelos seguros para CRM/ERP: `Customer`, `Quote`, `QuoteItem`, `Job`, `MaintenanceContract`, `TechnicalVisit`, `Income`, `Expense`, `Service`, `WebsiteContent`, `CompanySettings`.
- `/api/leads` ahora acepta email opcional y no inventa emails falsos.
- Se mantiene Resend, Mercado Pago, Prisma, SQLite y auth existentes.

## Capturas / rutas visuales
- Público: `/`, `/servicios`, `/packs`, `/mantenimiento`, `/obras`, `/empresa`, `/contacto`, `/presupuestador`.
- Admin: `/admin`, `/admin/leads`, `/admin/packs`, `/admin/ops`, `/admin/ajustes`.

## Checklist de pruebas
- `npm run test`: 22 tests passed.
- Build validada en Windows con equivalente PowerShell: `$env:DB_ENABLED='false'; npx prisma generate; npx next build`.
- La build compila y genera rutas correctamente.
- Warnings existentes: uso de `<img>` en componentes previos, variables auth faltantes en entorno local, Browserslist desactualizado.
- `npm run build` directo falla en Windows por sintaxis Unix `DB_ENABLED=false`; en Render/Linux debería funcionar igual que antes.

## Riesgos o pendientes
- Cargar WhatsApp real, datos legales, CUIT, responsables técnicos y matrículas desde configuración antes de mostrarlos públicamente.
- Implementar CRUD completo para los nuevos modelos CRM/ERP en una siguiente iteración.
- Revisar variables `AUTH_SECRET`/`NEXTAUTH_URL` en Render si todavía no están configuradas.

## Próximos pasos recomendados
- Cargar datos reales de contacto y empresa.
- Conectar métricas financieras reales del dashboard a `Income` y `Expense`.
- Crear pantallas CRUD específicas para presupuestos, visitas técnicas, mantenimiento, ingresos y gastos.