### PR TITLE
[codex] Implementar base SEO tecnico

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(site)/contacto/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/contacto/page.tsx
@@ -1,17 +1,24 @@
 import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import { LeadWizard } from '@/components/LeadWizard'
+import { breadcrumbJsonLd, buildSeoMetadata } from '@/lib/seo'
 
-export const metadata = {
-  title: 'Contacto y presupuesto electrico | NERIN',
-  description: 'Solicita presupuesto para trabajos chicos, refacciones, obras y servicios electricos especiales en CABA/GBA.',
-}
+export const metadata = buildSeoMetadata({
+  title: 'Contacto para presupuesto electrico en CABA | NERIN',
+  description: 'Solicita presupuesto para trabajos electricos chicos, refacciones, obras y servicios especiales en CABA/GBA con fotos, zona y urgencia.',
+  path: '/contacto',
+})
 
 export default async function ContactoPage() {
   const site = await getSiteContent()
   const whatsappHref = getWhatsappHref(site)
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: 'Inicio', path: '/' },
+    { name: 'Contacto', path: '/contacto' },
+  ])
 
   return (
     <div className="bg-slate-50">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }} />
       <section className="border-b border-slate-200 bg-white py-14">
         <div className="container max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Contacto</p>

--- a/nerin-electric-site-v3-fixed/app/(site)/empresa/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/empresa/page.tsx
@@ -1,15 +1,23 @@
 import { CheckCircle2 } from 'lucide-react'
+import { breadcrumbJsonLd, buildSeoMetadata } from '@/lib/seo'
 
 const process = ['Relevamiento', 'Diagnostico', 'Presupuesto claro', 'Ejecucion prolija', 'Seguimiento y cierre']
 
-export const metadata = {
-  title: 'Empresa de electricidad en CABA y GBA | NERIN',
-  description: 'NERIN Electricidad, empresa de servicios electricos para hogares, comercios, edificios, empresas y obras.',
-}
+export const metadata = buildSeoMetadata({
+  title: 'Empresa de electricidad en CABA | NERIN',
+  description: 'NERIN Electricidad trabaja en servicios electricos para hogares, comercios, edificios, empresas y obras en CABA/GBA con alcance claro.',
+  path: '/empresa',
+})
 
 export default function EmpresaPage() {
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: 'Inicio', path: '/' },
+    { name: 'Empresa', path: '/empresa' },
+  ])
+
   return (
     <div className="bg-white">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }} />
       <section className="border-b border-slate-200 bg-slate-50 py-14">
         <div className="container max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Empresa</p>

--- a/nerin-electric-site-v3-fixed/app/(site)/obras-electricas/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/obras-electricas/page.tsx
@@ -2,11 +2,14 @@ import { FileCheck2, Milestone, PanelsTopLeft } from 'lucide-react'
 import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import { majorWorks } from '@/lib/nerin-electricidad'
 import { LeadWizard } from '@/components/LeadWizard'
+import { breadcrumbJsonLd, buildSeoMetadata } from '@/lib/seo'
 
-export const metadata = {
-  title: 'Obras electricas grandes | NERIN',
-  description: 'Obras electricas para locales, edificios y obras nuevas con planificacion, presupuesto formal, seguimiento y portal cliente.',
-}
+export const metadata = buildSeoMetadata({
+  title: 'Obras e instalaciones electricas en CABA | NERIN',
+  description:
+    'Obra electrica para local comercial, edificios, oficinas y obras nuevas en CABA/GBA con planificacion por etapas, presupuesto formal y seguimiento.',
+  path: '/obras-electricas',
+})
 
 const obraHighlights = [
   { icon: Milestone, title: 'Planificacion por etapas', text: 'Alcance ordenado para coordinar rubros, tiempos, materiales y prioridades de obra.' },
@@ -17,9 +20,14 @@ const obraHighlights = [
 export default async function ObrasElectricasPage() {
   const site = await getSiteContent()
   const whatsappHref = getWhatsappHref(site)
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: 'Inicio', path: '/' },
+    { name: 'Obras electricas', path: '/obras-electricas' },
+  ])
 
   return (
     <div className="bg-white">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }} />
       <section className="border-b border-slate-200 bg-slate-950 py-14 text-white">
         <div className="container max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-[0.24em] text-amber-300">Obras electricas</p>

