### PR TITLE
[codex] Corregir typedRoutes en links comerciales

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(site)/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import type { Route } from 'next'
 import { ArrowRight, CheckCircle2, MessageCircle, Search, ShieldCheck, Zap } from 'lucide-react'
 import { getSiteContent, getWhatsappHref } from '@/lib/site-content'
 import { resolveCommercialSite, type CommercialSite } from '@/lib/commercial-content'
@@ -32,6 +33,10 @@ function imageFor(site: CommercialSite, location: string, fallback: string) {
   return site.commercialImages.find((image) => image.active && image.location === location)?.url || fallback
 }
 
+function asRoute(href: string, fallback: Route = '/trabajos-electricos') {
+  return (href || fallback) as Route
+}
+
 export default async function HomePage() {
   const site = resolveCommercialSite(await getSiteContent())
   const whatsappHref = getWhatsappHref(site)
@@ -55,7 +60,7 @@ export default async function HomePage() {
             </div>
             <div className="grid gap-3 sm:flex">
               <Button asChild size="lg" className="h-12 bg-slate-950 px-6 text-base font-bold text-white hover:bg-slate-800">
-                <Link href={site.hero.primaryCta.href || '/trabajos-electricos'}>
+                <Link href={asRoute(site.hero.primaryCta.href)}>
                   <Search className="mr-2 h-5 w-5" />
                   {site.hero.primaryCta.label}
                 </Link>
@@ -113,7 +118,7 @@ export default async function HomePage() {
             <article key={item.title} className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
               <h3 className="text-2xl font-semibold text-slate-950">{item.title}</h3>
               <p className="mt-3 text-sm leading-6 text-slate-600">{item.description}</p>
-              <Link href={item.href} className="mt-5 inline-flex items-center rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white">
+              <Link href={asRoute(item.href)} className="mt-5 inline-flex items-center rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white">
                 {item.ctaLabel}
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>

--- a/nerin-electric-site-v3-fixed/app/(site)/trabajos-electricos/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/trabajos-electricos/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import type { Route } from 'next'
 import { ArrowRight, Camera, Search } from 'lucide-react'
 import { getSiteContent } from '@/lib/site-content'
 import { resolveCommercialSite } from '@/lib/commercial-content'
@@ -83,7 +84,7 @@ export default async function TrabajosElectricosPage() {
               <p><strong className="text-slate-950">Zona:</strong> {service.coverageZone}</p>
               <p><strong className="text-slate-950">Duracion:</strong> {service.estimatedDuration}</p>
             </div>
-            <Link href={`/trabajos-electricos/${service.slug}`} className="mt-5 inline-flex items-center rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white">
+            <Link href={`/trabajos-electricos/${service.slug}` as Route} className="mt-5 inline-flex items-center rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white">
               <Camera className="mr-2 h-4 w-4" />
               {service.customCta || 'Enviar fotos para cotizar'}
               <ArrowRight className="ml-2 h-4 w-4" />

--- a/nerin-electric-site-v3-fixed/components/Header.tsx
+++ b/nerin-electric-site-v3-fixed/components/Header.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import type { Route } from 'next'
 import { useEffect, useMemo, useState } from 'react'
 import { Menu, MessageCircle, X, Zap } from 'lucide-react'
 import { Logo } from './Logo'
@@ -30,6 +31,10 @@ const navigation = [
 ] as const
 
 const fallbackMessages = ['Visita tecnica desde $80.000', 'Precios orientativos online', 'CABA y GBA', 'Envia fotos por WhatsApp']
+
+function asRoute(href: string) {
+  return href as Route
+}
 
 export function Header({ contact, logo, commercialBar }: HeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false)
@@ -61,7 +66,7 @@ export function Header({ contact, logo, commercialBar }: HeaderProps) {
                 ))}
               </div>
               {commercialBar?.optionalLinkHref && commercialBar.optionalLinkLabel ? (
-                <Link href={commercialBar.optionalLinkHref} className="text-amber-200 underline-offset-4 hover:underline">
+                <Link href={asRoute(commercialBar.optionalLinkHref)} className="text-amber-200 underline-offset-4 hover:underline">
                   {commercialBar.optionalLinkLabel}
                 </Link>
               ) : null}
@@ -73,7 +78,7 @@ export function Header({ contact, logo, commercialBar }: HeaderProps) {
                 {barMessages[activeMessage] ?? barMessages[0]}
               </span>
               {commercialBar?.optionalLinkHref && commercialBar.optionalLinkLabel ? (
-                <Link href={commercialBar.optionalLinkHref} className="hidden text-amber-200 underline-offset-4 hover:underline sm:inline-flex">
+                <Link href={asRoute(commercialBar.optionalLinkHref)} className="hidden text-amber-200 underline-offset-4 hover:underline sm:inline-flex">
                   {commercialBar.optionalLinkLabel}
                 </Link>
               ) : null}
@@ -87,7 +92,7 @@ export function Header({ contact, logo, commercialBar }: HeaderProps) {
                 </span>
               ))}
               {commercialBar?.optionalLinkHref && commercialBar.optionalLinkLabel ? (
-                <Link href={commercialBar.optionalLinkHref} className="inline-flex whitespace-nowrap text-amber-200 underline-offset-4 hover:underline">
+                <Link href={asRoute(commercialBar.optionalLinkHref)} className="inline-flex whitespace-nowrap text-amber-200 underline-offset-4 hover:underline">
                   {commercialBar.optionalLinkLabel}
                 </Link>
               ) : null}


### PR DESCRIPTION
## Que cambia

- Corrige el error de build de Next `Type 'string' is not assignable to type 'UrlObject | RouteImpl<string>'` en el CTA principal de la home.
- Agrega casts controlados a `Route` para links comerciales editables en la home.
- Aplica el mismo ajuste a links dinamicos de servicios en `/trabajos-electricos` y links opcionales de la franja comercial.

## Por que

Con `typedRoutes` activo, `next/link` no acepta strings genericos provenientes del contenido administrable. Los href editables deben convertirse explicitamente a `Route` cuando se pasan a `Link`.

## Validacion

- Revise el log de Render compartido: el fallo ocurre en `app/(site)/page.tsx:58`.
- Compare la rama contra `main`: solo toca 3 archivos relacionados con esos links.
- No pude correr build local porque el entorno no tiene `git` ni dependencias del repo instaladas.