### PR TITLE
Add interactive SmallJobsExperience page with estimators and data for small electrical services

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(site)/trabajos-electricos/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/trabajos-electricos/page.tsx
@@ -1,122 +1,26 @@
-import Link from 'next/link'
-import type { Route } from 'next'
-import { ArrowRight, Camera, Search } from 'lucide-react'
-import { getSiteContent } from '@/lib/site-content'
-import { resolveCommercialSite } from '@/lib/commercial-content'
+import { SmallJobsExperience } from '@/components/electrical-services/SmallJobsExperience'
 import { breadcrumbJsonLd, buildSeoMetadata } from '@/lib/seo'
 
 export const metadata = buildSeoMetadata({
-  title: 'Trabajos electricos chicos con precios orientativos | NERIN',
+  title: 'Servicios eléctricos con alcance claro | NERIN Electricidad',
   description:
-    'Cambio de tomacorriente, llave de luz, revision de tablero, fallas, luminarias y diagnostico electrico en CABA y GBA con precio desde y cotizacion por fotos.',
+    'Catálogo de servicios rápidos, configurador de instalaciones, diagnóstico de fallas y solicitudes para comercios con valores orientativos sujetos a validación técnica.',
   path: '/trabajos-electricos',
 })
 
-function money(value: number, currency: string) {
-  return new Intl.NumberFormat('es-AR', { style: 'currency', currency, maximumFractionDigits: 0 }).format(value)
-}
-
-function priceLabel(service: { showPrice: boolean; priceFrom: number }, currency: string) {
-  if (!service.showPrice || !service.priceFrom) return 'A confirmar'
-  return `Desde ${money(service.priceFrom, currency)}`
-}
-
-export default async function TrabajosElectricosPage() {
-  const site = resolveCommercialSite(await getSiteContent())
-  const services = site.smallServices.filter((service) => service.active).sort((a, b) => a.order - b.order)
-  const categories = Array.from(new Set(services.map((service) => service.category)))
+export default function TrabajosElectricosPage() {
   const breadcrumbs = breadcrumbJsonLd([
     { name: 'Inicio', path: '/' },
     { name: 'Trabajos electricos', path: '/trabajos-electricos' },
   ])
 
   return (
-    <div className="bg-white">
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }} />
-      <section className="border-b border-slate-200 bg-slate-50 py-10">
-        <div className="container max-w-5xl">
-          <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-500">Trabajos chicos con precios</p>
-          <h1 className="mt-3 text-4xl font-semibold text-slate-950 sm:text-5xl">Pedi un trabajo electrico simple sin vueltas.</h1>
-          <p className="mt-4 max-w-3xl text-lg leading-8 text-slate-600">
-            Tomas, llaves de luz, fallas, tableros, luminarias, puesta a tierra y diagnosticos. Si el trabajo es simple,
-            te mostramos un precio orientativo. Si es complejo, lo revisamos antes de presupuestar.
-          </p>
-          <div className="mt-6 grid gap-3 rounded-lg border border-amber-200 bg-white p-4 sm:grid-cols-[0.8fr_1.2fr]">
-            <div>
-              <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-500">Visita técnica</p>
-              <p className="mt-1 text-2xl font-semibold text-slate-950">
-                Desde {money(site.pricingRules.technicalVisitFrom, site.pricingRules.currency)}
-              </p>
-            </div>
-            <p className="text-sm leading-6 text-slate-600">{site.pricingRules.priceDisclaimer}</p>
-          </div>
-          <div className="mt-5 flex items-center gap-3 rounded-lg border border-slate-200 bg-white px-4 py-3 text-slate-500">
-            <Search className="h-5 w-5" />
-            <span className="text-sm">Buscá por categoría o elegí la ficha más parecida a tu pedido y enviá fotos.</span>
-          </div>
-        </div>
-      </section>
-
-      <section className="container py-6">
-        <div className="flex flex-wrap gap-2">
-          {categories.map((category) => (
-            <a key={category} href={`#${category.toLowerCase().replace(/\s+/g, '-')}`} className="rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-600 hover:border-slate-950">
-              {category}
-            </a>
-          ))}
-        </div>
-      </section>
-
-      <section className="container grid gap-4 pb-12 md:grid-cols-2 xl:grid-cols-3">
-        {services.map((service) => (
-          <article key={service.slug} id={service.category.toLowerCase().replace(/\s+/g, '-')} className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
-            <div className="flex items-start justify-between gap-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{service.category}</p>
-              {service.featured ? <span className="rounded-full bg-amber-100 px-2 py-1 text-[10px] font-bold uppercase tracking-[0.12em] text-amber-800">Destacado</span> : null}
-            </div>
-            <h2 className="mt-2 text-xl font-semibold text-slate-950">{service.name}</h2>
-            <p className="mt-2 text-sm leading-6 text-slate-600">{service.shortDescription}</p>
-            <div className="mt-4 grid gap-2 text-sm text-slate-600">
-              <p><strong className="text-slate-950">Precio:</strong> {priceLabel(service, site.pricingRules.currency)}</p>
-              <p><strong className="text-slate-950">Incluye:</strong> {service.includes.slice(0, 2).join(', ')}</p>
-              <p><strong className="text-slate-950">No incluye:</strong> {service.excludes.slice(0, 2).join(', ')}</p>
-              <p><strong className="text-slate-950">Puede cambiar por:</strong> {service.priceChanges.slice(0, 2).join(', ')}</p>
-              <p><strong className="text-slate-950">Zona:</strong> {service.coverageZone}</p>
-              <p><strong className="text-slate-950">Duracion:</strong> {service.estimatedDuration}</p>
-              <p><strong className="text-slate-950">Visita técnica:</strong> {service.requiresVisit ? 'Requerida' : 'No siempre es necesaria'}</p>
-              <p><strong className="text-slate-950">Cotización por fotos:</strong> {service.quoteByPhotos ? 'Disponible' : 'Requiere revisión previa'}</p>
-            </div>
-            <Link href={`/trabajos-electricos/${service.slug}` as Route} className="mt-5 inline-flex items-center rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white">
-              <Camera className="mr-2 h-4 w-4" />
-              {service.customCta || 'Enviar fotos para cotizar'}
-              <ArrowRight className="ml-2 h-4 w-4" />
-            </Link>
-          </article>
-        ))}
-      </section>
-
-      <section className="border-y border-slate-200 bg-slate-950 py-10 text-white">
-        <div className="container grid gap-5 lg:grid-cols-[0.75fr_1.25fr]">
-          <div>
-            <p className="text-xs font-bold uppercase tracking-[0.22em] text-amber-300">Costos adicionales</p>
-            <h2 className="mt-2 text-3xl font-semibold">Lo que puede modificar el precio</h2>
-          </div>
-          <div className="grid gap-3 md:grid-cols-2">
-            {site.additionalCosts
-              .filter((cost) => cost.active)
-              .sort((a, b) => a.order - b.order)
-              .slice(0, 6)
-              .map((cost) => (
-                <div key={cost.name} className="rounded-lg border border-white/10 bg-white/5 p-4">
-                  <p className="font-semibold text-white">{cost.name}</p>
-                  <p className="mt-1 text-sm leading-6 text-slate-300">{cost.description}</p>
-                  <p className="mt-2 text-xs font-semibold uppercase tracking-[0.14em] text-amber-200">{cost.appliesWhen}</p>
-                </div>
-              ))}
-          </div>
-        </div>
-      </section>
-    </div>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }}
+      />
+      <SmallJobsExperience />
+    </>
   )
 }