--- a/nerin-electric-site-v3-fixed/app/(site)/obras/[slug]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/obras/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation'
 import { ArrowLeft, FileText, ImageIcon, LockKeyhole, MapPin } from 'lucide-react'
 import { getRealCaseBySlug, realCases } from '@/lib/real-cases'
 import { Badge } from '@/components/ui/badge'
+import { breadcrumbJsonLd, buildSeoMetadata, caseStudyJsonLd } from '@/lib/seo'
 
 export const revalidate = 60
 
@@ -17,15 +18,15 @@ export function generateStaticParams() {
 export function generateMetadata({ params }: Props) {
   const caseItem = getRealCaseBySlug(params.slug)
   if (!caseItem) {
-    return {
-      title: 'Caso real | NERIN',
-    }
+    return { title: 'Caso real | NERIN' }
   }
 
-  return {
+  return buildSeoMetadata({
     title: `${caseItem.title} | Caso real NERIN`,
     description: `${caseItem.clientType}. ${caseItem.scope}`,
-  }
+    path: `/obras/${caseItem.slug}`,
+    type: 'article',
+  })
 }
 
 export default function ObraDetallePage({ params }: Props) {
@@ -34,8 +35,17 @@ export default function ObraDetallePage({ params }: Props) {
     notFound()
   }
 
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: 'Inicio', path: '/' },
+    { name: 'Casos reales', path: '/obras' },
+    { name: caseItem.title, path: `/obras/${caseItem.slug}` },
+  ])
+  const caseSchema = caseStudyJsonLd(caseItem)
+
   return (
     <article className="bg-white">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(caseSchema) }} />
       <section className="border-b border-slate-200 bg-slate-950 py-12 text-white">
         <div className="container max-w-5xl">
           <Link href="/obras" className="inline-flex items-center text-sm font-semibold text-slate-300 hover:text-white">
