### PR TITLE
[codex] Fix build error en urgencias de LeadWizard

### DIFF
--- a/nerin-electric-site-v3-fixed/components/LeadWizard.tsx
+++ b/nerin-electric-site-v3-fixed/components/LeadWizard.tsx
@@ -68,7 +68,7 @@ function getFlowType(requestType: string) {
   return 'small'
 }
 
-function getUrgencyList(requestType: string) {
+function getUrgencyList(requestType: string): string[] {
   if (requestType === 'Refaccion electrica') return [...renovationUrgencies]
   if (requestType === 'Obra grande') return [...urgencyOptions]
   return [...smallJobUrgencies]


### PR DESCRIPTION
## Resumen

- Corrige el error de build de Render en `components/LeadWizard.tsx`.
- `getUrgencyList` ahora declara `string[]` como retorno para evitar que TypeScript infiera una union demasiado estrecha en `includes`.

## Error de Render

`Argument of type 'string' is not assignable to parameter of type '"Esta semana"'` en la linea donde se valida si la urgencia actual existe en la lista nueva.

## Validacion

- Revise el diff contra `main`: cambia una sola linea en `LeadWizard.tsx`.
- No pude correr build local porque este entorno sigue sin checkout completo ni herramientas locales de Git/Node para el proyecto.