-

--- a/nerin-electric-site-v3-fixed/components/electrical-services/SmallJobsExperience.tsx
+++ b/nerin-electric-site-v3-fixed/components/electrical-services/SmallJobsExperience.tsx
@@ -1,0 +1,747 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { CheckCircle2, ClipboardList, Settings2, Store, Wrench, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  commercialServices,
+  currency,
+  diagnosticFaults,
+  quickServices,
+  type ElectricalService,
+} from '@/data/electricalServices'
+import { generateTechnicalSummary, type InstallationSelection } from './estimateRules'
+
+function money(value: number) {
+  return new Intl.NumberFormat('es-AR', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 0,
+  }).format(value)
+}
+
+const pointTypes = [
+  'toma común 10A',
+  'toma 20A',
+  'toma para aire acondicionado',
+  'punto de iluminación',
+  'llave de luz',
+  'circuito dedicado',
+  'tablero / protección',
+]
+const installationTypes = [
+  'sobre punto existente',
+  'sobre cañería existente',
+  'exterior con caño/cablecanal',
+  'embutida con canalización ya hecha',
+  'embutida completa',
+  'solo cableado y conexionado',
+]
+const distances = ['hasta 3 m', '3 a 6 m', '6 a 10 m', 'más de 10 m']
+const propertyTypes = [
+  'departamento',
+  'casa',
+  'local comercial',
+  'oficina',
+  'consorcio',
+  'country / barrio privado',
+]
+const urgencies = ['normal', 'prioritaria', 'fuera de horario']
+
+const entryCards = [
+  {
+    href: '#servicios-rapidos',
+    title: 'Servicios rápidos',
+    text: 'Reemplazos simples sobre puntos existentes.',
+    Icon: Wrench,
+  },
+  {
+    href: '#instalaciones-configurables',
+    title: 'Instalaciones configurables',
+    text: 'Nuevos puntos, recorridos, canalización o circuito.',
+    Icon: Settings2,
+  },
+  {
+    href: '#diagnostico-de-fallas',
+    title: 'Diagnóstico de fallas',
+    text: 'Búsqueda técnica de problemas eléctricos.',
+    Icon: ClipboardList,
+  },
+  {
+    href: '#comercios-consorcios',
+    title: 'Comercios / consorcios / barrios privados',
+    text: 'Pedidos repetitivos, acceso, horarios y autorizaciones.',
+    Icon: Store,
+  },
+]
+
+type RequestItem = { id: string; title: string; quantity: number; labor: number; note: string }
+
+function SelectField({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string
+  value: string
+  options: string[]
+  onChange: (value: string) => void
+}) {
+  return (
+    <label className="space-y-2 text-sm font-semibold text-slate-800">
+      <span>{label}</span>
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-12 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-900/10"
+      >
+        {options.map((option) => (
+          <option key={option}>{option}</option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function DetailList({ title, items }: { title: string; items: string[] }) {
+  return (
+    <div>
+      <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">{title}</p>
+      <ul className="mt-2 space-y-1 text-sm leading-6 text-slate-600">
+        {items.map((item) => (
+          <li key={item}>• {item}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function StatusPill({ children }: { children: string }) {
+  return (
+    <span className="inline-flex rounded-full bg-amber-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.12em] text-amber-900">
+      {children}
+    </span>
+  )
+}
+
+export function SmallJobsExperience() {
+  const [openService, setOpenService] = useState<string | null>(quickServices[0]?.id ?? null)
+  const [items, setItems] = useState<RequestItem[]>([])
+  const [sent, setSent] = useState(false)
+  const [selection, setSelection] = useState<InstallationSelection>({
+    pointType: pointTypes[0],
+    quantity: 1,
+    installationType: installationTypes[1],
+    distance: distances[0],
+    propertyType: propertyTypes[0],
+    urgency: urgencies[0],
+  })
+  const estimate = useMemo(() => generateTechnicalSummary(selection), [selection])
+  const subtotal = items.reduce((acc, item) => acc + item.labor * item.quantity, 0)
+
+  function addService(service: ElectricalService) {
+    setItems((current) => [
+      ...current,
+      {
+        id: `${service.id}-${Date.now()}`,
+        title: service.title,
+        quantity: 1,
+        labor: service.baseLaborPrice,
+        note: service.materialPolicy,
+      },
+    ])
+    setSent(false)
+  }
+
+  function addRequestItem(item: Omit<RequestItem, 'id'>, prefix: string) {
+    setItems((current) => [...current, { ...item, id: `${prefix}-${Date.now()}` }])
+    setSent(false)
+  }
+
+  function addConfigurable() {
+    addRequestItem(
+      {
+        title: estimate.workType,
+        quantity: 1,
+        labor: estimate.labor,
+        note: 'Instalación configurable · estimado pendiente de validación técnica',
+      },
+      'config',
+    )
+  }
+
+  return (
+    <div className="bg-white pb-20 lg:pb-0">
+      <a
+        href="#solicitud"
+        className="fixed inset-x-3 bottom-3 z-40 flex items-center justify-between rounded-2xl border border-slate-200 bg-slate-950 px-4 py-3 text-sm font-semibold text-white shadow-2xl lg:hidden"
+      >
+        <span>Solicitud ({items.length})</span>
+        <span>{subtotal ? money(subtotal) : 'Ver resumen'}</span>
+      </a>
+
+      <section className="border-b border-slate-200 bg-gradient-to-b from-slate-50 via-white to-white py-9 sm:py-14">
+        <div className="container max-w-6xl">
+          <div className="max-w-4xl">
+            <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-500">
+              NERIN Electricidad · Solicitud técnica
+            </p>
+            <h1 className="mt-3 text-balance text-4xl font-semibold tracking-tight text-slate-950 sm:text-6xl">
+              Pedí un servicio eléctrico con alcance claro.
+            </h1>
+            <p className="mt-5 max-w-3xl text-pretty text-base leading-7 text-slate-600 sm:text-lg sm:leading-8">
+              Elegí un trabajo estándar, configurá una instalación o solicitá diagnóstico. Te
+              mostramos mano de obra, materiales habituales, tiempos estimados y condiciones antes
+              de enviar la solicitud.
+            </p>
+          </div>
+
+          <div className="mt-6 grid gap-3 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm sm:grid-cols-3">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">
+                Materiales
+              </p>
+              <p className="mt-1 text-sm font-semibold text-slate-950">
+                No incluidos salvo aclaración.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">Estado</p>
+              <p className="mt-1 text-sm font-semibold text-slate-950">
+                Pendiente de validación técnica.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">
+                Validación
+              </p>
+              <p className="mt-1 text-sm font-semibold text-slate-950">
+                Zona, fotos, agenda y alcance real.
+              </p>
+            </div>
+          </div>
+
+          <p className="mt-4 rounded-2xl border border-amber-100 bg-amber-50/60 p-4 text-sm leading-6 text-slate-700">
+            Los valores publicados corresponden a mano de obra base o estimaciones para alcances
+            estándar. No incluyen materiales salvo que se indique lo contrario. Toda solicitud queda
+            sujeta a validación por zona, fotos, disponibilidad y estado real de la instalación.
+          </p>
+
+          <div className="mt-7 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {entryCards.map(({ href, title, text, Icon }) => (
+              <a
+                href={href}
+                key={title}
+                className="group rounded-3xl border border-slate-200 bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md sm:p-5"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="rounded-2xl bg-slate-950 p-2 text-white">
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  <p className="font-semibold leading-snug text-slate-950">{title}</p>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-slate-600">{text}</p>
+              </a>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="container max-w-6xl py-7">
+        <div className="grid gap-3 rounded-3xl border border-slate-200 bg-white p-3 shadow-sm md:grid-cols-2">
+          <div className="rounded-2xl bg-slate-50 p-5">
+            <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">
+              Reemplazo
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-slate-950">
+              Ya existe el punto y solo se cambia el elemento.
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              Ejemplo: cambiar toma, llave, luminaria o protección existente sin crear recorridos.
+            </p>
+          </div>
+          <div className="rounded-2xl bg-slate-950 p-5 text-white">
+            <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-400">
+              Instalación nueva
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold">
+              Hay que crear punto, pasar cable, definir recorrido, canalización o circuito.
+            </h2>
+            <a
+              href="#instalaciones-configurables"
+              className="mt-4 inline-flex min-h-11 items-center rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-950"
+            >
+              Calcular estimado
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <section id="servicios-rapidos" className="container max-w-6xl py-8">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-500">Catálogo</p>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-950">Servicios rápidos</h2>
+          </div>
+          <p className="max-w-md text-sm leading-6 text-slate-500">
+            Primero ves alcance, mano de obra, duración y materiales. El detalle queda desplegable.
+          </p>
+        </div>
+        <div className="mt-6 grid gap-4 lg:grid-cols-2">
+          {quickServices.map((service) => (
+            <article
+              key={service.id}
+              className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">
+                    {service.category}
+                  </p>
+                  <h3 className="mt-2 text-xl font-semibold text-slate-950">{service.title}</h3>
+                </div>
+                <div className="shrink-0 rounded-2xl bg-slate-50 px-3 py-2 text-right">
+                  <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-slate-500">
+                    Mano de obra
+                  </p>
+                  <p className="text-sm font-semibold text-slate-950">
+                    {money(service.baseLaborPrice)}
+                  </p>
+                </div>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-slate-600">{service.description}</p>
+              <div className="mt-4 grid gap-2 text-sm text-slate-600 sm:grid-cols-3">
+                <p className="rounded-2xl bg-slate-50 p-3">
+                  <b className="text-slate-950">Duración</b>
+                  <br />
+                  {service.durationMin} a {service.durationMax} min
+                </p>
+                <p className="rounded-2xl bg-slate-50 p-3 sm:col-span-2">
+                  <b className="text-slate-950">Materiales</b>
+                  <br />
+                  {service.materialPolicy}
+                </p>
+              </div>
+              <details
+                className="mt-4 rounded-2xl border border-slate-200 bg-white p-4"
+                open={openService === service.id}
+                onToggle={(event) => {
+                  if (event.currentTarget.open) setOpenService(service.id)
+                }}
+              >
+                <summary className="cursor-pointer text-sm font-semibold text-slate-950">
+                  Ver detalle
+                </summary>
+                <div className="mt-5 grid gap-5 border-t border-slate-100 pt-5 sm:grid-cols-2">
+                  <DetailList title="Qué incluye" items={service.includes} />
+                  <DetailList title="Qué no incluye" items={service.excludes} />
+                  <DetailList title="Materiales habituales" items={service.usualMaterials} />
+                  <DetailList title="Cuándo cambia el precio" items={service.priceModifiers} />
+                  <p className="text-sm leading-6 text-slate-600">
+                    <b>Aplica si:</b> {service.appliesWhen}
+                  </p>
+                  <p className="text-sm leading-6 text-slate-600">
+                    <b>NO aplica si:</b> {service.doesNotApplyWhen}
+                  </p>
+                </div>
+              </details>
+              <div className="mt-4 grid gap-2 sm:grid-cols-2">
+                <Button onClick={() => addService(service)} className="min-h-12 w-full">
+                  Agregar a solicitud
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setOpenService(openService === service.id ? null : service.id)}
+                  className="min-h-12 w-full"
+                >
+                  Ver detalle
+                </Button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section
+        id="instalaciones-configurables"
+        className="border-y border-slate-200 bg-slate-50 py-10"
+      >
+        <div className="container grid max-w-6xl gap-6 lg:grid-cols-[1fr_0.85fr]">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-500">
+              Configurador básico
+            </p>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-950">Configurá tu instalación</h2>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+              Es una herramienta de estimación inicial. No promete cálculo exacto: ayuda a ordenar
+              el pedido antes de revisión técnica.
+            </p>
+            <div className="mt-6 space-y-5 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
+              <fieldset>
+                <legend className="text-sm font-bold text-slate-950">1. Qué necesitás</legend>
+                <div className="mt-3 grid gap-4 sm:grid-cols-[1fr_140px]">
+                  <SelectField
+                    label="Tipo de punto"
+                    value={selection.pointType}
+                    options={pointTypes}
+                    onChange={(pointType) => setSelection({ ...selection, pointType })}
+                  />
+                  <label className="space-y-2 text-sm font-semibold text-slate-800">
+                    <span>Cantidad</span>
+                    <Input
+                      className="h-12"
+                      type="number"
+                      min={1}
+                      value={selection.quantity}
+                      onChange={(e) =>
+                        setSelection({ ...selection, quantity: Number(e.target.value) })
+                      }
+                    />
+                  </label>
+                </div>
+              </fieldset>
+              <fieldset>
+                <legend className="text-sm font-bold text-slate-950">2. Alcance y recorrido</legend>
+                <div className="mt-3 grid gap-4 sm:grid-cols-2">
+                  <SelectField
+                    label="Tipo de instalación"
+                    value={selection.installationType}
+                    options={installationTypes}
+                    onChange={(installationType) =>
+                      setSelection({ ...selection, installationType })
+                    }
+                  />
+                  <SelectField
+                    label="Distancia aproximada"
+                    value={selection.distance}
+                    options={distances}
+                    onChange={(distance) => setSelection({ ...selection, distance })}
+                  />
+                </div>
+              </fieldset>
+              <fieldset>
+                <legend className="text-sm font-bold text-slate-950">3. Contexto operativo</legend>
+                <div className="mt-3 grid gap-4 sm:grid-cols-2">
+                  <SelectField
+                    label="Tipo de propiedad"
+                    value={selection.propertyType}
+                    options={propertyTypes}
+                    onChange={(propertyType) => setSelection({ ...selection, propertyType })}
+                  />
+                  <SelectField
+                    label="Urgencia"
+                    value={selection.urgency}
+                    options={urgencies}
+                    onChange={(urgency) => setSelection({ ...selection, urgency })}
+                  />
+                </div>
+              </fieldset>
+            </div>
+          </div>
+          <aside className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm lg:sticky lg:top-24 lg:self-start">
+            <div className="flex flex-wrap items-center gap-2">
+              <StatusPill>Estimado</StatusPill>
+              <StatusPill>Pendiente de validación técnica</StatusPill>
+            </div>
+            <h3 className="mt-4 text-3xl font-semibold text-slate-950">{money(estimate.labor)}</h3>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              {estimate.quantity} punto(s) · {estimate.workType}
+            </p>
+            <div className="mt-4 rounded-2xl bg-slate-50 p-4">
+              <DetailList title="Materiales habituales" items={estimate.materials} />
+            </div>
+            <div className="mt-4 grid gap-2 text-sm text-slate-600 sm:grid-cols-2 lg:grid-cols-1">
+              <p>
+                <b>Duración:</b> {estimate.duration}
+              </p>
+              <p>
+                <b>Puede requerir visita:</b>{' '}
+                {estimate.requiresVisit ? 'sí' : 'según fotos y alcance'}
+              </p>
+              <p>
+                <b>Fotos:</b> sí, para validar recorrido y estado existente.
+              </p>
+            </div>
+            <p className="mt-4 rounded-2xl bg-amber-50 p-3 text-sm leading-6 text-amber-950">
+              Estimación para alcances estándar. Puede ajustarse por zona, acceso, estado real,
+              materiales, recorrido o disponibilidad.
+            </p>
+            <Button onClick={addConfigurable} className="mt-4 min-h-12 w-full">
+              Agregar a solicitud
+            </Button>
+          </aside>
+        </div>
+      </section>
+
+      <section id="diagnostico-de-fallas" className="container max-w-6xl py-10">
+        <div className="max-w-3xl">
+          <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-500">
+            Diagnóstico de fallas
+          </p>
+          <h2 className="mt-2 text-3xl font-semibold text-slate-950">
+            Tiempo técnico para encontrar el problema.
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-slate-600">
+            El diagnóstico ordena síntomas, pruebas y próximos pasos. Cobra el tiempo técnico de
+            revisión; no promete una solución definitiva si la falla es oculta o intermitente.
+          </p>
+        </div>
+        <div className="mt-5 grid gap-3 md:grid-cols-3">
+          <div className="rounded-2xl border border-slate-200 bg-white p-4">
+            <b>Diagnóstico básico</b>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Incluye hasta 90 minutos de revisión inicial. Si la falla se detecta y la reparación
+              es simple, se informa el costo antes de avanzar. Si requiere más tiempo, se solicita
+              aprobación previa.
+            </p>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white p-4">
+            <b>Diagnóstico avanzado</b>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Pensado para fallas ocultas, intermitentes, instalaciones desordenadas o casos donde
+              ya revisaron otros técnicos. Incluye una primera etapa de búsqueda técnica y propuesta
+              de próximos pasos.
+            </p>
+          </div>
+          <div className="rounded-2xl border border-amber-100 bg-amber-50/70 p-4">
+            <b>Horas adicionales</b>
+            <p className="mt-2 text-sm leading-6 text-slate-700">
+              Las horas adicionales nunca se continúan sin aprobación del cliente.
+            </p>
+          </div>
+        </div>
+        <div className="mt-6 grid gap-3 lg:grid-cols-2">
+          {diagnosticFaults.map((fault) => (
+            <details key={fault.id} className="rounded-2xl border border-slate-200 bg-white p-4">
+              <summary className="cursor-pointer text-sm font-semibold text-slate-950 sm:text-base">
+                {fault.faultName} · diagnóstico inicial {money(fault.initialPrice)}
+              </summary>
+              <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                <DetailList title="Posibles causas" items={fault.possibleCauses} />
+                <DetailList title="Pruebas habituales" items={fault.usualTests} />
+                <DetailList title="Soluciones posibles" items={fault.possibleSolutions} />
+                <DetailList title="Puede requerir más tiempo" items={fault.advancedRequiredWhen} />
+              </div>
+              <p className="mt-4 text-sm leading-6 text-slate-600">
+                Incluye {fault.includedMinutes} minutos. {fault.extraHourPolicy}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-slate-600">{fault.disclaimer}</p>
+              <Button
+                onClick={() =>
+                  addRequestItem(
+                    {
+                      title: `Diagnóstico: ${fault.faultName}`,
+                      quantity: 1,
+                      labor: fault.initialPrice,
+                      note: 'Diagnóstico inicial con aprobación previa para adicionales',
+                    },
+                    fault.id,
+                  )
+                }
+                className="mt-4 min-h-12 w-full sm:w-auto"
+              >
+                Pedir revisión técnica
+              </Button>
+            </details>
+          ))}
+        </div>
+        <p className="mt-5 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm leading-6 text-slate-600">
+          El valor del diagnóstico corresponde al tiempo técnico de revisión y a las pruebas
+          realizadas. Si no se logra confirmar una solución definitiva en el tiempo contratado, se
+          entrega un resumen con sectores revisados, hipótesis probable y próximos pasos
+          recomendados.
+        </p>
+      </section>
+
+      <section
+        id="comercios-consorcios"
+        className="border-y border-slate-200 bg-slate-950 py-10 text-white"
+      >
+        <div className="container max-w-6xl">
+          <div className="grid gap-6 lg:grid-cols-[0.8fr_1.2fr]">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-400">
+                Comercios, consorcios y barrios privados
+              </p>
+              <h2 className="mt-2 text-3xl font-semibold">
+                Pedidos con acceso, horarios y coordinación.
+              </h2>
+              <p className="mt-3 text-sm leading-6 text-slate-300">
+                Para locales, oficinas, depósitos, galerías, consorcios y barrios privados donde
+                importan cantidad, altura, autorizaciones, materiales y horarios fuera de atención.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {commercialServices.map((service) => (
+                <div
+                  key={service}
+                  className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200"
+                >
+                  {service}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="mt-6 grid gap-4 rounded-3xl bg-white p-5 text-slate-950 lg:grid-cols-[0.9fr_1.1fr]">
+            <div>
+              <h3 className="text-xl font-semibold">Ficha: Cambio de lámparas en comercio</h3>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                Relevamos cantidad de luminarias, altura aproximada, horario normal o fuera de
+                horario, quién aporta materiales y si se requiere escalera especial.
+              </p>
+            </div>
+            <div className="grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
+              <p className="rounded-2xl bg-slate-50 p-3">
+                Local, oficina, depósito, galería o consorcio.
+              </p>
+              <p className="rounded-2xl bg-slate-50 p-3">
+                Materiales aportados por cliente o por NERIN.
+              </p>
+              <p className="rounded-2xl bg-slate-50 p-3">Altura mayor a 3 m requiere revisión.</p>
+              <p className="rounded-2xl bg-slate-50 p-3">
+                Sujeto a acceso, autorización, zona y agenda.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section
+        id="solicitud"
+        className="container grid max-w-6xl gap-6 py-10 lg:grid-cols-[0.9fr_1.1fr]"
+      >
+        <aside className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm lg:sticky lg:top-24 lg:self-start">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">
+                Resumen
+              </p>
+              <h2 className="mt-1 text-2xl font-semibold text-slate-950">Solicitud</h2>
+            </div>
+            <StatusPill>Pendiente</StatusPill>
+          </div>
+          {items.length === 0 ? (
+            <p className="mt-4 rounded-2xl bg-slate-50 p-4 text-sm leading-6 text-slate-500">
+              Agregá servicios para ver el subtotal estimado y preparar el pedido.
+            </p>
+          ) : (
+            <div className="mt-4 space-y-3">
+              {items.map((item) => (
+                <div key={item.id} className="rounded-2xl bg-slate-50 p-3">
+                  <div className="flex justify-between gap-3">
+                    <p className="text-sm font-semibold text-slate-950">{item.title}</p>
+                    <button
+                      type="button"
+                      onClick={() => setItems(items.filter((entry) => entry.id !== item.id))}
+                      aria-label="Eliminar"
+                      className="rounded-full p-1 text-slate-500 hover:bg-white hover:text-slate-950"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  </div>
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
+                    <Input
+                      className="h-10 w-20"
+                      type="number"
+                      min={1}
+                      value={item.quantity}
+                      onChange={(e) =>
+                        setItems(
+                          items.map((entry) =>
+                            entry.id === item.id
+                              ? { ...entry, quantity: Number(e.target.value) }
+                              : entry,
+                          ),
+                        )
+                      }
+                    />
+                    <span className="text-sm text-slate-600">
+                      {money(item.labor)} mano de obra base
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs leading-5 text-slate-500">{item.note}</p>
+                </div>
+              ))}
+              <div className="rounded-2xl border border-slate-200 bg-white p-4">
+                <p className="text-lg font-semibold text-slate-950">
+                  Subtotal estimado: {money(subtotal)}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Materiales: no incluidos o estimados según ficha. Estado: pendiente de validación
+                  técnica. Sujeto a aprobación por zona, fotos, agenda y alcance real.
+                </p>
+              </div>
+            </div>
+          )}
+        </aside>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            setSent(true)
+          }}
+          className="rounded-3xl border border-slate-200 bg-slate-50 p-5"
+        >
+          <h2 className="text-2xl font-semibold text-slate-950">Enviar solicitud</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            NERIN Instalaciones Eléctricas revisa zona, fotos, disponibilidad, alcance y estado de
+            la instalación antes de confirmar.
+          </p>
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <Input className="h-12" required placeholder="Nombre" />
+            <Input className="h-12" required placeholder="Teléfono" />
+            <Input className="h-12" type="email" placeholder="Email opcional" />
+            <Input className="h-12" required placeholder="Dirección / zona" />
+            <SelectField
+              label="Tipo de propiedad"
+              value={selection.propertyType}
+              options={propertyTypes}
+              onChange={(propertyType) => setSelection({ ...selection, propertyType })}
+            />
+            <Input className="h-12" placeholder="Disponibilidad horaria" />
+            <Input type="file" multiple className="h-12 pt-3 sm:col-span-2" />
+            <Textarea className="min-h-28 sm:col-span-2" placeholder="Observaciones" />
+          </div>
+          <Button className="mt-5 min-h-12 w-full" size="lg" disabled={items.length === 0}>
+            Enviar solicitud
+          </Button>
+          {sent ? (
+            <div className="mt-5 rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm leading-6 text-emerald-950">
+              <CheckCircle2 className="mb-2 h-5 w-5" />
+              <b>Solicitud enviada. Pendiente de aprobación por NERIN.</b>
+              <p>
+                Vamos a revisar zona, fotos, disponibilidad, alcance y estado de la instalación.
+                Luego confirmamos si el servicio puede realizarse con el valor estimado, si requiere
+                ajuste o si corresponde una visita técnica previa.
+              </p>
+            </div>
+          ) : null}
+          <a
+            className="mt-4 inline-flex text-sm font-semibold text-slate-950"
+            href={`https://wa.me/?text=${encodeURIComponent(`Solicitud NERIN Instalaciones Eléctricas\nSubtotal estimado: ${money(subtotal)}\n${items.map((item) => `- ${item.title} x${item.quantity}`).join('\n')}`)}`}
+          >
+            Generar resumen para WhatsApp
+          </a>
+        </form>
+      </section>
+
+      <section className="border-t border-slate-200 bg-slate-50 py-8">
+        <div className="container max-w-6xl space-y-3 text-sm leading-6 text-slate-600">
+          <p>
+            Todos los valores son orientativos o base para alcances estándar. No incluyen materiales
+            salvo indicación expresa. La solicitud no implica confirmación automática del servicio.
+            NERIN puede confirmar, ajustar o rechazar la solicitud según zona, agenda, fotos
+            recibidas, condiciones de acceso, estado de la instalación y alcance real.
+          </p>
+          <p className="font-semibold text-slate-950">
+            Nunca se realizan trabajos adicionales ni se continúan horas extra sin aprobación previa
+            del cliente.
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/nerin-electric-site-v3-fixed/components/electrical-services/estimateRules.ts
+++ b/nerin-electric-site-v3-fixed/components/electrical-services/estimateRules.ts
@@ -1,0 +1,93 @@
+export interface InstallationSelection {
+  pointType: string
+  quantity: number
+  installationType: string
+  distance: string
+  propertyType: string
+  urgency: string
+}
+
+const baseByPoint: Record<string, number> = {
+  'toma común 10A': 38000,
+  'toma 20A': 45000,
+  'toma para aire acondicionado': 78000,
+  'punto de iluminación': 52000,
+  'llave de luz': 42000,
+  'circuito dedicado': 95000,
+  'tablero / protección': 110000,
+}
+
+export function requiresTechnicalVisit(selection: InstallationSelection) {
+  return (
+    selection.installationType.includes('embutida completa') ||
+    selection.distance === 'más de 10 m' ||
+    selection.propertyType === 'consorcio' ||
+    selection.propertyType === 'country / barrio privado' ||
+    selection.pointType === 'tablero / protección'
+  )
+}
+
+export function estimateMaterials(selection: InstallationSelection) {
+  const common = ['cable normalizado según sección', 'conectores', 'tornillería menor']
+  if (selection.installationType.includes('exterior'))
+    return [...common, 'caño o cablecanal', 'curvas y accesorios', 'cajas exteriores']
+  if (selection.pointType.includes('toma'))
+    return [...common, 'módulo toma', 'bastidor', 'tapa', 'caja si corresponde']
+  if (selection.pointType.includes('tablero'))
+    return [...common, 'protección compatible', 'riel DIN o accesorios', 'terminales']
+  return [...common, 'módulo o portalámparas según alcance', 'caja o tapa si corresponde']
+}
+
+export function calculateServiceEstimate(selection: InstallationSelection) {
+  const quantity = Math.max(1, Number(selection.quantity) || 1)
+  const base = baseByPoint[selection.pointType] || 45000
+  const installFactor = selection.installationType.includes('existente')
+    ? 1
+    : selection.installationType.includes('exterior')
+      ? 1.45
+      : selection.installationType.includes('embutida completa')
+        ? 2.2
+        : 1.25
+  const distanceFactor =
+    selection.distance === 'hasta 3 m'
+      ? 1
+      : selection.distance === '3 a 6 m'
+        ? 1.18
+        : selection.distance === '6 a 10 m'
+          ? 1.35
+          : 1.7
+  const urgencyFactor =
+    selection.urgency === 'normal' ? 1 : selection.urgency === 'prioritaria' ? 1.25 : 1.55
+  const labor =
+    Math.round((base * quantity * installFactor * distanceFactor * urgencyFactor) / 1000) * 1000
+  return {
+    labor,
+    duration: `${Math.max(1, quantity)} a ${Math.max(2, quantity * 2)} horas estimadas`,
+    requiresVisit: requiresTechnicalVisit(selection),
+    photoRequired: true,
+    materials: estimateMaterials(selection),
+  }
+}
+
+export function calculateDiagnosticEstimate(selection: { advanced?: boolean }) {
+  return {
+    initialPrice: selection.advanced ? 85000 : 65000,
+    includedMinutes: 90,
+    status: 'pendiente de validación técnica',
+  }
+}
+
+export function generateTechnicalSummary(selection: InstallationSelection) {
+  const estimate = calculateServiceEstimate(selection)
+  return {
+    ...estimate,
+    quantity: selection.quantity,
+    workType: `${selection.pointType} · ${selection.installationType} · ${selection.distance}`,
+    scopeNotes: [
+      'Estimación preparada para alcances estándar.',
+      'Sujeto a aprobación por zona, agenda, fotos, acceso y estado real de la instalación.',
+      'No incluye materiales salvo pacto expreso.',
+    ],
+    status: 'pendiente de validación técnica',
+  }
+}

--- a/nerin-electric-site-v3-fixed/data/electricalServices.ts
+++ b/nerin-electric-site-v3-fixed/data/electricalServices.ts
@@ -1,0 +1,321 @@
+export type ElectricalServiceType = 'quick_service' | 'configurable' | 'diagnostic' | 'commercial'
+
+export interface ElectricalService {
+  id: string
+  category: string
+  type: ElectricalServiceType
+  title: string
+  description: string
+  baseLaborPrice: number
+  materialPolicy: string
+  materialEstimateMin: number | null
+  materialEstimateMax: number | null
+  durationMin: number
+  durationMax: number
+  requiresVisit: boolean | 'segun_caso'
+  photoRequired: boolean
+  includes: string[]
+  excludes: string[]
+  usualMaterials: string[]
+  priceModifiers: string[]
+  appliesWhen: string
+  doesNotApplyWhen: string
+  relatedServices: string[]
+  approvalRequired: true
+}
+
+export interface DiagnosticFault {
+  id: string
+  faultName: string
+  initialPrice: number
+  includedMinutes: number
+  possibleCauses: string[]
+  usualTests: string[]
+  possibleSolutions: string[]
+  advancedRequiredWhen: string[]
+  extraHourPolicy: string
+  disclaimer: string
+  approvalRequired: true
+}
+
+export const currency = 'ARS'
+export const additionalHourPrice = 30000
+
+const quickBase = {
+  type: 'quick_service' as const,
+  category: 'Servicios rápidos',
+  approvalRequired: true as const,
+  photoRequired: true,
+  materialPolicy: 'Materiales no incluidos salvo indicación expresa.',
+  materialEstimateMin: null,
+  materialEstimateMax: null,
+}
+
+export const quickServices: ElectricalService[] = [
+  {
+    ...quickBase,
+    id: 'cambio-tomacorriente-existente',
+    title: 'Cambio de tomacorriente existente',
+    description: 'Reemplazo de toma sobre un punto eléctrico ya existente.',
+    baseLaborPrice: 35000,
+    materialPolicy: 'No incluidos. Estimado habitual: módulo, bastidor y tapa según línea elegida.',
+    durationMin: 30,
+    durationMax: 60,
+    requiresVisit: false,
+    includes: [
+      'retiro del toma existente',
+      'colocación del nuevo módulo',
+      'conexión',
+      'ajuste',
+      'prueba de funcionamiento',
+    ],
+    excludes: [
+      'canalización nueva',
+      'cableado nuevo',
+      'albañilería',
+      'pintura',
+      'reparación de caja dañada',
+      'agregado de puesta a tierra si no existe',
+    ],
+    usualMaterials: ['módulo toma 10A o 20A', 'bastidor', 'tapa', 'tornillería menor'],
+    priceModifiers: [
+      'caja rota',
+      'cables quemados o cortos',
+      'falta de puesta a tierra',
+      'cañería tapada',
+      'urgencia',
+      'zona fuera de cobertura principal',
+    ],
+    appliesWhen: 'Ya existe el punto eléctrico y solo hay que reemplazar el mecanismo.',
+    doesNotApplyWhen: 'Querés crear un toma nuevo donde no hay instalación previa.',
+    relatedServices: ['nuevo-punto-toma'],
+  },
+  {
+    ...quickBase,
+    id: 'cambio-llave-luz',
+    title: 'Cambio de llave de luz',
+    description: 'Reemplazo de tecla o llave sobre caja existente, con prueba de encendido.',
+    baseLaborPrice: 32000,
+    durationMin: 30,
+    durationMax: 60,
+    requiresVisit: false,
+    includes: [
+      'retiro de tecla existente',
+      'conexión de módulo nuevo',
+      'ajuste de bastidor y tapa',
+      'prueba de funcionamiento',
+    ],
+    excludes: [
+      'nuevo punto de comando',
+      'cableado adicional',
+      'reparación de caja o cañería',
+      'cambios de circuito',
+    ],
+    usualMaterials: ['módulo tecla', 'bastidor', 'tapa', 'tornillería menor'],
+    priceModifiers: [
+      'cables cortos',
+      'falso contacto previo',
+      'caja floja',
+      'combinación o escalera',
+      'urgencia',
+    ],
+    appliesWhen: 'La llave ya existe y solo se reemplaza el mecanismo.',
+    doesNotApplyWhen: 'Hay que crear una llave nueva, agregar retorno o modificar recorridos.',
+    relatedServices: ['nuevo-punto-iluminacion'],
+  },
+  {
+    ...quickBase,
+    id: 'instalacion-luminaria-punto-existente',
+    title: 'Instalación de luminaria sobre punto existente',
+    description: 'Colocación de artefacto provisto sobre boca o punto de iluminación existente.',
+    baseLaborPrice: 42000,
+    durationMin: 45,
+    durationMax: 90,
+    requiresVisit: 'segun_caso',
+    includes: [
+      'desembalaje básico',
+      'fijación en punto existente',
+      'conexionado',
+      'prueba de encendido',
+    ],
+    excludes: [
+      'armado complejo',
+      'altura mayor a 3 m',
+      'nuevo cableado',
+      'refuerzo de cielorraso',
+      'materiales especiales',
+    ],
+    usualMaterials: ['tarugos', 'tornillos', 'conectores', 'lámparas si corresponde'],
+    priceModifiers: [
+      'altura',
+      'peso del artefacto',
+      'techo delicado',
+      'cantidad de piezas',
+      'fuera de horario',
+    ],
+    appliesWhen: 'Existe una boca eléctrica funcional donde se colocará la luminaria.',
+    doesNotApplyWhen: 'No hay punto de iluminación o se requiere canalización/cableado nuevo.',
+    relatedServices: ['nuevo-punto-iluminacion'],
+  },
+  {
+    ...quickBase,
+    id: 'cambio-termica',
+    title: 'Cambio de térmica',
+    description: 'Reemplazo de interruptor termomagnético existente compatible con el tablero.',
+    baseLaborPrice: 45000,
+    durationMin: 45,
+    durationMax: 90,
+    requiresVisit: 'segun_caso',
+    includes: [
+      'corte seguro',
+      'retiro de protección existente',
+      'colocación de nueva térmica',
+      'ajuste y prueba',
+    ],
+    excludes: [
+      'rediseño de tablero',
+      'normalización completa',
+      'cableado nuevo',
+      'detección de fallas del circuito',
+    ],
+    usualMaterials: [
+      'interruptor termomagnético',
+      'peines o puentes si corresponden',
+      'terminales',
+    ],
+    priceModifiers: [
+      'tablero saturado',
+      'cables recalentados',
+      'protección incompatible',
+      'falla aguas abajo',
+      'urgencia',
+    ],
+    appliesWhen:
+      'La protección existente debe reemplazarse por una equivalente y el tablero lo permite.',
+    doesNotApplyWhen:
+      'La térmica salta por una falla sin diagnosticar o el tablero requiere reforma.',
+    relatedServices: ['diagnostico-salta-termica'],
+  },
+  {
+    ...quickBase,
+    id: 'cambio-disyuntor',
+    title: 'Cambio de disyuntor',
+    description: 'Reemplazo de interruptor diferencial existente con verificación básica.',
+    baseLaborPrice: 52000,
+    durationMin: 60,
+    durationMax: 120,
+    requiresVisit: 'segun_caso',
+    includes: [
+      'retiro de diferencial existente',
+      'colocación del nuevo',
+      'ajuste de conductores',
+      'prueba de disparo',
+    ],
+    excludes: [
+      'búsqueda de fuga',
+      'separación de circuitos',
+      'normalización de tablero',
+      'puesta a tierra nueva',
+    ],
+    usualMaterials: ['interruptor diferencial', 'terminales', 'puentes si corresponden'],
+    priceModifiers: [
+      'fuga persistente',
+      'neutros mezclados',
+      'tablero sin espacio',
+      'instalación antigua',
+      'urgencia',
+    ],
+    appliesWhen: 'El diferencial está dañado o debe cambiarse por uno compatible.',
+    doesNotApplyWhen: 'El disyuntor salta por fuga o falla no identificada.',
+    relatedServices: ['diagnostico-salta-disyuntor'],
+  },
+  {
+    ...quickBase,
+    id: 'revision-simple-tablero',
+    title: 'Revisión simple de tablero',
+    description:
+      'Control visual y funcional básico de tablero existente para orientar próximos pasos.',
+    baseLaborPrice: 40000,
+    durationMin: 45,
+    durationMax: 90,
+    requiresVisit: true,
+    includes: [
+      'revisión visual',
+      'ajustes menores accesibles',
+      'pruebas básicas',
+      'recomendación de próximos pasos',
+    ],
+    excludes: [
+      'normalización completa',
+      'mediciones certificadas',
+      'materiales',
+      'reparaciones extensas',
+    ],
+    usualMaterials: ['terminales menores', 'precintos', 'rotulación básica'],
+    priceModifiers: [
+      'tablero muy deteriorado',
+      'falta de espacio',
+      'riesgo visible',
+      'más de un tablero',
+      'fuera de cobertura',
+    ],
+    appliesWhen: 'Se necesita una revisión inicial de un tablero accesible y acotado.',
+    doesNotApplyWhen: 'Hay fallas activas, olor a quemado o necesidad de reforma completa.',
+    relatedServices: ['ampliacion-tablero'],
+  },
+]
+
+export const diagnosticFaults: DiagnosticFault[] = [
+  'Salta el disyuntor.|Fuga a tierra, humedad, artefacto defectuoso, neutros mezclados.',
+  'Salta la térmica.|Sobrecarga, cortocircuito, térmica dañada, cable recalentado.',
+  'No funciona un sector.|Conexión floja, térmica baja, empalme abierto, cable cortado.',
+  'Falso contacto.|Bornes flojos, módulo dañado, cable corto, caja deteriorada.',
+  'Olor a quemado.|Recalentamiento, falso contacto, sobrecarga, material dañado.',
+  'Luces que parpadean.|Falso contacto, baja tensión, neutro flojo, carga variable.',
+  'Falla intermitente.|Humedad, vibración, empalme flojo, artefacto con defecto eventual.',
+  'Ya vinieron otros electricistas y no encontraron la falla.|Instalación desordenada, falla oculta, recorridos no identificados, evento intermitente.',
+].map((item, index) => {
+  const [faultName, causes] = item.split('|')
+  return {
+    id: `diagnostico-${index + 1}`,
+    faultName,
+    initialPrice: index === 7 ? 85000 : 65000,
+    includedMinutes: 90,
+    possibleCauses: causes.split(', '),
+    usualTests: [
+      'entrevista sobre síntomas',
+      'inspección visual',
+      'pruebas por sectores',
+      'verificación de protecciones',
+      'aislamiento progresivo de cargas',
+    ],
+    possibleSolutions: [
+      'ajuste o reemplazo puntual',
+      'separación de sector afectado',
+      'reparación simple con aprobación',
+      'propuesta de visita avanzada',
+    ],
+    advancedRequiredWhen: [
+      'la falla no aparece durante la visita',
+      'hay sectores ocultos',
+      'la instalación está desordenada',
+      'se requiere desmontaje o más tiempo',
+    ],
+    extraHourPolicy: `Hora adicional editable: ${additionalHourPrice.toLocaleString('es-AR')} ARS. Las horas adicionales nunca se continúan sin aprobación del cliente.`,
+    disclaimer:
+      'No se garantiza detección total de fallas ocultas o intermitentes en una única visita.',
+    approvalRequired: true as const,
+  }
+})
+
+export const commercialServices = [
+  'Cambio de lámparas en comercio',
+  'Mantenimiento de luminarias',
+  'Revisión de tablero de local',
+  'Tomas para equipos comerciales',
+  'Electricidad para mostradores y cajas',
+  'Urgencias fuera de horario',
+  'Mantenimiento preventivo mensual',
+  'Trabajos en consorcios',
+  'Trabajos en countries / barrios privados',
+]


### PR DESCRIPTION
### Motivation
- Replace the previous static, server-rendered catalog with an interactive client-side experience to let users configure installations, request diagnostics and build a service request with estimated labor and materials.
- Centralize service data and estimation rules so the UI can present consistent quick services, diagnostics and configurable installation estimates.

### Description
- Replace the old `/trabajos-electricos` page implementation to render a new client component `SmallJobsExperience` and keep breadcrumb JSON-LD; update metadata `title` and `description` for the page.
- Add `components/electrical-services/SmallJobsExperience.tsx` implementing the full interactive UI: quick services catalog, configurable installation estimator, diagnostic entries, commercial notes and a request form with a local request summary and subtotal.
- Add `components/electrical-services/estimateRules.ts` implementing estimation logic (`calculateServiceEstimate`, `generateTechnicalSummary`, `requiresTechnicalVisit`, `estimateMaterials`) and types for `InstallationSelection`.
- Add `data/electricalServices.ts` exporting `quickServices`, `diagnosticFaults`, `commercialServices`, `currency` and related types/constants used by the UI.
- Remove previous server-side content fetching and rendering logic and related imports; the new UI is client-only (`'use client'`) and manages its own state and interactions.

### Testing
- Type-check run with `tsc --noEmit` completed successfully.
- Production build verified with `next build` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4087629e5c8331bbcdde2211fd8c8a)