@@ -56,29 +66,14 @@ export default function ObraDetallePage({ params }: Props) {
           <div className="rounded-lg border border-slate-200 bg-slate-50 p-5">
             <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-500">Ficha minima</p>
             <dl className="mt-4 space-y-4 text-sm">
-              <div>
-                <dt className="font-semibold text-slate-950">Tipo de cliente</dt>
-                <dd className="mt-1 text-slate-600">{caseItem.clientType}</dd>
-              </div>
-              <div>
-                <dt className="font-semibold text-slate-950">Tipo de trabajo</dt>
-                <dd className="mt-1 text-slate-600">{caseItem.workType}</dd>
-              </div>
-              <div>
-                <dt className="font-semibold text-slate-950">Estado</dt>
-                <dd className="mt-1 text-slate-600">{caseItem.status}</dd>
-              </div>
-              <div>
-                <dt className="font-semibold text-slate-950">Periodo</dt>
-                <dd className="mt-1 text-slate-600">{caseItem.period ?? 'No publicado'}</dd>
-              </div>
+              <div><dt className="font-semibold text-slate-950">Tipo de cliente</dt><dd className="mt-1 text-slate-600">{caseItem.clientType}</dd></div>
+              <div><dt className="font-semibold text-slate-950">Tipo de trabajo</dt><dd className="mt-1 text-slate-600">{caseItem.workType}</dd></div>
+              <div><dt className="font-semibold text-slate-950">Estado</dt><dd className="mt-1 text-slate-600">{caseItem.status}</dd></div>
+              <div><dt className="font-semibold text-slate-950">Periodo</dt><dd className="mt-1 text-slate-600">{caseItem.period ?? 'No publicado'}</dd></div>
               {caseItem.approximateLocation ? (
                 <div>
                   <dt className="font-semibold text-slate-950">Ubicacion aproximada</dt>
-                  <dd className="mt-1 inline-flex items-center gap-2 text-slate-600">
-                    <MapPin className="h-4 w-4 text-slate-500" />
-                    {caseItem.approximateLocation}
-                  </dd>
+                  <dd className="mt-1 inline-flex items-center gap-2 text-slate-600"><MapPin className="h-4 w-4 text-slate-500" />{caseItem.approximateLocation}</dd>
                 </div>
               ) : null}
             </dl>
@@ -86,10 +81,7 @@ export default function ObraDetallePage({ params }: Props) {
 
           {caseItem.confidentialityNote ? (
             <div className="rounded-lg border border-amber-200 bg-amber-50 p-5 text-amber-950">
-              <div className="flex items-center gap-2 text-sm font-semibold">
-                <LockKeyhole className="h-4 w-4" />
-                Nota de confidencialidad
-              </div>
+              <div className="flex items-center gap-2 text-sm font-semibold"><LockKeyhole className="h-4 w-4" />Nota de confidencialidad</div>
               <p className="mt-3 text-sm leading-6">{caseItem.confidentialityNote}</p>
             </div>
           ) : null}
@@ -102,24 +94,14 @@ export default function ObraDetallePage({ params }: Props) {
           </section>
 
           <div className="grid gap-5 md:grid-cols-2">
-            <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
-              <h2 className="text-xl font-semibold text-slate-950">Problema / reto</h2>
-              <p className="mt-3 text-sm leading-6 text-slate-600">{caseItem.challenge ?? 'Informacion en revision para completar la ficha tecnica.'}</p>
-            </section>
-            <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
-              <h2 className="text-xl font-semibold text-slate-950">Solucion</h2>
-              <p className="mt-3 text-sm leading-6 text-slate-600">{caseItem.solution ?? 'Informacion en revision para completar la ficha tecnica.'}</p>
-            </section>
+            <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm"><h2 className="text-xl font-semibold text-slate-950">Problema / reto</h2><p className="mt-3 text-sm leading-6 text-slate-600">{caseItem.challenge ?? 'Informacion en revision para completar la ficha tecnica.'}</p></section>
+            <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm"><h2 className="text-xl font-semibold text-slate-950">Solucion</h2><p className="mt-3 text-sm leading-6 text-slate-600">{caseItem.solution ?? 'Informacion en revision para completar la ficha tecnica.'}</p></section>
           </div>
 
           <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
             <h2 className="text-xl font-semibold text-slate-950">Alcance tecnico</h2>
             <ul className="mt-4 grid gap-3 text-sm leading-6 text-slate-600 sm:grid-cols-2">
-              {caseItem.technicalScope.map((item) => (
-                <li key={item} className="rounded-lg border border-slate-200 bg-slate-50 p-3">
-                  {item}
-                </li>
-              ))}
+              {caseItem.technicalScope.map((item) => (<li key={item} className="rounded-lg border border-slate-200 bg-slate-50 p-3">{item}</li>))}
             </ul>
           </section>
 
@@ -128,16 +110,12 @@ export default function ObraDetallePage({ params }: Props) {
             {caseItem.gallery.length > 0 ? (
               <div className="mt-4 grid gap-3 sm:grid-cols-2">
                 {caseItem.gallery.map((image) => (
-                  <img key={image} src={image} alt={caseItem.title} className="aspect-video rounded-lg border border-slate-200 object-cover" />
+                  <img key={image} src={image} alt={`Imagen del caso ${caseItem.title}`} loading="lazy" className="aspect-video rounded-lg border border-slate-200 object-cover" />
                 ))}
               </div>
             ) : (
               <div className="mt-4 flex min-h-32 items-center justify-center rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-center">
-                <div>
-                  <ImageIcon className="mx-auto h-6 w-6 text-slate-500" />
-                  <p className="mt-2 text-sm font-semibold text-slate-950">Caso en actualizacion</p>
-                  <p className="mt-1 text-sm text-slate-600">Se agregaran imagenes solo si existen y estan autorizadas.</p>
-                </div>
+                <div><ImageIcon className="mx-auto h-6 w-6 text-slate-500" /><p className="mt-2 text-sm font-semibold text-slate-950">Caso en actualizacion</p><p className="mt-1 text-sm text-slate-600">Se agregaran imagenes solo si existen y estan autorizadas.</p></div>
               </div>
             )}
           </section>
@@ -146,17 +124,10 @@ export default function ObraDetallePage({ params }: Props) {
             <h2 className="text-xl font-semibold text-slate-950">Documentacion relacionada</h2>
             {caseItem.relatedDocumentation.length > 0 ? (
               <ul className="mt-4 space-y-2 text-sm text-slate-600">
-                {caseItem.relatedDocumentation.map((item) => (
-                  <li key={item} className="flex items-center gap-2">
-                    <FileText className="h-4 w-4 text-slate-500" />
-                    {item}
-                  </li>
-                ))}
+                {caseItem.relatedDocumentation.map((item) => (<li key={item} className="flex items-center gap-2"><FileText className="h-4 w-4 text-slate-500" />{item}</li>))}
               </ul>
             ) : (
-              <p className="mt-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm leading-6 text-slate-600">
-                Documentacion no publicada. Puede incorporarse a futuro si corresponde y cuenta con autorizacion.
-              </p>
+              <p className="mt-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm leading-6 text-slate-600">Documentacion no publicada. Puede incorporarse a futuro si corresponde y cuenta con autorizacion.</p>
             )}
           </section>
         </div>

--- a/nerin-electric-site-v3-fixed/app/(site)/refacciones-electricas/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/refacciones-electricas/page.tsx
@@ -2,18 +2,26 @@ import { ClipboardList, Images } from 'lucide-react'
 import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import { renovationCards } from '@/lib/nerin-electricidad'
 import { LeadWizard } from '@/components/LeadWizard'
+import { breadcrumbJsonLd, buildSeoMetadata } from '@/lib/seo'
 
-export const metadata = {
-  title: 'Refacciones electricas y trabajos medianos | NERIN',
-  description: 'Refacciones de departamentos, casas, locales y oficinas con relevamiento, fotos y presupuesto por Valdir Nerin.',
-}
+export const metadata = buildSeoMetadata({
+  title: 'Refaccion electrica de departamento en CABA | NERIN',
+  description:
+    'Refacciones electricas de departamentos, casas, locales y oficinas en CABA/GBA con relevamiento, fotos, alcance claro y presupuesto por caso.',
+  path: '/refacciones-electricas',
+})
 
 export default async function RefaccionesElectricasPage() {
   const site = await getSiteContent()
   const whatsappHref = getWhatsappHref(site)
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: 'Inicio', path: '/' },
+    { name: 'Refacciones electricas', path: '/refacciones-electricas' },
+  ])
 
   return (
     <div className="bg-white">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }} />
       <section className="border-b border-slate-200 bg-slate-50 py-14">
         <div className="container max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Refacciones electricas</p>

--- a/nerin-electric-site-v3-fixed/app/(site)/servicios-especiales/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/servicios-especiales/page.tsx
@@ -1,18 +1,26 @@
 import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import { specialServices } from '@/lib/nerin-electricidad'
 import { LeadWizard } from '@/components/LeadWizard'
+import { breadcrumbJsonLd, buildSeoMetadata } from '@/lib/seo'
 
-export const metadata = {
-  title: 'Servicios electricos especiales | NERIN',
-  description: 'Diagnostico, informes, revision de tablero, puesta a tierra, cortes frecuentes y relevamientos electricos.',
-}
+export const metadata = buildSeoMetadata({
+  title: 'Servicios electricos especiales en CABA | NERIN',
+  description:
+    'Diagnostico electrico, informes, revision de tablero, puesta a tierra, cortes frecuentes y relevamientos en CABA/GBA con revision tecnica.',
+  path: '/servicios-especiales',
+})
 
 export default async function ServiciosEspecialesPage() {
   const site = await getSiteContent()
   const whatsappHref = getWhatsappHref(site)
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: 'Inicio', path: '/' },
+    { name: 'Servicios especiales', path: '/servicios-especiales' },
+  ])
 
   return (
     <div className="bg-white">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }} />
       <section className="border-b border-slate-200 bg-slate-50 py-14">
         <div className="container max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Servicios especiales</p>

