### PR TITLE
[codex] Reorganize admin control panel

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/(dashboard)/page.tsx
@@ -8,67 +8,70 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 
 const todayCards: Array<{ label: string; value: string; href: Route }> = [
-  { label: 'Solicitudes nuevas', value: '0', href: '/admin/solicitudes' as Route },
-  { label: 'Trabajos por presupuestar', value: '0', href: '/admin/presupuestos' as Route },
-  { label: 'Trabajos en curso', value: '0', href: '/admin/trabajos-chicos' as Route },
+  { label: 'Consultas nuevas', value: '0', href: '/admin/consultas' as Route },
+  { label: 'Presupuestos', value: '0', href: '/admin/presupuestos' as Route },
+  { label: 'Trabajos chicos', value: '0', href: '/admin/trabajos-chicos' as Route },
+  { label: 'Refacciones', value: '0', href: '/admin/refacciones' as Route },
   { label: 'Obras activas', value: '0', href: '/admin/obras' as Route },
-  { label: 'Cobros pendientes', value: '$0', href: '/admin/dinero' as Route },
-  { label: 'Gastos del mes', value: '$0', href: '/admin/dinero' as Route },
-  { label: 'Alertas de gestion', value: '0', href: '/admin/dinero' as Route },
+  { label: 'Dinero', value: '$0', href: '/admin/dinero' as Route },
+  { label: 'Capacidad', value: 'Ver', href: '/admin/capacidad' as Route },
 ]
 
 const reviewItems = [
-  'Solicitudes nuevas sin responder.',
-  'Pedidos fuera de zona o con riesgo electrico.',
+  'Consultas nuevas sin responder.',
+  'Presupuestos aceptados sin inicio.',
   'Trabajos terminados sin registrar cobro.',
-  'Refacciones sin presupuesto enviado.',
+  'Refacciones sin proximo paso.',
   'Obras sin avance o certificado reciente.',
-  'Gastos cargados sin asociar a trabajo u obra.',
+  'Capacidad sin actualizar.',
 ]
 
 export default async function AdminPage() {
   if (!DB_ENABLED) {
     return (
       <div className="space-y-4">
-        <Badge>Panel de NERIN</Badge>
-        <h1 className="text-3xl font-semibold text-slate-950">Panel de NERIN</h1>
-        <p className="text-sm text-slate-600">Activá la base de datos para ver solicitudes, trabajos, obras y dinero.</p>
+        <Badge>NERIN Electricidad</Badge>
+        <h1 className="text-3xl font-semibold text-slate-950">Centro de control</h1>
+        <p className="text-sm text-slate-600">Activa la base de datos para ver consultas, trabajos, obras, dinero y capacidad.</p>
       </div>
     )
   }
 
-  const [leads, projects, clients, certificates] = await Promise.all([
+  const [leads, serviceRequests, quotes, smallJobs, renovations, projects] = await Promise.all([
     prisma.lead.findMany({ orderBy: { createdAt: 'desc' }, take: 6 }),
-    prisma.project.count(),
-    prisma.opsClient.count().catch(() => 0),
-    prisma.opsProgressCertificate.count().catch(() => 0),
+    prisma.serviceRequest.count().catch(() => 0),
+    prisma.quote.count().catch(() => 0),
+    prisma.smallJob.count().catch(() => 0),
+    prisma.renovationJob.count().catch(() => 0),
+    prisma.project.count().catch(() => 0),
   ])
 
-  const cards = todayCards.map((card) =>
-    card.label === 'Solicitudes nuevas'
-      ? { ...card, value: String(leads.length) }
-      : card.label === 'Obras activas'
-        ? { ...card, value: String(projects) }
-        : card,
-  )
+  const cards = todayCards.map((card) => {
+    if (card.label === 'Consultas nuevas') return { ...card, value: String(leads.length + serviceRequests) }
+    if (card.label === 'Presupuestos') return { ...card, value: String(quotes) }
+    if (card.label === 'Trabajos chicos') return { ...card, value: String(smallJobs) }
+    if (card.label === 'Refacciones') return { ...card, value: String(renovations) }
+    if (card.label === 'Obras activas') return { ...card, value: String(projects) }
+    return card
+  })
 
   return (
     <div className="space-y-8">
-      <header className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-        <Badge>Inicio</Badge>
+      <header className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <Badge>NERIN Electricidad</Badge>
         <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>
-            <h1 className="text-3xl font-semibold text-slate-950">Panel de NERIN</h1>
+            <h1 className="text-3xl font-semibold text-slate-950">Centro de control</h1>
             <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
-              Solicitudes, trabajos, obras, presupuestos, cobros y gastos en un solo lugar.
+              Consultas, presupuestos, trabajos, obras, dinero y capacidad en un solo lugar.
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
             <Button asChild className="bg-slate-950 hover:bg-slate-800">
-              <Link href="/admin/solicitudes">Ver solicitudes</Link>
+              <Link href="/admin/consultas">Ver consultas</Link>
             </Button>
             <Button asChild variant="outline">
-              <Link href="/admin/catalogo-web">Editar catalogo</Link>
+              <Link href="/admin/capacidad">Ver capacidad</Link>
             </Button>
           </div>
         </div>
@@ -88,14 +91,14 @@ export default async function AdminPage() {
 
       <section className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
         <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <h2 className="text-xl font-semibold text-slate-950">Ultimas solicitudes</h2>
+          <h2 className="text-xl font-semibold text-slate-950">Ultimas consultas</h2>
           <div className="mt-4 overflow-x-auto">
             <table className="w-full min-w-[720px] text-left text-sm">
               <thead className="text-xs uppercase tracking-[0.16em] text-slate-500">
                 <tr>
                   <th className="border-b border-slate-200 py-3">Cliente</th>
                   <th className="border-b border-slate-200 py-3">Tipo</th>
-                  <th className="border-b border-slate-200 py-3">Servicio/trabajo</th>
+                  <th className="border-b border-slate-200 py-3">Trabajo</th>
                   <th className="border-b border-slate-200 py-3">Zona</th>
                   <th className="border-b border-slate-200 py-3">Urgencia</th>
                   <th className="border-b border-slate-200 py-3">Fecha</th>
@@ -105,7 +108,7 @@ export default async function AdminPage() {
                 {leads.map((lead) => (
                   <tr key={lead.id} className="border-b border-slate-100">
                     <td className="py-3 font-medium text-slate-950">{lead.name}</td>
-                    <td className="py-3 text-slate-600">{lead.leadType ?? 'Solicitud'}</td>
+                    <td className="py-3 text-slate-600">{lead.leadType ?? 'Consulta'}</td>
                     <td className="py-3 text-slate-600">{lead.workType}</td>
                     <td className="py-3 text-slate-600">{lead.location}</td>
                     <td className="py-3 text-slate-600">{lead.urgency}</td>
@@ -115,7 +118,7 @@ export default async function AdminPage() {
                 {leads.length === 0 ? (
                   <tr>
                     <td colSpan={6} className="py-6 text-center text-slate-500">
-                      Todavia no hay solicitudes. Cuando un cliente pida un trabajo desde la web, va a aparecer aca. Tambien podes cargar una solicitud manual recibida por WhatsApp.
+                      Todavia no hay consultas. Cuando un cliente pida un trabajo desde la web, va a aparecer aca.
                     </td>
                   </tr>
                 ) : null}
@@ -132,10 +135,6 @@ export default async function AdminPage() {
                 {item}
               </p>
             ))}
-          </div>
-          <div className="mt-5 grid grid-cols-2 gap-3 text-sm text-slate-300">
-            <span>Clientes: {clients}</span>
-            <span>Certificados: {certificates}</span>
           </div>
         </div>
       </section>

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/capacidad/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/capacidad/page.tsx
@@ -1,0 +1,138 @@
+import { revalidatePath } from 'next/cache'
+import { prisma } from '@/lib/db'
+import { DB_ENABLED } from '@/lib/dbMode'
+import { Button } from '@/components/ui/button'
+import { FormSection } from '@/components/admin/ui/FormSection'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+const CAPACITY_KEY = 'admin_capacity_status'
+
+const options = [
+  {
+    value: 'verde',
+    label: 'Verde',
+    meaning: 'Se puede tomar mas trabajo.',
+    className: 'border-emerald-200 bg-emerald-50 text-emerald-800',
+  },
+  {
+    value: 'amarillo',
+    label: 'Amarillo',
+    meaning: 'Filtrar por zona, ticket o urgencia.',
+    className: 'border-amber-200 bg-amber-50 text-amber-800',
+  },
+  {
+    value: 'rojo',
+    label: 'Rojo',
+    meaning: 'Solo urgencias rentables u obras estrategicas.',
+    className: 'border-rose-200 bg-rose-50 text-rose-800',
+  },
+] as const
+
+async function saveCapacity(formData: FormData) {
+  'use server'
+
+  if (!DB_ENABLED) return
+
+  const status = String(formData.get('status') || 'verde')
+  const note = String(formData.get('note') || '').trim()
+  const safeStatus = options.some((option) => option.value === status) ? status : 'verde'
+
+  await prisma.websiteContent.upsert({
+    where: { key: CAPACITY_KEY },
+    update: {
+      title: 'Capacidad operativa',
+      content: JSON.stringify({ status: safeStatus, note }),
+      visible: false,
+    },
+    create: {
+      key: CAPACITY_KEY,
+      title: 'Capacidad operativa',
+      content: JSON.stringify({ status: safeStatus, note }),
+      visible: false,
+    },
+  })
+
+  revalidatePath('/admin/capacidad')
+}
+
+function parseContent(content?: string | null) {
+  try {
+    const parsed = JSON.parse(content || '{}') as { status?: string; note?: string }
+    return {
+      status: options.some((option) => option.value === parsed.status) ? parsed.status || 'verde' : 'verde',
+      note: parsed.note || '',
+    }
+  } catch {
+    return { status: 'verde', note: '' }
+  }
+}
+
+export default async function AdminCapacidadPage() {
+  if (!DB_ENABLED) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-3xl font-semibold text-slate-950">Capacidad</h1>
+        <p className="text-sm text-slate-600">La base de datos esta deshabilitada. No se puede guardar el semaforo.</p>
+      </div>
+    )
+  }
+
+  const record = await prisma.websiteContent.findUnique({ where: { key: CAPACITY_KEY } })
+  const current = parseContent(record?.content)
+  const selected = options.find((option) => option.value === current.status) || options[0]
+
+  return (
+    <div className="space-y-6">
+      <header className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-3xl font-semibold text-slate-950">Capacidad</h1>
+        <p className="mt-2 text-sm leading-6 text-slate-600">
+          Semaforo operativo para decidir que trabajos tomar esta semana.
+        </p>
+      </header>
+
+      <section className={`rounded-2xl border p-5 shadow-sm ${selected.className}`}>
+        <p className="text-xs font-semibold uppercase tracking-[0.18em]">Estado actual</p>
+        <h2 className="mt-2 text-3xl font-semibold">{selected.label}</h2>
+        <p className="mt-2 text-sm">{selected.meaning}</p>
+        <p className="mt-4 text-xs">
+          Actualizado: {record?.updatedAt ? record.updatedAt.toLocaleString('es-AR') : 'sin actualizacion guardada'}
+        </p>
+      </section>
+
+      <FormSection title="Definir capacidad" description="Este dato es interno y no se publica en el sitio.">
+        <form action={saveCapacity} className="space-y-5">
+          <div className="grid gap-3 md:grid-cols-3">
+            {options.map((option) => (
+              <label key={option.value} className={`cursor-pointer rounded-2xl border p-4 ${option.className}`}>
+                <input
+                  type="radio"
+                  name="status"
+                  value={option.value}
+                  defaultChecked={option.value === current.status}
+                  className="mr-2"
+                />
+                <span className="font-semibold">{option.label}</span>
+                <p className="mt-2 text-sm">{option.meaning}</p>
+              </label>
+            ))}
+          </div>
+
+          <label className="block space-y-2">
+            <span className="text-sm font-semibold text-slate-700">Nota interna</span>
+            <textarea
+              name="note"
+              defaultValue={current.note}
+              rows={4}
+              className="w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none focus:border-slate-400"
+              placeholder="Ej: dos obras activas, tomar solo CABA norte y urgencias con ticket alto."
+            />
+          </label>
+
+          <Button type="submit" className="bg-slate-950 hover:bg-slate-800">Guardar capacidad</Button>
+        </form>
+      </FormSection>
+    </div>
+  )
+}

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/consultas/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/consultas/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../leads/page'

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/dinero/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/dinero/page.tsx
@@ -1,39 +1,104 @@
-const alerts = [
-  'Trabajos terminados sin cobrar.',
-  'Obras con costos altos.',
-  'Obras sin certificado reciente.',
-  'Clientes con deuda.',
-  'Gastos del mes altos.',
-  'Presupuestos aceptados sin inicio.',
-  'Solicitudes sin responder.',
-  'Trabajos fuera de zona pendientes de revision.',
-]
+import { prisma } from '@/lib/db'
+import { DB_ENABLED } from '@/lib/dbMode'
+import { FormSection } from '@/components/admin/ui/FormSection'
 
-export default function AdminDineroPage() {
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+function money(value: number | bigint) {
+  const asNumber = typeof value === 'bigint' ? Number(value) : value
+  return new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 }).format(asNumber)
+}
+
+export default async function AdminDineroPage() {
+  if (!DB_ENABLED) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-3xl font-semibold text-slate-950">Dinero</h1>
+        <p className="text-sm text-slate-600">La base de datos esta deshabilitada. No hay datos de dinero para mostrar.</p>
+      </div>
+    )
+  }
+
+  const [quotes, incomes, expenses, projectPayments, certificates] = await Promise.all([
+    prisma.quote.findMany({ include: { customer: true }, orderBy: { updatedAt: 'desc' } }),
+    prisma.income.findMany({ include: { customer: true, quote: true, job: true }, orderBy: { date: 'desc' } }),
+    prisma.expense.findMany({ orderBy: { date: 'desc' } }),
+    prisma.projectPayment.findMany(),
+    prisma.opsProgressCertificate.findMany(),
+  ])
+
+  const acceptedQuotes = quotes.filter((quote) => quote.status.toLowerCase() === 'aceptado')
+  const estimatedIncome = acceptedQuotes.reduce((sum, quote) => sum + quote.totalAmount, 0)
+  const isPaid = (status: string) => status.toLowerCase() === 'cobrado' || status.toLowerCase() === 'pagado'
+  const collectedIncome =
+    incomes.filter((income) => isPaid(income.status)).reduce((sum, income) => sum + income.amount, 0) +
+    projectPayments.filter((payment) => isPaid(payment.status)).reduce((sum, payment) => sum + payment.amount, 0) +
+    Number(certificates.filter((certificate) => certificate.paidAt).reduce((sum, certificate) => sum + certificate.amount, 0n))
+  const pendingAcceptedQuotes = acceptedQuotes.reduce((sum, quote) => {
+    const collectedForQuote = incomes
+      .filter((income) => income.quoteId === quote.id && isPaid(income.status))
+      .reduce((subtotal, income) => subtotal + income.amount, 0)
+    return sum + Math.max(quote.totalAmount - collectedForQuote, 0)
+  }, 0)
+  const pendingIncome =
+    incomes.filter((income) => !isPaid(income.status) && !income.quoteId).reduce((sum, income) => sum + income.amount, 0) +
+    pendingAcceptedQuotes
+  const expenseTotal = expenses.reduce((sum, expense) => sum + expense.amount, 0)
+
+  const recentItems = [
+    ...acceptedQuotes.slice(0, 4).map((quote) => ({
+      id: `quote-${quote.id}`,
+      concept: `Presupuesto aceptado · ${quote.customer?.name || 'Sin cliente'}`,
+      amount: quote.totalAmount,
+      status: quote.status,
+    })),
+    ...incomes.slice(0, 4).map((income) => ({
+      id: `income-${income.id}`,
+      concept: income.concept,
+      amount: income.amount,
+      status: income.status,
+    })),
+  ].slice(0, 6)
+
   return (
     <div className="space-y-6">
-      <header className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <header className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <h1 className="text-3xl font-semibold text-slate-950">Dinero</h1>
         <p className="mt-2 text-sm leading-6 text-slate-600">
-          Ingresos, gastos, cobros pendientes, resultado mensual y rentabilidad estimada por trabajo, refaccion u obra.
+          Control basico de ingresos estimados, cobrados, presupuestos aceptados, pendientes y egresos existentes.
         </p>
       </header>
-      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        {['Ingresos del mes', 'Gastos del mes', 'Resultado estimado', 'Cobros pendientes'].map((item) => (
-          <article key={item} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{item}</p>
-            <p className="mt-3 text-3xl font-semibold text-slate-950">$0</p>
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+        {[
+          ['Ingresos estimados', money(estimatedIncome)],
+          ['Ingresos cobrados', money(collectedIncome)],
+          ['Presupuestos aceptados', String(acceptedQuotes.length)],
+          ['Pendientes de cobro', money(pendingIncome)],
+          ['Egresos', money(expenseTotal)],
+        ].map(([label, value]) => (
+          <article key={label} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{label}</p>
+            <p className="mt-3 text-2xl font-semibold text-slate-950">{value}</p>
           </article>
         ))}
       </section>
-      <section className="rounded-2xl border border-slate-200 bg-slate-950 p-5 text-white shadow-sm">
-        <h2 className="text-xl font-semibold text-white">Alertas financieras</h2>
-        <div className="mt-4 grid gap-3 md:grid-cols-2">
-          {alerts.map((alert) => (
-            <p key={alert} className="rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-slate-200">{alert}</p>
+
+      <FormSection title="Movimientos para revisar" description="MVP financiero: suficiente para decidir sin armar una contabilidad completa.">
+        <div className="space-y-3">
+          {recentItems.map((item) => (
+            <article key={item.id} className="flex flex-col gap-2 rounded-2xl border border-slate-200 bg-slate-50 p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="font-semibold text-slate-950">{item.concept}</p>
+                <p className="text-sm text-slate-600">{item.status}</p>
+              </div>
+              <p className="text-lg font-semibold text-slate-950">{money(item.amount)}</p>
+            </article>
           ))}
+          {recentItems.length === 0 ? <p className="text-sm text-slate-500">Todavia no hay movimientos para revisar.</p> : null}
         </div>
-      </section>
+      </FormSection>
     </div>
   )
 }

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/leads/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/leads/page.tsx
@@ -11,26 +11,45 @@ type SearchParams = {
   tipo?: string
   urgencia?: string
   zona?: string
+  estado?: string
 }
 
 const filters = [
-  ['Todas', '/admin/solicitudes'],
-  ['Nuevas', '/admin/solicitudes?estado=nueva'],
-  ['Trabajos chicos', '/admin/solicitudes?tipo=Trabajo chico'],
-  ['Refacciones', '/admin/solicitudes?tipo=Refaccion electrica'],
-  ['Obras', '/admin/solicitudes?tipo=Obra grande'],
-  ['Servicios especiales', '/admin/solicitudes?tipo=Servicio especial'],
-  ['Urgentes', '/admin/solicitudes?urgencia=Lo antes posible'],
-  ['A revisar por Valdir Nerin', '/admin/solicitudes?estado=revision'],
-  ['Fuera de zona', '/admin/solicitudes?zona=fuera'],
+  ['Todas', '/admin/consultas'],
+  ['Nuevo', '/admin/consultas?estado=nuevo'],
+  ['Revisado', '/admin/consultas?estado=revisado'],
+  ['Esperando respuesta', '/admin/consultas?estado=esperando respuesta'],
+  ['Presupuestado', '/admin/consultas?estado=presupuestado'],
+  ['Ganado', '/admin/consultas?estado=ganado'],
+  ['Perdido', '/admin/consultas?estado=perdido'],
+  ['Descartado', '/admin/consultas?estado=descartado'],
+  ['Urgentes', '/admin/consultas?urgencia=Lo antes posible'],
+  ['Fuera de zona', '/admin/consultas?zona=fuera'],
 ] as const
+
+const suggestedStates = ['nuevo', 'revisado', 'esperando respuesta', 'presupuestado', 'ganado', 'perdido', 'descartado']
+
+function normalizeState(value?: string | null) {
+  const normalized = String(value || 'nuevo').trim().toLowerCase()
+  if (normalized === 'nueva') return 'nuevo'
+  if (normalized === 'revision' || normalized === 'a revisar') return 'revisado'
+  return suggestedStates.includes(normalized) ? normalized : normalized || 'nuevo'
+}
+
+function resolveOrigin(record: { utmSource?: string | null; landingPage?: string | null; referrer?: string | null }) {
+  return record.utmSource || record.landingPage || record.referrer || 'Web'
+}
+
+function contactText(whatsapp?: string | null, email?: string | null) {
+  return [whatsapp, email].filter(Boolean).join(' / ') || 'Sin contacto'
+}
 
 export default async function LeadsPage({ searchParams }: { searchParams?: SearchParams }) {
   if (!DB_ENABLED) {
     return (
       <div className="space-y-4">
-        <h1 className="text-3xl font-semibold text-slate-950">Solicitudes</h1>
-        <p className="text-sm text-slate-600">La base de datos esta deshabilitada. No hay solicitudes para mostrar.</p>
+        <h1 className="text-3xl font-semibold text-slate-950">Consultas</h1>
+        <p className="text-sm text-slate-600">La base de datos esta deshabilitada. No hay consultas para mostrar.</p>
       </div>
     )
   }
@@ -39,30 +58,71 @@ export default async function LeadsPage({ searchParams }: { searchParams?: Searc
   const leadType = searchParams?.tipo
   const urgency = searchParams?.urgencia
   const zoneFilter = searchParams?.zona
+  const stateFilter = searchParams?.estado ? normalizeState(searchParams.estado) : null
 
-  const leads = await prisma.lead.findMany({
-    include: { attachments: true },
-    where: {
-      ...(leadType ? { leadType } : {}),
-      ...(urgency ? { urgency } : {}),
-      ...(zoneFilter === 'fuera'
-        ? {
-            OR: [
-              { location: { contains: 'Otra zona' } },
-              { location: { contains: 'Requiere confirmacion' } },
-            ],
-          }
-        : {}),
-    },
-    orderBy: { createdAt: 'desc' },
-  })
+  const [legacyLeads, serviceRequests] = await Promise.all([
+    prisma.lead.findMany({
+      include: { attachments: true },
+      where: {
+        ...(leadType ? { leadType } : {}),
+        ...(urgency ? { urgency } : {}),
+        ...(zoneFilter === 'fuera'
+          ? {
+              OR: [
+                { location: { contains: 'Otra zona' } },
+                { location: { contains: 'Requiere confirmacion' } },
+              ],
+            }
+          : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.serviceRequest.findMany({
+      include: { customer: true, serviceItem: true },
+      where: {
+        ...(leadType ? { type: leadType } : {}),
+        ...(urgency ? { urgency } : {}),
+        ...(zoneFilter === 'fuera' ? { zone: { contains: 'fuera' } } : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+    }),
+  ])
+
+  const rows = [
+    ...serviceRequests.map((request) => ({
+      id: `service-${request.id}`,
+      date: request.createdAt,
+      name: request.customerName || request.customer?.name || 'Sin nombre',
+      contact: contactText(request.whatsapp, request.email),
+      type: request.type || request.serviceItem?.name || 'Consulta',
+      zone: request.zone || 'Sin zona',
+      urgency: request.urgency || 'Sin urgencia',
+      origin: 'Presupuestador web',
+      state: normalizeState(request.status),
+      work: request.serviceItem?.name || request.selectedVariant || request.description || 'Sin detalle',
+    })),
+    ...legacyLeads.map((lead) => ({
+      id: `lead-${lead.id}`,
+      date: lead.createdAt,
+      name: lead.name,
+      contact: contactText(lead.phone, lead.email),
+      type: lead.leadType || lead.workType || 'Consulta',
+      zone: lead.location,
+      urgency: lead.urgency,
+      origin: resolveOrigin(lead),
+      state: 'nuevo',
+      work: lead.workType || lead.details || 'Sin detalle',
+    })),
+  ]
+    .filter((row) => (stateFilter ? row.state === stateFilter : true))
+    .sort((a, b) => b.date.getTime() - a.date.getTime())
 
   return (
     <div className="space-y-8">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
-          <h1 className="text-3xl font-semibold text-slate-950">Solicitudes</h1>
-          <p className="text-sm text-slate-600">Pedidos recibidos desde la web, WhatsApp o carga manual.</p>
+          <h1 className="text-3xl font-semibold text-slate-950">Consultas</h1>
+          <p className="text-sm text-slate-600">Leads entrantes ordenados por fecha, origen, urgencia y estado.</p>
         </div>
         <Button asChild className="bg-slate-950 hover:bg-slate-800">
           <a href="/presupuestador" target="_blank">Crear solicitud manual</a>
@@ -77,49 +137,43 @@ export default async function LeadsPage({ searchParams }: { searchParams?: Searc
         ))}
       </div>
 
-      <FormSection title="Tabla de solicitudes" description="Prioriza urgentes, fuera de zona y pedidos a revisar por Valdir Nerin.">
+      <FormSection title="Entradas recibidas" description="Cada fila muestra que pidio el cliente, por donde entro y en que estado esta.">
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[980px] text-left text-sm">
+          <table className="w-full min-w-[1100px] text-left text-sm">
             <thead className="text-xs uppercase tracking-[0.16em] text-slate-500">
               <tr>
-                <th className="border-b border-slate-200 py-3">Cliente</th>
+                <th className="border-b border-slate-200 py-3">Fecha</th>
+                <th className="border-b border-slate-200 py-3">Nombre</th>
+                <th className="border-b border-slate-200 py-3">WhatsApp/email</th>
                 <th className="border-b border-slate-200 py-3">Tipo</th>
-                <th className="border-b border-slate-200 py-3">Servicio/trabajo</th>
                 <th className="border-b border-slate-200 py-3">Zona</th>
                 <th className="border-b border-slate-200 py-3">Urgencia</th>
+                <th className="border-b border-slate-200 py-3">Origen</th>
                 <th className="border-b border-slate-200 py-3">Estado</th>
-                <th className="border-b border-slate-200 py-3">Fecha</th>
-                <th className="border-b border-slate-200 py-3">Accion</th>
               </tr>
             </thead>
             <tbody>
-              {leads.map((lead) => (
-                <tr key={lead.id} className="border-b border-slate-100 align-top">
+              {rows.map((row) => (
+                <tr key={row.id} className="border-b border-slate-100 align-top">
+                  <td className="py-3 text-slate-600">{row.date.toLocaleString('es-AR')}</td>
                   <td className="py-3">
-                    <p className="font-semibold text-slate-950">{lead.name}</p>
-                    <p className="text-xs text-slate-500">{lead.phone}</p>
+                    <p className="font-semibold text-slate-950">{row.name}</p>
+                    <p className="text-xs text-slate-500">{row.work}</p>
                   </td>
-                  <td className="py-3 text-slate-600">{lead.leadType ?? 'Solicitud'}</td>
-                  <td className="py-3 text-slate-600">{lead.workType}</td>
-                  <td className="py-3 text-slate-600">{lead.location}</td>
-                  <td className="py-3 text-slate-600">{lead.urgency}</td>
+                  <td className="py-3 text-slate-600">{row.contact}</td>
+                  <td className="py-3 text-slate-600">{row.type}</td>
+                  <td className="py-3 text-slate-600">{row.zone}</td>
+                  <td className="py-3 text-slate-600">{row.urgency}</td>
+                  <td className="py-3 text-slate-600">{row.origin}</td>
                   <td className="py-3">
-                    <span className="rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700">Nueva</span>
-                  </td>
-                  <td className="py-3 text-slate-600">{new Date(lead.createdAt).toLocaleString('es-AR')}</td>
-                  <td className="py-3">
-                    <div className="flex flex-wrap gap-2">
-                      <Button size="sm" variant="outline">Responder</Button>
-                      <Button size="sm" variant="outline">Pedir fotos</Button>
-                      <Button size="sm" className="bg-slate-950 hover:bg-slate-800">Crear presupuesto</Button>
-                    </div>
+                    <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">{row.state}</span>
                   </td>
                 </tr>
               ))}
-              {leads.length === 0 ? (
+              {rows.length === 0 ? (
                 <tr>
                   <td colSpan={8} className="py-8 text-center text-sm text-slate-500">
-                    Todavia no hay solicitudes. Cuando un cliente pida un trabajo desde la web, va a aparecer aca. Tambien podes cargar una solicitud manual recibida por WhatsApp.
+                    Todavia no hay consultas con estos filtros. Cuando un cliente pida un trabajo desde la web, WhatsApp o carga manual, va a aparecer aca.
                   </td>
                 </tr>
               ) : null}

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/obras/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/obras/page.tsx
@@ -1,32 +1,122 @@
-const tabs = ['Resumen', 'Avances', 'Certificados', 'Materiales', 'Jornales', 'Gastos', 'Adicionales', 'Cobros', 'Equipo', 'Cliente', 'Notas']
+import { prisma } from '@/lib/db'
+import { DB_ENABLED } from '@/lib/dbMode'
+import { FormSection } from '@/components/admin/ui/FormSection'
 
-export default function AdminObrasPage() {
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+function money(value: number | bigint) {
+  const asNumber = typeof value === 'bigint' ? Number(value) : value
+  return new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 }).format(asNumber)
+}
+
+export default async function AdminObrasPage() {
+  if (!DB_ENABLED) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-3xl font-semibold text-slate-950">Obras</h1>
+        <p className="text-sm text-slate-600">La base de datos esta deshabilitada. No hay obras para mostrar.</p>
+      </div>
+    )
+  }
+
+  const [opsProjects, legacyProjects] = await Promise.all([
+    prisma.opsProject.findMany({
+      include: { client: true, certificates: true, additionals: true },
+      orderBy: { updatedAt: 'desc' },
+    }),
+    prisma.project.findMany({
+      include: { client: { include: { user: true } }, progressCertificates: true, invoices: true, projectPayments: true },
+      orderBy: { updatedAt: 'desc' },
+    }),
+  ])
+
+  const rows = [
+    ...opsProjects.map((project) => ({
+      id: `ops-${project.id}`,
+      name: `${project.client.name} / ${project.title}`,
+      stage: project.status,
+      progress: `${project.progressPercent}%`,
+      certificates: `${project.certificates.length} certificados`,
+      docs: project.additionals.length ? `${project.additionals.length} adicionales` : 'Documentacion pendiente',
+      payments: money(project.certificates.reduce((sum, item) => sum + (item.paidAt ? item.amount : 0n), 0n)),
+      next: project.notes || 'Definir proximo hito',
+    })),
+    ...legacyProjects.map((project) => ({
+      id: `legacy-${project.id}`,
+      name: `${project.client.user.name || project.client.user.email} / ${project.nombre}`,
+      stage: project.estado,
+      progress: `${project.avanceCertificado}% certificado`,
+      certificates: `${project.progressCertificates.length} certificados`,
+      docs: project.invoices.length ? `${project.invoices.length} comprobantes` : 'Documentacion pendiente',
+      payments: money(project.projectPayments.reduce((sum, item) => sum + item.amount, 0)),
+      next: project.fechaFinEstimada ? `Hito estimado: ${project.fechaFinEstimada.toLocaleDateString('es-AR')}` : 'Definir proximo hito',
+    })),
+  ]
+
+  const activeCount = rows.length
+
   return (
     <div className="space-y-6">
-      <header className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <header className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <h1 className="text-3xl font-semibold text-slate-950">Obras</h1>
         <p className="mt-2 text-sm leading-6 text-slate-600">
-          Gestion de obras grandes, costos, avance, certificados y cobros.
+          Proyectos grandes con etapa, avance, certificados, documentacion, pagos y proximos hitos.
         </p>
       </header>
-      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        {['Obras activas', 'Total certificado', 'Total cobrado', 'Saldo pendiente', 'Costos cargados', 'Resultado estimado'].map((item) => (
-          <article key={item} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{item}</p>
-            <p className="mt-3 text-3xl font-semibold text-slate-950">0</p>
-          </article>
-        ))}
+
+      <section className="grid gap-4 sm:grid-cols-3">
+        <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Obras activas</p>
+          <p className="mt-3 text-3xl font-semibold text-slate-950">{activeCount}</p>
+        </article>
+        <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Con certificados</p>
+          <p className="mt-3 text-3xl font-semibold text-slate-950">{rows.filter((row) => !row.certificates.startsWith('0')).length}</p>
+        </article>
+        <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Hitos a revisar</p>
+          <p className="mt-3 text-3xl font-semibold text-slate-950">{rows.filter((row) => row.next.includes('Definir')).length}</p>
+        </article>
       </section>
-      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="text-xl font-semibold text-slate-950">Ficha de obra preparada</h2>
-        <div className="mt-4 flex flex-wrap gap-2">
-          {tabs.map((tab) => (
-            <span key={tab} className="rounded-full border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-600">
-              {tab}
-            </span>
-          ))}
+
+      <FormSection title="Proyectos grandes" description="Para seguimiento de obra, certificacion y pagos sin mezclar trabajos chicos.">
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[1000px] text-left text-sm">
+            <thead className="text-xs uppercase tracking-[0.16em] text-slate-500">
+              <tr>
+                <th className="border-b border-slate-200 py-3">Cliente/proyecto</th>
+                <th className="border-b border-slate-200 py-3">Etapa</th>
+                <th className="border-b border-slate-200 py-3">Avance</th>
+                <th className="border-b border-slate-200 py-3">Certificados</th>
+                <th className="border-b border-slate-200 py-3">Documentacion</th>
+                <th className="border-b border-slate-200 py-3">Pagos</th>
+                <th className="border-b border-slate-200 py-3">Proximos hitos</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id} className="border-b border-slate-100 align-top">
+                  <td className="py-3 font-semibold text-slate-950">{row.name}</td>
+                  <td className="py-3 text-slate-600">{row.stage}</td>
+                  <td className="py-3 text-slate-600">{row.progress}</td>
+                  <td className="py-3 text-slate-600">{row.certificates}</td>
+                  <td className="py-3 text-slate-600">{row.docs}</td>
+                  <td className="py-3 text-slate-600">{row.payments}</td>
+                  <td className="py-3 text-slate-600">{row.next}</td>
+                </tr>
+              ))}
+              {rows.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="py-8 text-center text-sm text-slate-500">
+                    Todavia no hay obras cargadas.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
         </div>
-      </section>
+      </FormSection>
     </div>
   )
 }

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/presupuestos/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/presupuestos/page.tsx
@@ -1,24 +1,85 @@
-const states = ['Borrador', 'Enviado', 'Esperando respuesta', 'Aceptado', 'Rechazado', 'Vencido']
+import { prisma } from '@/lib/db'
+import { DB_ENABLED } from '@/lib/dbMode'
+import { FormSection } from '@/components/admin/ui/FormSection'
 
-export default function AdminPresupuestosPage() {
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+const states = ['borrador', 'enviado', 'aceptado', 'rechazado', 'vencido']
+
+function money(value: number) {
+  return new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 }).format(value)
+}
+
+export default async function AdminPresupuestosPage() {
+  if (!DB_ENABLED) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-3xl font-semibold text-slate-950">Presupuestos</h1>
+        <p className="text-sm text-slate-600">La base de datos esta deshabilitada. No hay presupuestos para mostrar.</p>
+      </div>
+    )
+  }
+
+  const quotes = await prisma.quote.findMany({
+    include: { customer: true, jobs: true },
+    orderBy: { createdAt: 'desc' },
+  })
+
   return (
     <div className="space-y-6">
-      <header className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <header className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <h1 className="text-3xl font-semibold text-slate-950">Presupuestos</h1>
         <p className="mt-2 text-sm leading-6 text-slate-600">
-          Presupuestos para trabajos chicos, refacciones y obras con mano de obra, materiales, viaticos, adicionales y validez.
+          Control simple de presupuestos por cliente, tipo, monto, estado, fecha y trabajo asociado.
         </p>
       </header>
-      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="text-xl font-semibold text-slate-950">Estados</h2>
-        <div className="mt-4 flex flex-wrap gap-2">
-          {states.map((state) => (
-            <span key={state} className="rounded-full border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-600">
-              {state}
-            </span>
-          ))}
-        </div>
+
+      <section className="flex flex-wrap gap-2">
+        {states.map((state) => (
+          <span key={state} className="rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-600">
+            {state}
+          </span>
+        ))}
       </section>
+
+      <FormSection title="Presupuestos cargados" description="Estados usados: borrador, enviado, aceptado, rechazado y vencido.">
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[900px] text-left text-sm">
+            <thead className="text-xs uppercase tracking-[0.16em] text-slate-500">
+              <tr>
+                <th className="border-b border-slate-200 py-3">Cliente</th>
+                <th className="border-b border-slate-200 py-3">Tipo</th>
+                <th className="border-b border-slate-200 py-3">Monto</th>
+                <th className="border-b border-slate-200 py-3">Estado</th>
+                <th className="border-b border-slate-200 py-3">Fecha</th>
+                <th className="border-b border-slate-200 py-3">Trabajo asociado</th>
+              </tr>
+            </thead>
+            <tbody>
+              {quotes.map((quote) => (
+                <tr key={quote.id} className="border-b border-slate-100 align-top">
+                  <td className="py-3 font-semibold text-slate-950">{quote.customer?.name || 'Sin cliente'}</td>
+                  <td className="py-3 text-slate-600">{quote.serviceType}</td>
+                  <td className="py-3 text-slate-600">{money(quote.totalAmount)}</td>
+                  <td className="py-3">
+                    <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">{quote.status}</span>
+                  </td>
+                  <td className="py-3 text-slate-600">{quote.createdAt.toLocaleDateString('es-AR')}</td>
+                  <td className="py-3 text-slate-600">{quote.jobs[0]?.title || 'Sin trabajo creado'}</td>
+                </tr>
+              ))}
+              {quotes.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="py-8 text-center text-sm text-slate-500">
+                    Todavia no hay presupuestos cargados.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </FormSection>
     </div>
   )
 }

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/refacciones/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/refacciones/page.tsx
@@ -1,47 +1,77 @@
-import { renovationCards } from '@/lib/nerin-electricidad'
+import { prisma } from '@/lib/db'
+import { DB_ENABLED } from '@/lib/dbMode'
+import { FormSection } from '@/components/admin/ui/FormSection'
 
-const states = [
-  'Nueva solicitud',
-  'Relevamiento pendiente',
-  'Faltan datos',
-  'Presupuestando',
-  'Presupuesto enviado',
-  'Aceptado',
-  'Coordinado',
-  'En curso',
-  'Terminado',
-  'Cobrada',
-  'Cerrada',
-  'Cancelada',
-]
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
 
-export default function AdminRefaccionesPage() {
+function money(value: number) {
+  return value > 0
+    ? new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 }).format(value)
+    : 'Pendiente'
+}
+
+export default async function AdminRefaccionesPage() {
+  if (!DB_ENABLED) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-3xl font-semibold text-slate-950">Refacciones</h1>
+        <p className="text-sm text-slate-600">La base de datos esta deshabilitada. No hay refacciones para mostrar.</p>
+      </div>
+    )
+  }
+
+  const jobs = await prisma.renovationJob.findMany({
+    include: { customer: true, request: true },
+    orderBy: { updatedAt: 'desc' },
+  })
+
   return (
     <div className="space-y-6">
-      <header className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <header className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <h1 className="text-3xl font-semibold text-slate-950">Refacciones</h1>
         <p className="mt-2 text-sm leading-6 text-slate-600">
-          Trabajos medianos, reformas parciales, ampliaciones e instalaciones electricas por ambiente.
+          Trabajos medianos: cliente, propiedad, alcance, relevamiento, presupuesto, estado y proximos pasos.
         </p>
       </header>
-      <section className="grid gap-4 md:grid-cols-2">
-        {renovationCards.map((item) => (
-          <article key={item.title} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-            <h2 className="text-xl font-semibold text-slate-950">{item.title}</h2>
-            <p className="mt-2 text-sm text-slate-600">{item.description}</p>
-          </article>
-        ))}
-      </section>
-      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="text-xl font-semibold text-slate-950">Estados de refaccion</h2>
-        <div className="mt-4 flex flex-wrap gap-2">
-          {states.map((state) => (
-            <span key={state} className="rounded-full border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-600">
-              {state}
-            </span>
-          ))}
+
+      <FormSection title="Trabajos medianos" description="Separado de trabajos chicos y obras grandes para priorizar mejor.">
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[980px] text-left text-sm">
+            <thead className="text-xs uppercase tracking-[0.16em] text-slate-500">
+              <tr>
+                <th className="border-b border-slate-200 py-3">Cliente</th>
+                <th className="border-b border-slate-200 py-3">Propiedad</th>
+                <th className="border-b border-slate-200 py-3">Alcance</th>
+                <th className="border-b border-slate-200 py-3">Relevamiento</th>
+                <th className="border-b border-slate-200 py-3">Presupuesto</th>
+                <th className="border-b border-slate-200 py-3">Estado</th>
+                <th className="border-b border-slate-200 py-3">Proximos pasos</th>
+              </tr>
+            </thead>
+            <tbody>
+              {jobs.map((job) => (
+                <tr key={job.id} className="border-b border-slate-100 align-top">
+                  <td className="py-3 font-semibold text-slate-950">{job.customer?.name || job.request?.customerName || 'Sin cliente'}</td>
+                  <td className="py-3 text-slate-600">{job.propertyType || job.address || 'Sin propiedad'}</td>
+                  <td className="py-3 text-slate-600">{job.scope || `${job.rooms} ambientes · ${job.estimatedPoints} puntos`}</td>
+                  <td className="py-3 text-slate-600">{job.currentInstallationState || 'Pendiente'}</td>
+                  <td className="py-3 text-slate-600">{job.quoteStatus} · {money(job.estimatedLabor + job.estimatedMaterials)}</td>
+                  <td className="py-3 text-slate-600">{job.jobStatus}</td>
+                  <td className="py-3 text-slate-600">{job.notes || 'Definir visita, fotos o cierre comercial'}</td>
+                </tr>
+              ))}
+              {jobs.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="py-8 text-center text-sm text-slate-500">
+                    Todavia no hay refacciones cargadas.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
         </div>
-      </section>
+      </FormSection>
     </div>
   )
 }

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/trabajos-chicos/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/trabajos-chicos/page.tsx
@@ -1,55 +1,108 @@
-import { serviceCatalog } from '@/lib/nerin-electricidad'
+import { prisma } from '@/lib/db'
+import { DB_ENABLED } from '@/lib/dbMode'
+import { FormSection } from '@/components/admin/ui/FormSection'
 
-export default function AdminTrabajosChicosPage() {
-  return (
-    <AdminSection
-      title="Trabajos chicos"
-      subtitle="Servicios puntuales, reparaciones, instalaciones menores y diagnosticos."
-      tabs={['Solicitudes', 'Trabajos activos', 'Catalogo de trabajos', 'Precios y variantes', 'Zonas']}
-      rows={serviceCatalog.map((item) => ({
-        main: item.name,
-        meta: item.category,
-        detail: `${item.priceFrom ?? 'A presupuestar'} · ${item.estimatedDuration} · ${item.zone}`,
-      }))}
-    />
-  )
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+function money(value: number) {
+  return value > 0
+    ? new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 }).format(value)
+    : 'A definir'
 }
 
-function AdminSection({
-  title,
-  subtitle,
-  tabs,
-  rows,
-}: {
-  title: string
-  subtitle: string
-  tabs: string[]
-  rows: Array<{ main: string; meta: string; detail: string }>
-}) {
+export default async function AdminTrabajosChicosPage() {
+  if (!DB_ENABLED) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-3xl font-semibold text-slate-950">Trabajos chicos</h1>
+        <p className="text-sm text-slate-600">La base de datos esta deshabilitada. No hay trabajos para mostrar.</p>
+      </div>
+    )
+  }
+
+  const [jobs, catalog] = await Promise.all([
+    prisma.smallJob.findMany({
+      include: { customer: true, request: true, serviceItem: true },
+      orderBy: { updatedAt: 'desc' },
+    }),
+    prisma.serviceCatalogItem.findMany({
+      where: { visible: true },
+      orderBy: { name: 'asc' },
+      take: 12,
+    }),
+  ])
+
+  const rows = jobs.length
+    ? jobs.map((job) => ({
+        id: job.id,
+        service: job.title || job.serviceItem?.name || 'Trabajo chico',
+        priceFrom: money(job.estimatedPrice || job.serviceItem?.priceFrom || 0),
+        zone: job.request?.zone || job.serviceItem?.enabledZone || job.address || 'Sin zona',
+        technician: job.technician || 'Sin asignar',
+        status: job.status,
+        payment: job.collectedAmount > 0 ? money(job.collectedAmount) : 'Pendiente',
+        close: job.finalPrice > 0 && job.collectedAmount >= job.finalPrice ? 'Cerrado' : 'Abierto',
+      }))
+    : catalog.map((item) => ({
+        id: item.id,
+        service: item.name,
+        priceFrom: money(item.priceFrom),
+        zone: item.enabledZone,
+        technician: 'Sin asignar',
+        status: 'Disponible',
+        payment: 'Sin cobro',
+        close: 'Listo para vender',
+      }))
+
   return (
     <div className="space-y-6">
-      <header className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-        <h1 className="text-3xl font-semibold text-slate-950">{title}</h1>
-        <p className="mt-2 text-sm leading-6 text-slate-600">{subtitle}</p>
+      <header className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-3xl font-semibold text-slate-950">Trabajos chicos</h1>
+        <p className="mt-2 text-sm leading-6 text-slate-600">
+          Vista rapida de servicios simples, precio desde, zona, asignacion, estado, cobro y cierre.
+        </p>
       </header>
-      <div className="flex flex-wrap gap-2">
-        {tabs.map((tab) => (
-          <span key={tab} className="rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-600">
-            {tab}
-          </span>
-        ))}
-      </div>
-      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-        <div className="space-y-3">
+
+      <FormSection title="Trabajos simples" description="Si todavia no hay trabajos activos, se muestra el catalogo vendible para operar rapido.">
+        <div className="grid gap-3 md:hidden">
           {rows.map((row) => (
-            <article key={row.main} className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
-              <p className="text-sm font-semibold text-slate-950">{row.main}</p>
-              <p className="text-xs uppercase tracking-[0.16em] text-slate-500">{row.meta}</p>
-              <p className="mt-2 text-sm text-slate-600">{row.detail}</p>
+            <article key={row.id} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+              <p className="font-semibold text-slate-950">{row.service}</p>
+              <p className="mt-1 text-sm text-slate-600">{row.priceFrom} · {row.zone}</p>
+              <p className="mt-2 text-xs text-slate-500">Asignado: {row.technician} · {row.status} · {row.payment}</p>
             </article>
           ))}
         </div>
-      </section>
+        <div className="hidden overflow-x-auto md:block">
+          <table className="w-full min-w-[900px] text-left text-sm">
+            <thead className="text-xs uppercase tracking-[0.16em] text-slate-500">
+              <tr>
+                <th className="border-b border-slate-200 py-3">Servicio</th>
+                <th className="border-b border-slate-200 py-3">Precio desde</th>
+                <th className="border-b border-slate-200 py-3">Zona</th>
+                <th className="border-b border-slate-200 py-3">Tecnico/asignado</th>
+                <th className="border-b border-slate-200 py-3">Estado</th>
+                <th className="border-b border-slate-200 py-3">Cobro</th>
+                <th className="border-b border-slate-200 py-3">Cierre</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id} className="border-b border-slate-100 align-top">
+                  <td className="py-3 font-semibold text-slate-950">{row.service}</td>
+                  <td className="py-3 text-slate-600">{row.priceFrom}</td>
+                  <td className="py-3 text-slate-600">{row.zone}</td>
+                  <td className="py-3 text-slate-600">{row.technician}</td>
+                  <td className="py-3 text-slate-600">{row.status}</td>
+                  <td className="py-3 text-slate-600">{row.payment}</td>
+                  <td className="py-3 text-slate-600">{row.close}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </FormSection>
     </div>
   )
 }

--- a/nerin-electric-site-v3-fixed/components/admin/AdminSidebar.tsx
+++ b/nerin-electric-site-v3-fixed/components/admin/AdminSidebar.tsx
@@ -16,7 +16,7 @@ export function AdminSidebar({ onNavigate, className }: AdminSidebarProps) {
   return (
     <aside className={cn('flex h-full w-72 flex-col gap-6 border-r border-border bg-white px-4 py-6', className)}>
       <div className="px-2">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">NERIN</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">NERIN Electricidad</p>
         <p className="text-sm font-semibold text-slate-700">Centro de control</p>
       </div>
       <nav className="flex flex-1 flex-col gap-5 text-sm">
@@ -48,7 +48,7 @@ export function AdminSidebar({ onNavigate, className }: AdminSidebarProps) {
         ))}
       </nav>
       <div className="rounded-2xl border border-border/60 bg-slate-50 px-3 py-2 text-xs text-slate-500">
-        Flujo recomendado: Inicio admin → editar contenido → revisar consultas.
+        Flujo recomendado: consultas, presupuestos, trabajo, dinero y capacidad.
       </div>
     </aside>
   )

--- a/nerin-electric-site-v3-fixed/components/admin/AdminTopbar.tsx
+++ b/nerin-electric-site-v3-fixed/components/admin/AdminTopbar.tsx
@@ -12,7 +12,7 @@ export function AdminTopbar({ onToggleSidebar }: AdminTopbarProps) {
   const pathname = usePathname()
   const match = findAdminNavMatch(pathname)
   const sectionLabel = match?.sectionLabel ?? adminNav[0]?.label ?? 'Admin'
-  const title = match?.title ?? 'Inicio admin'
+  const title = match?.title ?? 'Centro de control'
 
   return (
     <div className="sticky top-0 z-20 border-b border-border bg-white/95 px-4 py-3 backdrop-blur sm:px-6 sm:py-4">
@@ -22,7 +22,7 @@ export function AdminTopbar({ onToggleSidebar }: AdminTopbarProps) {
             type="button"
             onClick={onToggleSidebar}
             className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-border bg-white lg:hidden"
-            aria-label="Abrir menú de administración"
+            aria-label="Abrir menu de administracion"
           >
             <svg aria-hidden viewBox="0 0 24 24" className="h-5 w-5 stroke-current" fill="none" strokeWidth="1.8">
               <path d="M4 7h16M4 12h16M4 17h16" />
@@ -35,16 +35,16 @@ export function AdminTopbar({ onToggleSidebar }: AdminTopbarProps) {
         </div>
         <div className="flex items-center gap-2">
           <Link
-            href="/admin"
-            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
-          >
-            Centro admin
-          </Link>
-          <Link
-            href="/admin/leads"
+            href="/admin/consultas"
             className="rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
           >
             Consultas
+          </Link>
+          <Link
+            href="/admin/capacidad"
+            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+          >
+            Capacidad
           </Link>
           <Link
             href="/"

--- a/nerin-electric-site-v3-fixed/components/admin/nav.ts
+++ b/nerin-electric-site-v3-fixed/components/admin/nav.ts
@@ -12,28 +12,15 @@ export type AdminNavSection = {
 
 export const adminNav: AdminNavSection[] = [
   {
-    label: 'Panel de NERIN',
+    label: 'Centro de control',
     items: [
-      { title: 'Inicio', href: '/admin' as Route },
-      { title: 'Solicitudes', href: '/admin/solicitudes' as Route },
-    ],
-  },
-  {
-    label: 'Operacion',
-    items: [
+      { title: 'Consultas', href: '/admin/consultas' as Route },
+      { title: 'Presupuestos', href: '/admin/presupuestos' as Route },
       { title: 'Trabajos chicos', href: '/admin/trabajos-chicos' as Route },
       { title: 'Refacciones', href: '/admin/refacciones' as Route },
       { title: 'Obras', href: '/admin/obras' as Route },
-      { title: 'Clientes', href: '/admin/clientes' as Route },
-      { title: 'Presupuestos', href: '/admin/presupuestos' as Route },
-    ],
-  },
-  {
-    label: 'Gestion',
-    items: [
       { title: 'Dinero', href: '/admin/dinero' as Route },
-      { title: 'Catalogo web', href: '/admin/catalogo-web' as Route },
-      { title: 'Configuracion', href: '/admin/ajustes' as Route },
+      { title: 'Capacidad', href: '/admin/capacidad' as Route },
     ],
   },
 ]


### PR DESCRIPTION
## Resumen

Reorganiza el admin de NERIN Electricidad como centro operativo con las vistas principales pedidas: Consultas, Presupuestos, Trabajos chicos, Refacciones, Obras, Dinero y Capacidad.

## Cambios principales

- Simplifica la navegacion principal del admin a las siete vistas operativas.
- Crea `/admin/consultas` como entrada ordenada para leads y solicitudes entrantes, manteniendo `/admin/solicitudes` como alias para no romper enlaces existentes.
- Convierte Presupuestos, Trabajos chicos, Refacciones, Obras y Dinero en vistas con tablas/resumenes basados en datos existentes.
- Agrega `/admin/capacidad` con semaforo verde/amarillo/rojo, nota interna y fecha de actualizacion, persistido en `WebsiteContent` sin migracion nueva.
- Actualiza el dashboard de `/admin` para hablar en terminos de centro de control de Electricidad.

## Validacion

- `npx next lint` pasa con advertencias preexistentes de uso de `<img>`.
- `DB_ENABLED=false npx next build` pasa correctamente.

## Notas

No se borran leads ni se modifica el esquema de base de datos. El cambio evita mezclar NERIN Parts/repuestos en la navegacion principal del admin.