### PR TITLE
[codex] Mejorar landing publica de NERIN

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(site)/clientes/login/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/clientes/login/page.tsx
@@ -3,7 +3,6 @@
 export const dynamic = 'force-dynamic'
 
 import { useEffect, useMemo } from 'react'
-import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 
@@ -39,7 +38,7 @@ export default function LoginPage() {
     }
 
     if (isAdmin) {
-      return 'Redirigiendo al panel administrativo...'
+      return 'Redirigiendo...'
     }
 
     if (isClient) {
@@ -53,39 +52,25 @@ export default function LoginPage() {
     <div className="mx-auto flex max-w-5xl flex-col gap-8 px-0 py-4 sm:py-8 md:flex-row md:items-start md:gap-10">
       <div className="max-w-md space-y-6">
         <Badge>Portal de clientes</Badge>
-        <h1 className="text-3xl font-semibold tracking-tight">Ingresá con tu email</h1>
+        <h1 className="text-3xl font-semibold tracking-tight">IngresÃ¡ con tu email</h1>
         <p className="text-sm text-slate-600">
-          Te enviamos un enlace mágico para que accedas a tus proyectos, certificaciones y documentación. Es rápido y seguro,
-          sin contraseñas.
+          Te enviamos un enlace mÃ¡gico para que accedas a tus proyectos, certificaciones y documentaciÃ³n. Es rÃ¡pido y seguro,
+          sin contraseÃ±as.
         </p>
         <ul className="space-y-3 text-sm text-slate-600">
           <li className="flex gap-2">
             <span className="mt-1 h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
-            Revisá los hitos de tu obra y certificaciones de avance.
+            RevisÃ¡ los hitos de tu obra y certificaciones de avance.
           </li>
           <li className="flex gap-2">
             <span className="mt-1 h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
-            Descargá presupuestos, documentación técnica y comprobantes.
+            DescargÃ¡ presupuestos, documentaciÃ³n tÃ©cnica y comprobantes.
           </li>
           <li className="flex gap-2">
             <span className="mt-1 h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
-            Coordiná visitas y soporte con el equipo NERIN.
+            CoordinÃ¡ visitas y soporte con el equipo NERIN.
           </li>
         </ul>
-        <p className="text-xs text-slate-500">
-          ¿No tenés acceso? Escribinos a{' '}
-          <a className="font-medium underline" href="mailto:hola@nerin.com.ar">
-            hola@nerin.com.ar
-          </a>
-          .
-        </p>
-        <p className="text-xs text-slate-500">
-          ¿Sos parte del equipo NERIN?{' '}
-          <Link className="font-medium underline" href="/admin/login">
-            Ingresá al panel administrativo
-          </Link>
-          .
-        </p>
       </div>
       <div className="flex w-full max-w-md shrink-0 justify-center md:justify-end">
         {redirectMessage ? (

--- a/nerin-electric-site-v3-fixed/app/(site)/obras/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/obras/page.tsx
@@ -15,7 +15,7 @@ export default function ObrasPage() {
           <p className="text-xs font-bold uppercase tracking-[0.24em] text-amber-300">Obras y experiencia</p>
           <h1 className="mt-3 text-4xl font-semibold text-white sm:text-5xl">Instalaciones electricas para obra, comercio y edificios.</h1>
           <p className="mt-4 text-lg leading-8 text-slate-300">
-            Se muestran referencias profesionales sin inventar metros, montos, fechas ni responsables. Los detalles reales se cargan desde admin cuando esten disponibles.
+            Experiencia en espacios comerciales, gimnasios, supermercados y edificios residenciales, con alcance definido por relevamiento.
           </p>
         </div>
       </section>

--- a/nerin-electric-site-v3-fixed/app/(site)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/page.tsx
@@ -4,16 +4,44 @@ import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import {
   featuredExperience,
   majorWorks,
-  manualReviewMessage,
   renovationCards,
   serviceCatalog,
   specialServices,
-  trustItems,
 } from '@/lib/nerin-electricidad'
 import { LeadWizard } from '@/components/LeadWizard'
 import { Button } from '@/components/ui/button'
 
 export const revalidate = 60
+
+const clientPaths = [
+  {
+    title: 'Trabajo chico',
+    description: 'Fallas, tomas, luces, tableros y pedidos simples con precio orientativo.',
+    href: '/trabajos-electricos',
+    cta: 'Ver trabajos chicos',
+  },
+  {
+    title: 'Refaccion electrica',
+    description: 'Renovacion electrica de departamentos, locales y espacios existentes.',
+    href: '/refacciones-electricas',
+    cta: 'Pedir relevamiento',
+  },
+  {
+    title: 'Obra electrica',
+    description: 'Instalaciones para locales, edificios y proyectos con seguimiento por etapas.',
+    href: '/obras-electricas',
+    cta: 'Consultar por obra',
+  },
+] as const
+
+const clientBenefits = [
+  'Presupuesto claro',
+  'Materiales separados cuando aplica',
+  'Trabajo prolijo',
+  'Seguimiento real',
+  'Criterio de seguridad',
+  'Documentacion cuando corresponde',
+] as const
 
 export async function generateMetadata() {
   const siteUrl = process.env.SITE_URL || 'https://nerin-1.onrender.com'
@@ -42,62 +70,54 @@ export default async function HomePage() {
   return (
     <div className="bg-white">
       <section className="border-b border-slate-200 bg-[linear-gradient(180deg,#fff_0%,#f8fafc_100%)]">
-        <div className="container grid min-h-[calc(100vh-7rem)] gap-10 py-10 lg:grid-cols-[1.05fr_0.95fr] lg:items-center lg:py-16">
-          <div className="space-y-7">
+        <div className="container flex min-h-[calc(100svh-7rem)] items-center py-10 lg:py-16">
+          <div className="max-w-4xl space-y-7">
             <div className="inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-bold uppercase tracking-[0.18em] text-slate-900">
               <Zap className="h-4 w-4 text-amber-500" />
               Trabajos chicos, refacciones y obras electricas
             </div>
             <div className="space-y-5">
               <h1 className="max-w-4xl text-4xl font-semibold leading-[1.03] tracking-tight text-slate-950 sm:text-6xl">
-                Instalaciones y trabajos electricos profesionales en CABA y GBA
+                Instalaciones electricas profesionales en CABA y GBA
               </h1>
               <p className="max-w-2xl text-lg leading-8 text-slate-600">
-                Trabajos chicos, refacciones electricas y obras completas con presupuesto claro, ejecucion prolija y
-                seguimiento real.
+                Trabajos chicos, refacciones y obras con presupuesto claro, ejecucion prolija y seguimiento real.
               </p>
             </div>
             <div className="grid gap-3 sm:flex">
-              <Button asChild size="lg" className="h-12 bg-slate-950 px-6 text-base font-bold text-white hover:bg-slate-800">
-                <Link href="/trabajos-electricos">
-                  <Search className="mr-2 h-5 w-5" />
-                  Buscar un trabajo electrico
-                </Link>
-              </Button>
               <Button asChild size="lg" className="h-12 bg-[#25D366] px-6 text-base font-bold text-black hover:bg-[#1ebe5a]">
                 <a href={whatsappHref} target={isWhatsappExternal ? '_blank' : undefined} rel={isWhatsappExternal ? 'noopener noreferrer' : undefined}>
                   <MessageCircle className="mr-2 h-5 w-5" />
-                  Pedir presupuesto
+                  Pedir presupuesto por WhatsApp
                 </a>
               </Button>
               <Button asChild size="lg" variant="outline" className="h-12 px-6 text-base">
-                <Link href="/obras-electricas">Ver obras</Link>
-              </Button>
-            </div>
-          </div>
-
-          <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
-            <div className="rounded-2xl bg-slate-950 p-6 text-white">
-              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-amber-300">Buscador comercial</p>
-              <h2 className="mt-4 text-3xl font-semibold text-white">Precios orientativos cuando el trabajo se puede estandarizar.</h2>
-              <p className="mt-4 text-sm leading-6 text-slate-300">{manualReviewMessage}</p>
-            </div>
-            <div className="mt-4 grid gap-3">
-              {serviceCatalog.slice(0, 4).map((item) => (
-                <Link key={item.slug} href={`/trabajos-electricos/${item.slug}`} className="flex items-center justify-between rounded-2xl border border-slate-200 px-4 py-3 hover:border-slate-950">
-                  <span>
-                    <span className="block font-semibold text-slate-900">{item.name}</span>
-                    <span className="block text-sm text-slate-500">{item.priceFrom ?? 'A presupuestar'}</span>
-                  </span>
-                  <ArrowRight className="h-5 w-5 text-slate-500" />
+                <Link href="/trabajos-electricos">
+                  <Search className="mr-2 h-5 w-5" />
+                  Ver precios de trabajos chicos
                 </Link>
-              ))}
+              </Button>
             </div>
           </div>
         </div>
       </section>
 
       <section className="container py-14">
+        <div className="grid gap-4 lg:grid-cols-3">
+          {clientPaths.map((item) => (
+            <article key={item.title} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+              <h2 className="text-2xl font-semibold text-slate-950">{item.title}</h2>
+              <p className="mt-3 text-sm leading-6 text-slate-600">{item.description}</p>
+              <Link href={item.href} className="mt-6 inline-flex items-center rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white">
+                {item.cta}
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="container pb-14">
         <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div className="max-w-2xl">
             <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Trabajos chicos</p>
@@ -183,10 +203,10 @@ export default async function HomePage() {
         <div className="grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
           <div>
             <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Por que elegir NERIN</p>
-            <h2 className="mt-2 text-3xl font-semibold text-slate-950">Vender mejor, presupuestar mejor y controlar costos.</h2>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-950">Trabajo claro, prolijo y seguro de principio a fin.</h2>
           </div>
           <div className="grid gap-3 sm:grid-cols-2">
-            {trustItems.map((item) => (
+            {clientBenefits.map((item) => (
               <div key={item} className="flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-800 shadow-sm">
                 <CheckCircle2 className="h-4 w-4 text-emerald-600" />
                 {item}
@@ -206,7 +226,7 @@ export default async function HomePage() {
             {featuredExperience.map((item) => (
               <article key={item} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
                 <h3 className="text-xl font-semibold text-slate-950">{item}</h3>
-                <p className="mt-2 text-sm text-slate-600">Referencia de experiencia profesional. Detalles reales editables cuando esten cargados.</p>
+                <p className="mt-2 text-sm text-slate-600">Experiencia profesional en instalaciones electricas para espacios de uso intensivo.</p>
               </article>
             ))}
           </div>

--- a/nerin-electric-site-v3-fixed/app/(site)/trabajos-electricos/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/trabajos-electricos/page.tsx
@@ -19,7 +19,7 @@ export default function TrabajosElectricosPage() {
           </p>
           <div className="mt-6 flex items-center gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-slate-500">
             <Search className="h-5 w-5" />
-            <span className="text-sm">Busca por categoria, nombre o problema. El buscador dinamico queda preparado para el admin.</span>
+            <span className="text-sm">Busca por categoria, nombre o problema y elegi el trabajo que mas se parezca a tu pedido.</span>
           </div>
         </div>
       </section>

--- a/nerin-electric-site-v3-fixed/components/Footer.tsx
+++ b/nerin-electric-site-v3-fixed/components/Footer.tsx
@@ -5,9 +5,9 @@ import { getWhatsappHref } from '@/lib/site-content'
 const quickLinks = [
   { href: '/trabajos-electricos', label: 'Trabajos chicos' },
   { href: '/refacciones-electricas', label: 'Refacciones' },
-  { href: '/obras-electricas', label: 'Obras electricas' },
-  { href: '/servicios-especiales', label: 'Servicios especiales' },
+  { href: '/obras-electricas', label: 'Obras' },
   { href: '/obras', label: 'Obras realizadas' },
+  { href: '/empresa', label: 'Empresa' },
   { href: '/contacto', label: 'Contacto' },
 ] as const
 
@@ -48,12 +48,9 @@ export function Footer({ site }: FooterProps) {
         <div className="space-y-3">
           <p className="text-xs font-semibold uppercase tracking-[0.34em] text-slate-500">NERIN Electricidad</p>
           <p className="max-w-sm text-sm font-medium text-slate-900">
-            Plataforma comercial y operativa para trabajos chicos, refacciones, obras y servicios electricos especiales.
+            Instalaciones electricas profesionales para trabajos chicos, refacciones y obras en CABA y GBA.
           </p>
-          <p className="text-sm text-slate-600">{site.contact.serviceArea}</p>
-          <p className="text-xs text-slate-500">
-            Datos legales, responsables tecnicos y matriculas se muestran cuando esten cargados en configuracion.
-          </p>
+          {site.contact.serviceArea ? <p className="text-sm text-slate-600">{site.contact.serviceArea}</p> : null}
         </div>
 
         <div>
@@ -92,7 +89,7 @@ export function Footer({ site }: FooterProps) {
         </div>
 
         <div>
-          <h4 className="text-xs font-semibold uppercase tracking-[0.34em] text-slate-500">Sistema</h4>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.34em] text-slate-500">Informacion</h4>
           <ul className="mt-3 space-y-2 text-sm text-slate-700">
             {legalLinks.map((item) => (
               <li key={item.href}>
@@ -100,7 +97,7 @@ export function Footer({ site }: FooterProps) {
               </li>
             ))}
             <li>
-              <Link href="/admin">Panel admin</Link>
+              <Link href="/clientes">Portal cliente</Link>
             </li>
           </ul>
         </div>
@@ -108,7 +105,7 @@ export function Footer({ site }: FooterProps) {
 
       <div className="border-t border-slate-200 bg-slate-50 py-5">
         <div className="container text-sm text-slate-500">
-          <span>© {new Date().getFullYear()} NERIN Electricidad.</span>
+          <span>Â© {new Date().getFullYear()} NERIN Electricidad.</span>
         </div>
       </div>
     </footer>

--- a/nerin-electric-site-v3-fixed/components/Header.tsx
+++ b/nerin-electric-site-v3-fixed/components/Header.tsx
@@ -22,9 +22,8 @@ const navigation = [
   { href: '/', label: 'Inicio' },
   { href: '/trabajos-electricos', label: 'Trabajos chicos' },
   { href: '/refacciones-electricas', label: 'Refacciones' },
-  { href: '/obras-electricas', label: 'Obras electricas' },
-  { href: '/servicios-especiales', label: 'Servicios especiales' },
-  { href: '/obras', label: 'Obras realizadas' },
+  { href: '/obras-electricas', label: 'Obras' },
+  { href: '/obras', label: 'Casos reales' },
   { href: '/empresa', label: 'Empresa' },
   { href: '/contacto', label: 'Contacto' },
 ] as const
@@ -80,11 +79,6 @@ export function Header({ contact, logo }: HeaderProps) {
                 WhatsApp
               </a>
             </Button>
-            <Button size="sm" asChild className="hidden bg-slate-950 hover:bg-slate-800 lg:inline-flex">
-              <Link href="/presupuestador" data-track="lead" data-content-name="Presupuesto header">
-                Pedir presupuesto
-              </Link>
-            </Button>
 
             <button
               type="button"
@@ -114,10 +108,7 @@ export function Header({ contact, logo }: HeaderProps) {
                 ))}
               </nav>
 
-              <div className="grid gap-2 sm:grid-cols-2">
-                <Button asChild className="bg-slate-950 hover:bg-slate-800" onClick={() => setMenuOpen(false)}>
-                  <Link href="/presupuestador">Pedir presupuesto</Link>
-                </Button>
+              <div className="grid gap-2">
                 <Button asChild className="bg-[#25D366] text-black hover:bg-[#1ebe5a]">
                   <a
                     href={contact.whatsappHref}


### PR DESCRIPTION
## Resumen

- Simplifica el hero de la home con H1, bajada y solo dos CTAs principales.
- Agrega un selector claro para Trabajo chico, Refaccion electrica y Obra electrica.
- Reorienta beneficios hacia el cliente y limpia copy publico con referencias internas/admin.
- Ajusta header y footer para reducir botones y quitar enlaces visibles al panel admin.

## Validacion

- `npm run lint` paso con warnings existentes de uso de `<img>`.
- `npm run test -- --run` paso: 7 archivos, 22 tests.
- Revision mobile local en 390px y 360px: hero con dos CTAs, selector presente y WhatsApp flotante sin tapar botones.