--- a/nerin-electric-site-v3-fixed/app/(site)/trabajos-chicos/[slug]/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/trabajos-chicos/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { Camera } from 'lucide-react'
 import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import { getServiceBySlug, manualReviewMessage, safetyNotice, serviceCatalog } from '@/lib/nerin-electricidad'
 import { LeadWizard } from '@/components/LeadWizard'
+import { breadcrumbJsonLd, buildSeoMetadata, serviceJsonLd } from '@/lib/seo'
 
 export function generateStaticParams() {
   return serviceCatalog.map((service) => ({ slug: service.slug }))
@@ -11,10 +12,12 @@ export function generateStaticParams() {
 export function generateMetadata({ params }: { params: { slug: string } }) {
   const service = getServiceBySlug(params.slug)
   if (!service) return {}
-  return {
-    title: `${service.name} | Trabajos chicos NERIN`,
-    description: `${service.shortDescription} Precio desde ${service.priceFrom ?? 'a presupuestar'}. Envia fotos para cotizar.`,
-  }
+
+  return buildSeoMetadata({
+    title: `${service.name} en CABA | NERIN`,
+    description: `${service.shortDescription} Precio orientativo desde ${service.priceFrom ?? 'a confirmar segun alcance'}. Envia fotos para cotizar el trabajo electrico.`,
+    path: `/trabajos-chicos/${service.slug}`,
+  })
 }
 
 export default async function TrabajoChicoPage({ params }: { params: { slug: string } }) {
@@ -23,9 +26,17 @@ export default async function TrabajoChicoPage({ params }: { params: { slug: str
 
   const site = await getSiteContent()
   const whatsappHref = getWhatsappHref(site)
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: 'Inicio', path: '/' },
+    { name: 'Trabajos chicos', path: '/trabajos-chicos' },
+    { name: service.name, path: `/trabajos-chicos/${service.slug}` },
+  ])
+  const serviceSchema = serviceJsonLd(service)
 
   return (
     <div className="bg-white">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(serviceSchema) }} />
       <section className="border-b border-slate-200 bg-slate-50 py-14">
         <div className="container grid gap-8 lg:grid-cols-[0.85fr_0.55fr]">
           <div>

--- a/nerin-electric-site-v3-fixed/app/(site)/trabajos-chicos/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/trabajos-chicos/page.tsx
@@ -1,15 +1,24 @@
 import Link from 'next/link'
 import { ArrowRight, Camera, Search } from 'lucide-react'
 import { serviceCatalog, smallJobCategories } from '@/lib/nerin-electricidad'
+import { breadcrumbJsonLd, buildSeoMetadata } from '@/lib/seo'
 
-export const metadata = {
-  title: 'Trabajos chicos electricos con precios orientativos | NERIN',
-  description: 'Pedidos electricos simples en CABA/GBA con precio desde, incluye, no incluye, duracion, zona y fotos para cotizar.',
-}
+export const metadata = buildSeoMetadata({
+  title: 'Trabajos electricos chicos en CABA | NERIN',
+  description:
+    'Cambio de tomacorriente, revision de tablero, fallas electricas, luminarias y tomas para aire en CABA con precios orientativos y cotizacion por fotos.',
+  path: '/trabajos-chicos',
+})
 
 export default function TrabajosChicosPage() {
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: 'Inicio', path: '/' },
+    { name: 'Trabajos chicos', path: '/trabajos-chicos' },
+  ])
+
   return (
     <div className="bg-white">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }} />
       <section className="border-b border-slate-200 bg-slate-50 py-14">
         <div className="container max-w-5xl">
           <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Trabajos chicos</p>

