### PR TITLE
[codex] Rework NERIN real cases section

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(site)/obras/[slug]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/obras/[slug]/page.tsx
@@ -1,7 +1,7 @@
-export const dynamic = 'force-dynamic'
-
+import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { getCaseStudyBySlug } from '@/lib/marketing-data'
+import { ArrowLeft, FileText, ImageIcon, LockKeyhole, MapPin } from 'lucide-react'
+import { getRealCaseBySlug, realCases } from '@/lib/real-cases'
 import { Badge } from '@/components/ui/badge'
 
 export const revalidate = 60
@@ -10,32 +10,157 @@ interface Props {
   params: { slug: string }
 }
 
-export default async function ObraDetallePage({ params }: Props) {
-  const caseStudy = await getCaseStudyBySlug(params.slug)
-  if (!caseStudy) {
+export function generateStaticParams() {
+  return realCases.map((caseItem) => ({ slug: caseItem.slug }))
+}
+
+export function generateMetadata({ params }: Props) {
+  const caseItem = getRealCaseBySlug(params.slug)
+  if (!caseItem) {
+    return {
+      title: 'Caso real | NERIN',
+    }
+  }
+
+  return {
+    title: `${caseItem.title} | Caso real NERIN`,
+    description: `${caseItem.clientType}. ${caseItem.scope}`,
+  }
+}
+
+export default function ObraDetallePage({ params }: Props) {
+  const caseItem = getRealCaseBySlug(params.slug)
+  if (!caseItem) {
     notFound()
   }
 
   return (
-    <article className="space-y-6">
-      <Badge>Obra</Badge>
-      <h1>{caseStudy.titulo}</h1>
-      <p className="text-lg text-slate-600">{caseStudy.resumen}</p>
-      <div className="space-y-4 text-base leading-relaxed text-slate-600">
-        {caseStudy.contenido.split('\n').map((paragraph, index) => (
-          <p key={index}>{paragraph}</p>
-        ))}
-      </div>
-      {caseStudy.metricas.length > 0 && (
-        <section className="grid gap-4 md:grid-cols-3">
-          {caseStudy.metricas.map((metric) => (
-            <div key={metric.label} className="rounded-2xl border border-border bg-white p-4 shadow-subtle">
-              <p className="text-sm text-slate-500">{metric.label}</p>
-              <p className="text-lg font-semibold text-foreground">{metric.value}</p>
+    <article className="bg-white">
+      <section className="border-b border-slate-200 bg-slate-950 py-12 text-white">
+        <div className="container max-w-5xl">
+          <Link href="/obras" className="inline-flex items-center text-sm font-semibold text-slate-300 hover:text-white">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Volver a obras
+          </Link>
+          <div className="mt-6 flex flex-wrap gap-2">
+            <Badge>Obra</Badge>
+            <Badge variant="secondary">{caseItem.clientType}</Badge>
+          </div>
+          <h1 className="mt-4 text-4xl font-semibold text-white sm:text-5xl">{caseItem.title}</h1>
+          <p className="mt-4 max-w-3xl text-lg leading-8 text-slate-300">{caseItem.scope}</p>
+        </div>
+      </section>
+
+      <section className="container grid gap-8 py-12 lg:grid-cols-[0.72fr_1.28fr]">
+        <aside className="space-y-4">
+          <div className="rounded-lg border border-slate-200 bg-slate-50 p-5">
+            <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-500">Ficha minima</p>
+            <dl className="mt-4 space-y-4 text-sm">
+              <div>
+                <dt className="font-semibold text-slate-950">Tipo de cliente</dt>
+                <dd className="mt-1 text-slate-600">{caseItem.clientType}</dd>
+              </div>
+              <div>
+                <dt className="font-semibold text-slate-950">Tipo de trabajo</dt>
+                <dd className="mt-1 text-slate-600">{caseItem.workType}</dd>
+              </div>
+              <div>
+                <dt className="font-semibold text-slate-950">Estado</dt>
+                <dd className="mt-1 text-slate-600">{caseItem.status}</dd>
+              </div>
+              <div>
+                <dt className="font-semibold text-slate-950">Periodo</dt>
+                <dd className="mt-1 text-slate-600">{caseItem.period ?? 'No publicado'}</dd>
+              </div>
+              {caseItem.approximateLocation ? (
+                <div>
+                  <dt className="font-semibold text-slate-950">Ubicacion aproximada</dt>
+                  <dd className="mt-1 inline-flex items-center gap-2 text-slate-600">
+                    <MapPin className="h-4 w-4 text-slate-500" />
+                    {caseItem.approximateLocation}
+                  </dd>
+                </div>
+              ) : null}
+            </dl>
+          </div>
+
+          {caseItem.confidentialityNote ? (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-5 text-amber-950">
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <LockKeyhole className="h-4 w-4" />
+                Nota de confidencialidad
+              </div>
+              <p className="mt-3 text-sm leading-6">{caseItem.confidentialityNote}</p>
             </div>
-          ))}
-        </section>
-      )}
+          ) : null}
+        </aside>
+
+        <div className="space-y-8">
+          <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+            <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-500">Resultado</p>
+            <p className="mt-3 text-base leading-7 text-slate-700">{caseItem.result}</p>
+          </section>
+
+          <div className="grid gap-5 md:grid-cols-2">
+            <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+              <h2 className="text-xl font-semibold text-slate-950">Problema / reto</h2>
+              <p className="mt-3 text-sm leading-6 text-slate-600">{caseItem.challenge ?? 'Informacion en revision para completar la ficha tecnica.'}</p>
+            </section>
+            <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+              <h2 className="text-xl font-semibold text-slate-950">Solucion</h2>
+              <p className="mt-3 text-sm leading-6 text-slate-600">{caseItem.solution ?? 'Informacion en revision para completar la ficha tecnica.'}</p>
+            </section>
+          </div>
+
+          <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-xl font-semibold text-slate-950">Alcance tecnico</h2>
+            <ul className="mt-4 grid gap-3 text-sm leading-6 text-slate-600 sm:grid-cols-2">
+              {caseItem.technicalScope.map((item) => (
+                <li key={item} className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-xl font-semibold text-slate-950">Galeria</h2>
+            {caseItem.gallery.length > 0 ? (
+              <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                {caseItem.gallery.map((image) => (
+                  <img key={image} src={image} alt={caseItem.title} className="aspect-video rounded-lg border border-slate-200 object-cover" />
+                ))}
+              </div>
+            ) : (
+              <div className="mt-4 flex min-h-32 items-center justify-center rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-center">
+                <div>
+                  <ImageIcon className="mx-auto h-6 w-6 text-slate-500" />
+                  <p className="mt-2 text-sm font-semibold text-slate-950">Caso en actualizacion</p>
+                  <p className="mt-1 text-sm text-slate-600">Se agregaran imagenes solo si existen y estan autorizadas.</p>
+                </div>
+              </div>
+            )}
+          </section>
+
+          <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-xl font-semibold text-slate-950">Documentacion relacionada</h2>
+            {caseItem.relatedDocumentation.length > 0 ? (
+              <ul className="mt-4 space-y-2 text-sm text-slate-600">
+                {caseItem.relatedDocumentation.map((item) => (
+                  <li key={item} className="flex items-center gap-2">
+                    <FileText className="h-4 w-4 text-slate-500" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm leading-6 text-slate-600">
+                Documentacion no publicada. Puede incorporarse a futuro si corresponde y cuenta con autorizacion.
+              </p>
+            )}
+          </section>
+        </div>
+      </section>
     </article>
   )
 }

--- a/nerin-electric-site-v3-fixed/app/(site)/obras/[slug]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/obras/[slug]/page.tsx
@@ -44,7 +44,7 @@ export default function ObraDetallePage({ params }: Props) {
           </Link>
           <div className="mt-6 flex flex-wrap gap-2">
             <Badge>Obra</Badge>
-            <Badge variant="secondary">{caseItem.clientType}</Badge>
+            <Badge className="border-white/10 bg-white/10 text-slate-200">{caseItem.clientType}</Badge>
           </div>
           <h1 className="mt-4 text-4xl font-semibold text-white sm:text-5xl">{caseItem.title}</h1>
           <p className="mt-4 max-w-3xl text-lg leading-8 text-slate-300">{caseItem.scope}</p>

--- a/nerin-electric-site-v3-fixed/app/(site)/obras/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/obras/page.tsx
@@ -1,10 +1,11 @@
 import Link from 'next/link'
-import { ArrowRight } from 'lucide-react'
-import { featuredExperience } from '@/lib/nerin-electricidad'
+import { ArrowRight, CheckCircle2, ClipboardCheck, FileText, LockKeyhole, MapPin } from 'lucide-react'
+import { realCases, workMethodSteps } from '@/lib/real-cases'
 
 export const metadata = {
-  title: 'Obras electricas y experiencia | NERIN',
-  description: 'Experiencia en locales comerciales, gimnasios, supermercados y edificios residenciales sin inventar datos especificos.',
+  title: 'Casos reales y obras electricas | NERIN',
+  description:
+    'Casos tecnicos minimos de NERIN Electricidad para locales, gimnasios, retail y edificios, con informacion prudente y sin uso de marcas no autorizadas.',
 }
 
 export default function ObrasPage() {
@@ -12,23 +13,136 @@ export default function ObrasPage() {
     <div className="bg-white">
       <section className="border-b border-slate-200 bg-slate-950 py-14 text-white">
         <div className="container max-w-4xl">
-          <p className="text-xs font-bold uppercase tracking-[0.24em] text-amber-300">Obras y experiencia</p>
-          <h1 className="mt-3 text-4xl font-semibold text-white sm:text-5xl">Instalaciones electricas para obra, comercio y edificios.</h1>
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-amber-300">Casos reales</p>
+          <h1 className="mt-3 text-4xl font-semibold text-white sm:text-5xl">
+            Obras electricas presentadas con criterio tecnico y prudencia comercial.
+          </h1>
           <p className="mt-4 text-lg leading-8 text-slate-300">
-            Experiencia en espacios comerciales, gimnasios, supermercados y edificios residenciales, con alcance definido por relevamiento.
+            Referencias de trabajos realizados o participaciones tecnicas, sin inventar permisos de marca, logos, testimonios ni imagenes que no esten confirmadas.
           </p>
         </div>
       </section>
-      <section className="container grid gap-5 py-14 md:grid-cols-2">
-        {featuredExperience.map((name) => (
-          <article key={name} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-            <h2 className="text-2xl font-semibold text-slate-950">{name}</h2>
-            <p className="mt-3 text-sm leading-6 text-slate-600">
-              Experiencia en instalaciones electricas para locales comerciales, gimnasios, supermercados y edificios residenciales.
-            </p>
-          </article>
-        ))}
+
+      <section className="container py-14">
+        <div className="mb-8 max-w-3xl">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Obras realizadas / casos reales</p>
+          <h2 className="mt-2 text-3xl font-semibold text-slate-950">Evidencia tecnica minima, sin name-dropping vacio.</h2>
+          <p className="mt-3 text-sm leading-6 text-slate-600">
+            Cuando no hay permiso explicito para usar una marca, el caso se comunica por rubro, alcance y resultado. Cada ficha puede ampliarse luego con fotos, documentacion y detalles autorizados.
+          </p>
+        </div>
+
+        <div className="grid gap-5 lg:grid-cols-2">
+          {realCases.map((caseItem) => (
+            <article key={caseItem.slug} className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+              <div className="flex min-h-36 items-center justify-center border-b border-slate-200 bg-[linear-gradient(135deg,#f8fafc_0%,#eef2f7_48%,#fff7ed_100%)] p-6 text-center">
+                <div>
+                  <FileText className="mx-auto h-7 w-7 text-slate-500" />
+                  <p className="mt-3 text-xs font-bold uppercase tracking-[0.18em] text-slate-500">Caso en actualizacion</p>
+                  <p className="mt-1 text-sm text-slate-600">Imagenes disponibles solo cuando exista autorizacion.</p>
+                </div>
+              </div>
+              <div className="p-6">
+                <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                  <span>{caseItem.clientType}</span>
+                  <span className="h-1 w-1 rounded-full bg-slate-300" />
+                  <span>{caseItem.workType}</span>
+                </div>
+                <h3 className="mt-3 text-2xl font-semibold text-slate-950">{caseItem.title}</h3>
+                <dl className="mt-5 grid gap-4 text-sm sm:grid-cols-2">
+                  <div>
+                    <dt className="font-semibold text-slate-950">Alcance</dt>
+                    <dd className="mt-1 leading-6 text-slate-600">{caseItem.scope}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-semibold text-slate-950">Resultado</dt>
+                    <dd className="mt-1 leading-6 text-slate-600">{caseItem.result}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-semibold text-slate-950">Estado</dt>
+                    <dd className="mt-1 leading-6 text-slate-600">{caseItem.status}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-semibold text-slate-950">Periodo</dt>
+                    <dd className="mt-1 leading-6 text-slate-600">{caseItem.period ?? 'No publicado'}</dd>
+                  </div>
+                </dl>
+                <div className="mt-5 flex flex-wrap gap-3 text-sm text-slate-600">
+                  {caseItem.approximateLocation ? (
+                    <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5">
+                      <MapPin className="h-4 w-4 text-slate-500" />
+                      {caseItem.approximateLocation}
+                    </span>
+                  ) : null}
+                  {caseItem.confidentialityNote ? (
+                    <span className="inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-3 py-1.5 text-amber-900">
+                      <LockKeyhole className="h-4 w-4" />
+                      Datos reservados
+                    </span>
+                  ) : null}
+                </div>
+                {caseItem.confidentialityNote ? (
+                  <p className="mt-4 rounded-lg border border-slate-200 bg-slate-50 p-3 text-xs leading-5 text-slate-600">
+                    {caseItem.confidentialityNote}
+                  </p>
+                ) : null}
+                <Link href={`/obras/${caseItem.slug}`} className="mt-6 inline-flex items-center text-sm font-semibold text-slate-950">
+                  Ver ficha tecnica
+                  <ArrowRight className="ml-1 h-4 w-4" />
+                </Link>
+              </div>
+            </article>
+          ))}
+        </div>
       </section>
+
+      <section className="border-y border-slate-200 bg-slate-50 py-14">
+        <div className="container grid gap-8 lg:grid-cols-[0.75fr_1.25fr]">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Como trabaja NERIN</p>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-950">Proceso claro para obra, refaccion y mantenimiento.</h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              El objetivo es reducir improvisacion: entender el problema, ordenar alcance, ejecutar por etapas y dejar registro cuando corresponde.
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {workMethodSteps.map((step, index) => (
+              <div key={step} className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+                <p className="text-xs font-bold uppercase tracking-[0.16em] text-amber-600">Paso {index + 1}</p>
+                <div className="mt-2 flex items-center gap-2">
+                  <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                  <p className="text-sm font-semibold text-slate-950">{step}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="container py-14">
+        <div className="rounded-lg border border-slate-200 bg-slate-950 p-6 text-white shadow-sm md:p-8">
+          <div className="grid gap-6 md:grid-cols-[0.7fr_1.3fr] md:items-center">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.24em] text-amber-300">Portal cliente</p>
+              <h2 className="mt-2 text-3xl font-semibold text-white">Seguimiento privado para obras y refacciones.</h2>
+            </div>
+            <div>
+              <p className="text-base leading-7 text-slate-300">
+                En obras y refacciones, NERIN puede entregar un portal privado para consultar avances, certificados, documentacion y estado del proyecto.
+              </p>
+              <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                {['Avances por etapa', 'Certificados y archivos', 'Estado del proyecto', 'Historial de documentacion'].map((item) => (
+                  <div key={item} className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-3 text-sm font-semibold text-white">
+                    <ClipboardCheck className="h-4 w-4 text-amber-300" />
+                    {item}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section className="border-t border-slate-200 bg-slate-50 py-12">
         <div className="container flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>

--- a/nerin-electric-site-v3-fixed/app/(site)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/page.tsx
@@ -2,13 +2,13 @@ import Link from 'next/link'
 import { ArrowRight, CheckCircle2, MessageCircle, Search, ShieldAlert, Zap } from 'lucide-react'
 import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import {
-  featuredExperience,
   majorWorks,
   renovationCards,
   serviceCatalog,
   specialServices,
 } from '@/lib/nerin-electricidad'
 import { LeadWizard } from '@/components/LeadWizard'
+import { realCases } from '@/lib/real-cases'
 import { Button } from '@/components/ui/button'
 
 export const revalidate = 60
@@ -66,6 +66,7 @@ export default async function HomePage() {
   const site = await getSiteContent()
   const whatsappHref = getWhatsappHref(site)
   const isWhatsappExternal = whatsappHref.startsWith('http')
+  const featuredCases = realCases.slice(0, 4)
 
   return (
     <div className="bg-white">
@@ -230,13 +231,22 @@ export default async function HomePage() {
         <div className="container grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
           <div>
             <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Obras realizadas</p>
-            <h2 className="mt-2 text-3xl font-semibold text-slate-950">Experiencia sin inventar datos oficiales.</h2>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-950">Casos reales comunicados con prudencia tecnica.</h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              Referencias por rubro, alcance y resultado. No usamos logos ni presentamos marcas como clientes directos sin permiso confirmado.
+            </p>
+            <Link href="/obras" className="mt-5 inline-flex items-center rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white">
+              Ver casos reales
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
           </div>
           <div className="grid gap-4 sm:grid-cols-2">
-            {featuredExperience.map((item) => (
-              <article key={item} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-                <h3 className="text-xl font-semibold text-slate-950">{item}</h3>
-                <p className="mt-2 text-sm text-slate-600">Experiencia profesional en instalaciones electricas para espacios de uso intensivo.</p>
+            {featuredCases.map((item) => (
+              <article key={item.slug} className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{item.clientType}</p>
+                <h3 className="mt-2 text-xl font-semibold text-slate-950">{item.title}</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-600">{item.workType}</p>
+                <p className="mt-3 text-sm leading-6 text-slate-600">{item.result}</p>
               </article>
             ))}
           </div>

--- a/nerin-electric-site-v3-fixed/lib/nerin-electricidad.ts
+++ b/nerin-electric-site-v3-fixed/lib/nerin-electricidad.ts
@@ -318,10 +318,10 @@ export const specialServices = [
 ] as const
 
 export const featuredExperience = [
-  'KFC',
-  'Smart Fit',
-  'Supermercados DIA',
-  'Edificios residenciales',
+  'Local gastronomico de cadena',
+  'Gimnasio comercial',
+  'Supermercado / local de retail',
+  'Edificio residencial',
 ] as const
 
 export const trustItems = [

--- a/nerin-electric-site-v3-fixed/lib/real-cases.ts
+++ b/nerin-electric-site-v3-fixed/lib/real-cases.ts
@@ -1,0 +1,147 @@
+export type RealCase = {
+  slug: string
+  title: string
+  clientType: string
+  workType: string
+  scope: string
+  status: string
+  result: string
+  approximateLocation?: string
+  period?: string
+  images: string[]
+  confidentialityNote?: string
+  challenge?: string
+  solution?: string
+  technicalScope: string[]
+  gallery: string[]
+  relatedDocumentation: string[]
+}
+
+export const realCases: RealCase[] = [
+  {
+    slug: 'local-gastronomico-cadena',
+    title: 'Local gastronomico de cadena',
+    clientType: 'Comercio gastronomico',
+    workType: 'Participacion en instalacion electrica comercial',
+    scope:
+      'Relevamiento de necesidades electricas, canalizaciones, tendido de circuitos, apoyo en tablero e instalacion para areas de atencion y servicio.',
+    status: 'Obra finalizada / informacion publica limitada',
+    result:
+      'Instalacion preparada para operacion comercial, con criterios de orden, seguridad y continuidad de servicio segun alcance confirmado.',
+    approximateLocation: 'CABA / GBA, ubicacion no publicada',
+    period: 'Periodo no publicado',
+    images: [],
+    confidentialityNote:
+      'Sin permiso explicito para uso de marca. Se describe el tipo de obra sin presentar a la marca como cliente directo.',
+    challenge:
+      'Coordinar una instalacion comercial con tiempos ajustados, consumos diferenciados y necesidad de dejar sectores listos para puesta en marcha.',
+    solution:
+      'Trabajo por etapas, separacion de circuitos, orden de tablero y pruebas funcionales sobre los puntos intervenidos.',
+    technicalScope: [
+      'Canalizaciones y tendido de lineas segun requerimiento del local',
+      'Circuitos para iluminacion, tomas y consumos especificos',
+      'Apoyo en tablero y protecciones segun alcance de obra',
+      'Pruebas basicas de funcionamiento y revision final',
+    ],
+    gallery: [],
+    relatedDocumentation: [],
+  },
+  {
+    slug: 'gimnasio-comercial',
+    title: 'Gimnasio comercial',
+    clientType: 'Espacio comercial de alto uso',
+    workType: 'Instalacion electrica y adecuaciones por sectores',
+    scope:
+      'Intervencion sobre circuitos de iluminacion, tomas, sectores tecnicos y necesidades electricas asociadas a equipamiento de uso intensivo.',
+    status: 'Obra finalizada / datos sensibles reservados',
+    result:
+      'Sectores electricos ordenados para uso comercial continuo, con revisiones y correcciones segun necesidades detectadas en obra.',
+    approximateLocation: 'CABA / GBA, ubicacion aproximada bajo reserva',
+    period: 'Periodo no publicado',
+    images: [],
+    confidentialityNote:
+      'Sin autorizacion de marca o logo. El caso se comunica por rubro y alcance tecnico minimo.',
+    challenge:
+      'Resolver consumos distribuidos, horarios de trabajo y sectores con alta exigencia operativa sin afectar el avance general.',
+    solution:
+      'Planificacion por areas, circuitos diferenciados y control de terminaciones antes del cierre de cada etapa.',
+    technicalScope: [
+      'Distribucion electrica para areas de entrenamiento y apoyo',
+      'Iluminacion y tomas de uso comercial',
+      'Revision de tablero y derivaciones segun alcance',
+      'Control visual y funcional de los puntos ejecutados',
+    ],
+    gallery: [],
+    relatedDocumentation: [],
+  },
+  {
+    slug: 'supermercado-local-retail',
+    title: 'Supermercado / local de retail',
+    clientType: 'Retail y atencion al publico',
+    workType: 'Participacion en instalacion electrica comercial',
+    scope:
+      'Trabajos electricos para local con circulacion de publico, puntos de consumo comercial, iluminacion y apoyo operativo.',
+    status: 'Obra finalizada / marcas no publicadas',
+    result:
+      'Instalacion ejecutada por sectores, con criterios de seguridad, orden de cableado y continuidad operativa segun alcance acordado.',
+    approximateLocation: 'Area metropolitana de Buenos Aires',
+    period: 'Periodo no publicado',
+    images: [],
+    confidentialityNote:
+      'No se mencionan nombres comerciales por falta de permiso explicito o confirmacion contractual publica.',
+    challenge:
+      'Organizar trabajos en un entorno comercial con multiples consumos, sectores de servicio y necesidad de coordinacion con otros rubros.',
+    solution:
+      'Ejecucion por etapas, priorizacion de circuitos criticos y control de avance para entregar sectores utilizables.',
+    technicalScope: [
+      'Alimentacion de puntos de consumo comercial',
+      'Tendido y ordenamiento de circuitos por sectores',
+      'Iluminacion funcional y puntos de apoyo',
+      'Pruebas de funcionamiento y correcciones finales',
+    ],
+    gallery: [],
+    relatedDocumentation: [],
+  },
+  {
+    slug: 'edificio-residencial',
+    title: 'Edificio residencial',
+    clientType: 'Consorcio / edificio de viviendas',
+    workType: 'Adecuaciones electricas y mantenimiento por sectores comunes',
+    scope:
+      'Revision e intervenciones sobre tableros, circuitos comunes, iluminacion y necesidades puntuales de seguridad electrica.',
+    status: 'Trabajos realizados / documentacion interna',
+    result:
+      'Mejoras puntuales para ordenar la instalacion comun, reducir riesgos visibles y dejar recomendaciones para futuras etapas.',
+    approximateLocation: 'CABA / GBA',
+    period: 'Periodo no publicado',
+    images: [],
+    confidentialityNote:
+      'Se resguarda la direccion y datos del consorcio. El caso se presenta como referencia tecnica general.',
+    challenge:
+      'Intervenir instalaciones existentes con acceso compartido, uso diario del edificio y posibles condiciones antiguas.',
+    solution:
+      'Diagnostico inicial, priorizacion de riesgos, ejecucion por sectores y cierre con observaciones tecnicas.',
+    technicalScope: [
+      'Revision de tableros y circuitos comunes',
+      'Correcciones puntuales en iluminacion o puntos existentes',
+      'Identificacion de riesgos visibles',
+      'Recomendaciones para mantenimiento o adecuacion futura',
+    ],
+    gallery: [],
+    relatedDocumentation: [],
+  },
+]
+
+export const workMethodSteps = [
+  'Diagnostico',
+  'Presupuesto',
+  'Planificacion',
+  'Ejecucion',
+  'Control',
+  'Documentacion',
+  'Cierre y resena',
+] as const
+
+export function getRealCaseBySlug(slug: string) {
+  return realCases.find((item) => item.slug === slug)
+}


### PR DESCRIPTION
## Que cambia

- Reemplaza la seccion de obras/casos por fichas tecnicas minimas con titulo, tipo de cliente, tipo de trabajo, alcance, estado, resultado, ubicacion aproximada, periodo, imagenes y nota de confidencialidad.
- Evita mencionar marcas como clientes directos cuando no hay permiso confirmado y elimina el name-dropping anterior de la portada y datos compartidos.
- Agrega pagina de detalle preparada para crecer con problema/reto, solucion, alcance tecnico, galeria y documentacion relacionada.
- Incorpora bloques de confianza: proceso de trabajo de NERIN y portal privado para avances, certificados, documentacion y estado del proyecto.

## Criterio usado

No se inventaron testimonios, permisos de marca, logos ni imagenes. Cuando faltan imagenes, se muestra un bloque neutro de "Caso en actualizacion".

## Validacion

- Compare la rama contra `main`: 5 archivos cambiados.
- Verifique que los archivos afectados no conserven `KFC`, `Smart Fit` ni `Supermercados DIA`.
- No pude correr build/lint completo porque el entorno no tiene `git` ni una copia local completa del repo; los cambios se realizaron mediante el conector de GitHub.