--- a/nerin-electric-site-v3-fixed/app/robots.ts
+++ b/nerin-electric-site-v3-fixed/app/robots.ts
@@ -1,30 +1,35 @@
-import { MetadataRoute } from 'next'
+import type { MetadataRoute } from 'next'
+import { SITE_ORIGIN } from '@/lib/seo'
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ||
-    process.env.SITE_URL?.replace(/\/$/, '') ||
-    'https://www.nerin.com.ar'
-
   return {
-    rules: {
-      userAgent: '*',
-      allow: '/',
-      disallow: [
-        '/admin',
-        '/admin/',
-        '/clientes',
-        '/clientes/',
-        '/tecnico',
-        '/tecnico/',
-        '/api/admin',
-        '/api/admin/',
-        '/api/quotes',
-        '/api/quotes/',
-        '/api/upload/project-photo',
-        '/api/upload/project-photo/',
-      ],
-    },
-    sitemap: `${baseUrl}/sitemap.xml`,
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [
+          '/admin',
+          '/admin/',
+          '/clientes',
+          '/clientes/',
+          '/clientes/login',
+          '/clientes/login/',
+          '/tecnico',
+          '/tecnico/',
+          '/portal',
+          '/portal/',
+          '/api',
+          '/api/',
+          '/presupuesto/',
+          '/presupuestos/',
+          '/token/',
+          '/*token=*',
+          '/*?token=*',
+          '/*estado=*',
+          '/*internal=*',
+        ],
+      },
+    ],
+    sitemap: new URL('/sitemap.xml', SITE_ORIGIN).toString(),
   }
 }

--- a/nerin-electric-site-v3-fixed/app/sitemap.ts
+++ b/nerin-electric-site-v3-fixed/app/sitemap.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from 'next'
+import { serviceCatalog } from '@/lib/nerin-electricidad'
+import { realCases } from '@/lib/real-cases'
+import { SITE_ORIGIN } from '@/lib/seo'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date()
+  const publicRoutes = [
+    '/',
+    '/trabajos-chicos',
+    '/refacciones-electricas',
+    '/obras-electricas',
+    '/servicios-especiales',
+    '/obras',
+    '/empresa',
+    '/contacto',
+  ]
+
+  const serviceRoutes = serviceCatalog.map((service) => `/trabajos-chicos/${service.slug}`)
+  const caseRoutes = realCases.map((caseItem) => `/obras/${caseItem.slug}`)
+
+  return [...publicRoutes, ...serviceRoutes, ...caseRoutes].map((route) => ({
+    url: new URL(route, SITE_ORIGIN).toString(),
+    lastModified: now,
+    changeFrequency: route === '/' ? 'weekly' : 'monthly',
+    priority: route === '/' ? 1 : route.includes('/trabajos-chicos/') ? 0.7 : 0.8,
+  }))
+}

--- a/nerin-electric-site-v3-fixed/lib/seo.ts
+++ b/nerin-electric-site-v3-fixed/lib/seo.ts
@@ -1,0 +1,138 @@
+import type { Metadata } from 'next'
+import type { RealCase } from '@/lib/real-cases'
+import type { ServiceCatalogItem } from '@/lib/nerin-electricidad'
+
+export const SITE_ORIGIN = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || 'https://nerin-1.onrender.com'
+export const SITE_NAME = 'NERIN Electricidad'
+export const OG_IMAGE = '/nerin/og-cover.png'
+
+export const initialKeywords = [
+  'electricista en CABA',
+  'trabajos electricos en CABA',
+  'instalaciones electricas CABA',
+  'cambio de tomacorriente CABA',
+  'revision de tablero electrico CABA',
+  'reparacion de falla electrica CABA',
+  'instalacion de toma para aire acondicionado CABA',
+  'refaccion electrica de departamento CABA',
+  'obra electrica para local comercial',
+  'instalaciones electricas para edificios en CABA',
+]
+
+type SeoMetadataInput = {
+  title: string
+  description: string
+  path?: string
+  type?: 'website' | 'article'
+}
+
+export function absoluteUrl(path = '/') {
+  return new URL(path, SITE_ORIGIN).toString()
+}
+
+export function buildSeoMetadata({ title, description, path = '/', type = 'website' }: SeoMetadataInput): Metadata {
+  return {
+    title,
+    description,
+    keywords: initialKeywords,
+    alternates: { canonical: path },
+    openGraph: {
+      title,
+      description,
+      url: absoluteUrl(path),
+      siteName: SITE_NAME,
+      locale: 'es_AR',
+      type,
+      images: [{ url: OG_IMAGE, width: 1200, height: 630, alt: SITE_NAME }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [OG_IMAGE],
+    },
+  }
+}
+
+export function breadcrumbJsonLd(items: Array<{ name: string; path: string }>) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: absoluteUrl(item.path),
+    })),
+  }
+}
+
+export function localBusinessJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'LocalBusiness',
+    '@id': `${SITE_ORIGIN}/#localbusiness`,
+    name: SITE_NAME,
+    url: SITE_ORIGIN,
+    areaServed: [
+      { '@type': 'AdministrativeArea', name: 'Ciudad Autonoma de Buenos Aires' },
+      { '@type': 'AdministrativeArea', name: 'Gran Buenos Aires' },
+    ],
+    address: {
+      '@type': 'PostalAddress',
+      addressLocality: 'Ciudad Autonoma de Buenos Aires',
+      addressRegion: 'CABA',
+      addressCountry: 'AR',
+    },
+    makesOffer: [
+      { '@type': 'Offer', itemOffered: { '@type': 'Service', name: 'Trabajos electricos en CABA' } },
+      { '@type': 'Offer', itemOffered: { '@type': 'Service', name: 'Refacciones electricas' } },
+      { '@type': 'Offer', itemOffered: { '@type': 'Service', name: 'Obras electricas' } },
+    ],
+  }
+}
+
+export function serviceJsonLd(service: ServiceCatalogItem) {
+  const price = parsePrice(service.priceFrom)
+  const offer: Record<string, unknown> = {
+    '@type': 'Offer',
+    name: service.name,
+    priceCurrency: 'ARS',
+    availability: 'https://schema.org/InStock',
+    areaServed: 'CABA y GBA con confirmacion',
+    description: service.priceFrom ? `Precio orientativo desde ${service.priceFrom}` : 'Precio a confirmar segun alcance',
+    url: absoluteUrl(`/trabajos-chicos/${service.slug}`),
+  }
+
+  if (price) offer.price = price
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    name: service.name,
+    description: service.longDescription,
+    serviceType: service.category,
+    areaServed: 'CABA y GBA con confirmacion',
+    provider: { '@type': 'LocalBusiness', name: SITE_NAME, url: SITE_ORIGIN },
+    offers: offer,
+  }
+}
+
+export function caseStudyJsonLd(caseItem: RealCase) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CreativeWork',
+    name: caseItem.title,
+    description: caseItem.scope,
+    about: caseItem.workType,
+    areaServed: caseItem.approximateLocation,
+    url: absoluteUrl(`/obras/${caseItem.slug}`),
+    provider: { '@type': 'Organization', name: SITE_NAME, url: SITE_ORIGIN },
+  }
+}
+
+function parsePrice(value?: string) {
+  if (!value) return null
+  const digits = value.replace(/[^0-9]/g, '')
+  return digits ? Number(digits) : null
+}


### PR DESCRIPTION
## Que cambia

- Agrega helpers SEO compartidos para metadata, canonicals, Open Graph, keywords iniciales y JSON-LD prudente.
- Agrega `sitemap.ts` con lista blanca de paginas publicas vendibles, fichas de servicios y casos reales publicos.
- Ajusta `robots.ts` para permitir la web publica y bloquear admin, clientes/login, portales, API, tokens y estados internos.
- Refuerza metadata y BreadcrumbList en categorias, fichas de servicios, empresa, contacto y casos reales.
- Agrega `Service` + `Offer` en fichas de trabajos chicos con precio orientativo sin prometer rich results.
- Mejora ALT/lazy-load en imagenes de galeria de casos reales.

## Enfoque

La implementacion evita sobreoptimizar y no agrega credenciales no confirmadas como matricula, COPIME, DCI ni certificaciones de distribuidoras. Las keywords iniciales quedan como base controlada para escalar por servicio y zona.

## Validacion

- Comparado contra `main`: la rama esta ahead y no behind.
- Revisado sitemap/robots para que no incluyan rutas privadas.
- No pude ejecutar build local desde este entorno porque no hay `git`/checkout con dependencias disponible; el PR queda en draft para validacion de CI.