### PR TITLE
Convertir /trabajos-electricos a flujo por modos con Solicitud persistente

### DIFF
--- a/nerin-electric-site-v3-fixed/components/electrical-services/SmallJobsExperience.tsx
+++ b/nerin-electric-site-v3-fixed/components/electrical-services/SmallJobsExperience.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { CheckCircle2, ClipboardList, Settings2, Store, Wrench, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import {
-  commercialServices,
   currency,
   diagnosticFaults,
   quickServices,
@@ -52,30 +51,109 @@ const urgencies = ['normal', 'prioritaria', 'fuera de horario']
 
 const entryCards = [
   {
-    href: '#servicios-rapidos',
+    id: 'servicios-rapidos',
     title: 'Servicios rápidos',
     text: 'Reemplazos simples sobre puntos existentes.',
     Icon: Wrench,
   },
   {
-    href: '#instalaciones-configurables',
+    id: 'instalaciones-configurables',
     title: 'Instalaciones configurables',
     text: 'Nuevos puntos, recorridos, canalización o circuito.',
     Icon: Settings2,
   },
   {
-    href: '#diagnostico-de-fallas',
+    id: 'diagnostico-de-fallas',
     title: 'Diagnóstico de fallas',
     text: 'Búsqueda técnica de problemas eléctricos.',
     Icon: ClipboardList,
   },
   {
-    href: '#comercios-consorcios',
+    id: 'comercios-consorcios',
     title: 'Comercios / consorcios / barrios privados',
     text: 'Pedidos repetitivos, acceso, horarios y autorizaciones.',
     Icon: Store,
   },
 ]
+
+const commercialRequestServices = [
+  {
+    id: 'cambio-lamparas-comercio',
+    title: 'Cambio de lámparas en comercio',
+    description: 'Recambio de lámparas o tubos sobre luminarias existentes en espacios operativos.',
+    quoteNeeds:
+      'Cantidad de luminarias, altura aproximada, tipo de espacio, horario, materiales y fotos.',
+    access:
+      'Requiere ingreso autorizado, sector despejado y validación de escalera o medio de acceso.',
+    configurable: true,
+  },
+  {
+    id: 'mantenimiento-luminarias',
+    title: 'Mantenimiento de luminarias',
+    description:
+      'Recambio, revisión y puesta en servicio de luminarias en local, oficina o áreas comunes.',
+    quoteNeeds: 'Cantidad, altura, tipo de artefacto, fotos del espacio y horario disponible.',
+    access: 'Requiere acceso autorizado, corte coordinado si corresponde y responsable presente.',
+  },
+  {
+    id: 'revision-tablero-local',
+    title: 'Revisión de tablero de local',
+    description:
+      'Control visual y funcional de protecciones, conexiones, recalentamientos y orden básico.',
+    quoteNeeds:
+      'Fotos del tablero abierto/cerrado, síntomas, potencia de equipos y horarios posibles.',
+    access:
+      'Puede requerir corte parcial, autorización del local/administración y sector despejado.',
+  },
+  {
+    id: 'tomas-mostrador-equipos',
+    title: 'Tomas para mostrador/equipos',
+    description:
+      'Solicitud para nuevos tomas o adecuación de puntos para equipos de atención o producción.',
+    quoteNeeds: 'Cantidad, consumo de equipos, distancia al tablero, recorrido posible y fotos.',
+    access: 'Se valida canalización, interferencias, horarios y permisos del inmueble.',
+  },
+  {
+    id: 'urgencia-fuera-horario',
+    title: 'Urgencia fuera de horario',
+    description:
+      'Atención prioritaria para comercios que no pueden frenar operación en horario normal.',
+    quoteNeeds: 'Síntoma, criticidad, dirección, contacto responsable y fotos/videos si existen.',
+    access:
+      'Sujeto a disponibilidad, seguridad de acceso y aprobación previa del adicional horario.',
+  },
+  {
+    id: 'preventivo-mensual',
+    title: 'Mantenimiento preventivo mensual',
+    description:
+      'Rutina mensual para revisar luminarias, tableros, tomas críticos y puntos reportados.',
+    quoteNeeds:
+      'Superficie, cantidad de sectores, frecuencia, horarios y listado de equipos críticos.',
+    access: 'Requiere referente operativo, permiso de ingreso y agenda recurrente aprobada.',
+  },
+  {
+    id: 'trabajo-consorcio',
+    title: 'Trabajo en consorcio',
+    description:
+      'Pedidos para espacios comunes, tableros, luminarias, bombas o sectores compartidos.',
+    quoteNeeds: 'Autorización, alcance, fotos, ubicación de llaves/tableros y horario permitido.',
+    access:
+      'Debe coordinarse con administración, encargado o consejo; materiales no incluidos salvo acuerdo.',
+  },
+  {
+    id: 'trabajo-country',
+    title: 'Trabajo en country / barrio privado',
+    description:
+      'Solicitudes con ingreso controlado, autorización previa y coordinación de acceso.',
+    quoteNeeds: 'Lote/unidad, autorización de ingreso, contacto de seguridad, fotos y alcance.',
+    access: 'Sujeto a ingreso aprobado, documentación requerida, zona y ventana horaria.',
+  },
+]
+
+const commercialSpaces = ['local', 'oficina', 'depósito', 'galería', 'consorcio', 'country']
+const commercialSchedules = ['normal', 'fuera de horario']
+const commercialMaterials = ['aporta cliente', 'cotiza NERIN']
+const ladderOptions = ['sí', 'no', 'no sé']
 
 type RequestItem = { id: string; title: string; quantity: number; labor: number; note: string }
 
@@ -128,7 +206,10 @@ function StatusPill({ children }: { children: string }) {
 }
 
 export function SmallJobsExperience() {
+  const [activeMode, setActiveMode] = useState(entryCards[0].id)
   const [openService, setOpenService] = useState<string | null>(quickServices[0]?.id ?? null)
+  const [addedLabel, setAddedLabel] = useState<string | null>(null)
+  const solicitudRef = useRef<HTMLElement | null>(null)
   const [items, setItems] = useState<RequestItem[]>([])
   const [sent, setSent] = useState(false)
   const [selection, setSelection] = useState<InstallationSelection>({
@@ -138,6 +219,15 @@ export function SmallJobsExperience() {
     distance: distances[0],
     propertyType: propertyTypes[0],
     urgency: urgencies[0],
+  })
+  const [commercialConfig, setCommercialConfig] = useState({
+    quantity: 4,
+    height: 'hasta 3 m',
+    spaceType: commercialSpaces[0],
+    schedule: commercialSchedules[0],
+    materials: commercialMaterials[0],
+    ladder: ladderOptions[2],
+    observations: '',
   })
   const estimate = useMemo(() => generateTechnicalSummary(selection), [selection])
   const subtotal = items.reduce((acc, item) => acc + item.labor * item.quantity, 0)
@@ -153,12 +243,18 @@ export function SmallJobsExperience() {
         note: service.materialPolicy,
       },
     ])
+    setAddedLabel(service.title)
     setSent(false)
   }
 
   function addRequestItem(item: Omit<RequestItem, 'id'>, prefix: string) {
     setItems((current) => [...current, { ...item, id: `${prefix}-${Date.now()}` }])
+    setAddedLabel(item.title)
     setSent(false)
+  }
+
+  function openSolicitud() {
+    solicitudRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }
 
   function addConfigurable() {
@@ -173,15 +269,28 @@ export function SmallJobsExperience() {
     )
   }
 
+  function addCommercialLampConfig() {
+    addRequestItem(
+      {
+        title: 'Cambio de lámparas en comercio',
+        quantity: Number(commercialConfig.quantity) || 1,
+        labor: 0,
+        note: `Cotizar: ${commercialConfig.height}, ${commercialConfig.spaceType}, ${commercialConfig.schedule}, materiales: ${commercialConfig.materials}, escalera especial: ${commercialConfig.ladder}. ${commercialConfig.observations}`.trim(),
+      },
+      'comercial-lamparas',
+    )
+  }
+
   return (
     <div className="bg-white pb-20 lg:pb-0">
-      <a
-        href="#solicitud"
+      <button
+        type="button"
+        onClick={openSolicitud}
         className="fixed inset-x-3 bottom-3 z-40 flex items-center justify-between rounded-2xl border border-slate-200 bg-slate-950 px-4 py-3 text-sm font-semibold text-white shadow-2xl lg:hidden"
       >
-        <span>Solicitud ({items.length})</span>
+        <span>Solicitud · {items.length} servicios</span>
         <span>{subtotal ? money(subtotal) : 'Ver resumen'}</span>
-      </a>
+      </button>
 
       <section className="border-b border-slate-200 bg-gradient-to-b from-slate-50 via-white to-white py-9 sm:py-14">
         <div className="container max-w-6xl">
@@ -230,387 +339,535 @@ export function SmallJobsExperience() {
             sujeta a validación por zona, fotos, disponibilidad y estado real de la instalación.
           </p>
 
-          <div className="mt-7 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            {entryCards.map(({ href, title, text, Icon }) => (
-              <a
-                href={href}
-                key={title}
-                className="group rounded-3xl border border-slate-200 bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md sm:p-5"
+          <div
+            className="mt-7 grid gap-3 sm:grid-cols-2 lg:grid-cols-4"
+            role="tablist"
+            aria-label="Elegir tipo de solicitud"
+          >
+            {entryCards.map(({ id, title, text, Icon }) => {
+              const active = activeMode === id
+              return (
+                <button
+                  type="button"
+                  key={title}
+                  onClick={() => setActiveMode(id)}
+                  className={`group rounded-3xl border p-4 text-left shadow-sm transition hover:-translate-y-0.5 sm:p-5 ${active ? 'border-slate-950 bg-slate-950 text-white' : 'border-slate-200 bg-white text-slate-950 hover:border-slate-300 hover:shadow-md'}`}
+                  role="tab"
+                  aria-selected={active}
+                >
+                  <div className="flex items-center gap-3">
+                    <span
+                      className={`rounded-2xl p-2 ${active ? 'bg-white text-slate-950' : 'bg-slate-950 text-white'}`}
+                    >
+                      <Icon className="h-4 w-4" />
+                    </span>
+                    <p className="font-semibold leading-snug">{title}</p>
+                  </div>
+                  <p
+                    className={`mt-3 text-sm leading-6 ${active ? 'text-slate-200' : 'text-slate-600'}`}
+                  >
+                    {text}
+                  </p>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+
+      <div className="sticky top-0 z-30 border-b border-slate-200 bg-white/95 py-3 backdrop-blur">
+        <div className="container flex max-w-6xl gap-2 overflow-x-auto">
+          {entryCards.map((card) => (
+            <button
+              key={card.id}
+              type="button"
+              onClick={() => setActiveMode(card.id)}
+              className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm font-semibold ${activeMode === card.id ? 'border-slate-950 bg-slate-950 text-white' : 'border-slate-200 bg-white text-slate-700'}`}
+            >
+              {card.title}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {addedLabel ? (
+        <div className="container max-w-6xl pt-5">
+          <div className="flex flex-col gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-950 sm:flex-row sm:items-center sm:justify-between">
+            <b>Agregado a solicitud: {addedLabel}</b>
+            <Button type="button" onClick={openSolicitud} className="min-h-11">
+              Ver solicitud
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {activeMode === 'servicios-rapidos' ? (
+        <section id="servicios-rapidos" className="container max-w-6xl py-8">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-500">
+                Catálogo
+              </p>
+              <h2 className="mt-2 text-3xl font-semibold text-slate-950">Servicios rápidos</h2>
+            </div>
+            <p className="max-w-md text-sm leading-6 text-slate-500">
+              Primero ves alcance, mano de obra, duración y materiales. El detalle queda
+              desplegable.
+            </p>
+          </div>
+          <div className="mt-6 grid gap-4 lg:grid-cols-2">
+            {quickServices.map((service) => (
+              <article
+                key={service.id}
+                className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5"
               >
-                <div className="flex items-center gap-3">
-                  <span className="rounded-2xl bg-slate-950 p-2 text-white">
-                    <Icon className="h-4 w-4" />
-                  </span>
-                  <p className="font-semibold leading-snug text-slate-950">{title}</p>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">
+                      {service.category}
+                    </p>
+                    <h3 className="mt-2 text-xl font-semibold text-slate-950">{service.title}</h3>
+                  </div>
+                  <div className="shrink-0 rounded-2xl bg-slate-50 px-3 py-2 text-right">
+                    <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-slate-500">
+                      Mano de obra
+                    </p>
+                    <p className="text-sm font-semibold text-slate-950">
+                      {money(service.baseLaborPrice)}
+                    </p>
+                  </div>
                 </div>
-                <p className="mt-3 text-sm leading-6 text-slate-600">{text}</p>
-              </a>
+                <p className="mt-3 text-sm leading-6 text-slate-600">{service.description}</p>
+                <div className="mt-4 grid gap-2 text-sm text-slate-600 sm:grid-cols-3">
+                  <p className="rounded-2xl bg-slate-50 p-3">
+                    <b className="text-slate-950">Duración</b>
+                    <br />
+                    {service.durationMin} a {service.durationMax} min
+                  </p>
+                  <p className="rounded-2xl bg-slate-50 p-3 sm:col-span-2">
+                    <b className="text-slate-950">Materiales</b>
+                    <br />
+                    {service.materialPolicy}
+                  </p>
+                </div>
+                <details
+                  className="mt-4 rounded-2xl border border-slate-200 bg-white p-4"
+                  open={openService === service.id}
+                  onToggle={(event) => {
+                    if (event.currentTarget.open) setOpenService(service.id)
+                  }}
+                >
+                  <summary className="cursor-pointer text-sm font-semibold text-slate-950">
+                    Ver detalle
+                  </summary>
+                  <div className="mt-5 grid gap-5 border-t border-slate-100 pt-5 sm:grid-cols-2">
+                    <DetailList title="Qué incluye" items={service.includes} />
+                    <DetailList title="Qué no incluye" items={service.excludes} />
+                    <DetailList title="Materiales habituales" items={service.usualMaterials} />
+                    <DetailList title="Cuándo cambia el precio" items={service.priceModifiers} />
+                    <p className="text-sm leading-6 text-slate-600">
+                      <b>Aplica si:</b> {service.appliesWhen}
+                    </p>
+                    <p className="text-sm leading-6 text-slate-600">
+                      <b>NO aplica si:</b> {service.doesNotApplyWhen}
+                    </p>
+                  </div>
+                </details>
+                <div className="mt-4 grid gap-2 sm:grid-cols-2">
+                  <Button onClick={() => addService(service)} className="min-h-12 w-full">
+                    Agregar a solicitud
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setOpenService(openService === service.id ? null : service.id)}
+                    className="min-h-12 w-full"
+                  >
+                    Ver detalle
+                  </Button>
+                </div>
+              </article>
             ))}
           </div>
-        </div>
-      </section>
+        </section>
+      ) : null}
 
-      <section className="container max-w-6xl py-7">
-        <div className="grid gap-3 rounded-3xl border border-slate-200 bg-white p-3 shadow-sm md:grid-cols-2">
-          <div className="rounded-2xl bg-slate-50 p-5">
-            <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">
-              Reemplazo
-            </p>
-            <h2 className="mt-2 text-2xl font-semibold text-slate-950">
-              Ya existe el punto y solo se cambia el elemento.
-            </h2>
-            <p className="mt-3 text-sm leading-6 text-slate-600">
-              Ejemplo: cambiar toma, llave, luminaria o protección existente sin crear recorridos.
-            </p>
-          </div>
-          <div className="rounded-2xl bg-slate-950 p-5 text-white">
-            <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-400">
-              Instalación nueva
-            </p>
-            <h2 className="mt-2 text-2xl font-semibold">
-              Hay que crear punto, pasar cable, definir recorrido, canalización o circuito.
-            </h2>
-            <a
-              href="#instalaciones-configurables"
-              className="mt-4 inline-flex min-h-11 items-center rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-950"
-            >
-              Calcular estimado
-            </a>
-          </div>
-        </div>
-      </section>
-
-      <section id="servicios-rapidos" className="container max-w-6xl py-8">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-500">Catálogo</p>
-            <h2 className="mt-2 text-3xl font-semibold text-slate-950">Servicios rápidos</h2>
-          </div>
-          <p className="max-w-md text-sm leading-6 text-slate-500">
-            Primero ves alcance, mano de obra, duración y materiales. El detalle queda desplegable.
-          </p>
-        </div>
-        <div className="mt-6 grid gap-4 lg:grid-cols-2">
-          {quickServices.map((service) => (
-            <article
-              key={service.id}
-              className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5"
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">
-                    {service.category}
-                  </p>
-                  <h3 className="mt-2 text-xl font-semibold text-slate-950">{service.title}</h3>
-                </div>
-                <div className="shrink-0 rounded-2xl bg-slate-50 px-3 py-2 text-right">
-                  <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-slate-500">
-                    Mano de obra
-                  </p>
-                  <p className="text-sm font-semibold text-slate-950">
-                    {money(service.baseLaborPrice)}
-                  </p>
-                </div>
-              </div>
-              <p className="mt-3 text-sm leading-6 text-slate-600">{service.description}</p>
-              <div className="mt-4 grid gap-2 text-sm text-slate-600 sm:grid-cols-3">
-                <p className="rounded-2xl bg-slate-50 p-3">
-                  <b className="text-slate-950">Duración</b>
-                  <br />
-                  {service.durationMin} a {service.durationMax} min
-                </p>
-                <p className="rounded-2xl bg-slate-50 p-3 sm:col-span-2">
-                  <b className="text-slate-950">Materiales</b>
-                  <br />
-                  {service.materialPolicy}
-                </p>
-              </div>
-              <details
-                className="mt-4 rounded-2xl border border-slate-200 bg-white p-4"
-                open={openService === service.id}
-                onToggle={(event) => {
-                  if (event.currentTarget.open) setOpenService(service.id)
-                }}
-              >
-                <summary className="cursor-pointer text-sm font-semibold text-slate-950">
-                  Ver detalle
-                </summary>
-                <div className="mt-5 grid gap-5 border-t border-slate-100 pt-5 sm:grid-cols-2">
-                  <DetailList title="Qué incluye" items={service.includes} />
-                  <DetailList title="Qué no incluye" items={service.excludes} />
-                  <DetailList title="Materiales habituales" items={service.usualMaterials} />
-                  <DetailList title="Cuándo cambia el precio" items={service.priceModifiers} />
-                  <p className="text-sm leading-6 text-slate-600">
-                    <b>Aplica si:</b> {service.appliesWhen}
-                  </p>
-                  <p className="text-sm leading-6 text-slate-600">
-                    <b>NO aplica si:</b> {service.doesNotApplyWhen}
-                  </p>
-                </div>
-              </details>
-              <div className="mt-4 grid gap-2 sm:grid-cols-2">
-                <Button onClick={() => addService(service)} className="min-h-12 w-full">
-                  Agregar a solicitud
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setOpenService(openService === service.id ? null : service.id)}
-                  className="min-h-12 w-full"
-                >
-                  Ver detalle
-                </Button>
-              </div>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section
-        id="instalaciones-configurables"
-        className="border-y border-slate-200 bg-slate-50 py-10"
-      >
-        <div className="container grid max-w-6xl gap-6 lg:grid-cols-[1fr_0.85fr]">
-          <div>
-            <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-500">
-              Configurador básico
-            </p>
-            <h2 className="mt-2 text-3xl font-semibold text-slate-950">Configurá tu instalación</h2>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-              Es una herramienta de estimación inicial. No promete cálculo exacto: ayuda a ordenar
-              el pedido antes de revisión técnica.
-            </p>
-            <div className="mt-6 space-y-5 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
-              <fieldset>
-                <legend className="text-sm font-bold text-slate-950">1. Qué necesitás</legend>
-                <div className="mt-3 grid gap-4 sm:grid-cols-[1fr_140px]">
-                  <SelectField
-                    label="Tipo de punto"
-                    value={selection.pointType}
-                    options={pointTypes}
-                    onChange={(pointType) => setSelection({ ...selection, pointType })}
-                  />
-                  <label className="space-y-2 text-sm font-semibold text-slate-800">
-                    <span>Cantidad</span>
-                    <Input
-                      className="h-12"
-                      type="number"
-                      min={1}
-                      value={selection.quantity}
-                      onChange={(e) =>
-                        setSelection({ ...selection, quantity: Number(e.target.value) })
+      {activeMode === 'instalaciones-configurables' ? (
+        <section
+          id="instalaciones-configurables"
+          className="border-y border-slate-200 bg-slate-50 py-10"
+        >
+          <div className="container grid max-w-6xl gap-6 lg:grid-cols-[1fr_0.85fr]">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-500">
+                Configurador básico
+              </p>
+              <h2 className="mt-2 text-3xl font-semibold text-slate-950">
+                Configurá tu instalación
+              </h2>
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+                Es una herramienta de estimación inicial. No promete cálculo exacto: ayuda a ordenar
+                el pedido antes de revisión técnica.
+              </p>
+              <div className="mt-6 space-y-5 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
+                <fieldset>
+                  <legend className="text-sm font-bold text-slate-950">1. Qué necesitás</legend>
+                  <div className="mt-3 grid gap-4 sm:grid-cols-[1fr_140px]">
+                    <SelectField
+                      label="Tipo de punto"
+                      value={selection.pointType}
+                      options={pointTypes}
+                      onChange={(pointType) => setSelection({ ...selection, pointType })}
+                    />
+                    <label className="space-y-2 text-sm font-semibold text-slate-800">
+                      <span>Cantidad</span>
+                      <Input
+                        className="h-12"
+                        type="number"
+                        min={1}
+                        value={selection.quantity}
+                        onChange={(e) =>
+                          setSelection({ ...selection, quantity: Number(e.target.value) })
+                        }
+                      />
+                    </label>
+                  </div>
+                </fieldset>
+                <fieldset>
+                  <legend className="text-sm font-bold text-slate-950">
+                    2. Alcance y recorrido
+                  </legend>
+                  <div className="mt-3 grid gap-4 sm:grid-cols-2">
+                    <SelectField
+                      label="Tipo de instalación"
+                      value={selection.installationType}
+                      options={installationTypes}
+                      onChange={(installationType) =>
+                        setSelection({ ...selection, installationType })
                       }
                     />
-                  </label>
-                </div>
-              </fieldset>
-              <fieldset>
-                <legend className="text-sm font-bold text-slate-950">2. Alcance y recorrido</legend>
-                <div className="mt-3 grid gap-4 sm:grid-cols-2">
-                  <SelectField
-                    label="Tipo de instalación"
-                    value={selection.installationType}
-                    options={installationTypes}
-                    onChange={(installationType) =>
-                      setSelection({ ...selection, installationType })
-                    }
-                  />
-                  <SelectField
-                    label="Distancia aproximada"
-                    value={selection.distance}
-                    options={distances}
-                    onChange={(distance) => setSelection({ ...selection, distance })}
-                  />
-                </div>
-              </fieldset>
-              <fieldset>
-                <legend className="text-sm font-bold text-slate-950">3. Contexto operativo</legend>
-                <div className="mt-3 grid gap-4 sm:grid-cols-2">
-                  <SelectField
-                    label="Tipo de propiedad"
-                    value={selection.propertyType}
-                    options={propertyTypes}
-                    onChange={(propertyType) => setSelection({ ...selection, propertyType })}
-                  />
-                  <SelectField
-                    label="Urgencia"
-                    value={selection.urgency}
-                    options={urgencies}
-                    onChange={(urgency) => setSelection({ ...selection, urgency })}
-                  />
-                </div>
-              </fieldset>
-            </div>
-          </div>
-          <aside className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm lg:sticky lg:top-24 lg:self-start">
-            <div className="flex flex-wrap items-center gap-2">
-              <StatusPill>Estimado</StatusPill>
-              <StatusPill>Pendiente de validación técnica</StatusPill>
-            </div>
-            <h3 className="mt-4 text-3xl font-semibold text-slate-950">{money(estimate.labor)}</h3>
-            <p className="mt-2 text-sm leading-6 text-slate-600">
-              {estimate.quantity} punto(s) · {estimate.workType}
-            </p>
-            <div className="mt-4 rounded-2xl bg-slate-50 p-4">
-              <DetailList title="Materiales habituales" items={estimate.materials} />
-            </div>
-            <div className="mt-4 grid gap-2 text-sm text-slate-600 sm:grid-cols-2 lg:grid-cols-1">
-              <p>
-                <b>Duración:</b> {estimate.duration}
-              </p>
-              <p>
-                <b>Puede requerir visita:</b>{' '}
-                {estimate.requiresVisit ? 'sí' : 'según fotos y alcance'}
-              </p>
-              <p>
-                <b>Fotos:</b> sí, para validar recorrido y estado existente.
-              </p>
-            </div>
-            <p className="mt-4 rounded-2xl bg-amber-50 p-3 text-sm leading-6 text-amber-950">
-              Estimación para alcances estándar. Puede ajustarse por zona, acceso, estado real,
-              materiales, recorrido o disponibilidad.
-            </p>
-            <Button onClick={addConfigurable} className="mt-4 min-h-12 w-full">
-              Agregar a solicitud
-            </Button>
-          </aside>
-        </div>
-      </section>
-
-      <section id="diagnostico-de-fallas" className="container max-w-6xl py-10">
-        <div className="max-w-3xl">
-          <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-500">
-            Diagnóstico de fallas
-          </p>
-          <h2 className="mt-2 text-3xl font-semibold text-slate-950">
-            Tiempo técnico para encontrar el problema.
-          </h2>
-          <p className="mt-3 text-sm leading-6 text-slate-600">
-            El diagnóstico ordena síntomas, pruebas y próximos pasos. Cobra el tiempo técnico de
-            revisión; no promete una solución definitiva si la falla es oculta o intermitente.
-          </p>
-        </div>
-        <div className="mt-5 grid gap-3 md:grid-cols-3">
-          <div className="rounded-2xl border border-slate-200 bg-white p-4">
-            <b>Diagnóstico básico</b>
-            <p className="mt-2 text-sm leading-6 text-slate-600">
-              Incluye hasta 90 minutos de revisión inicial. Si la falla se detecta y la reparación
-              es simple, se informa el costo antes de avanzar. Si requiere más tiempo, se solicita
-              aprobación previa.
-            </p>
-          </div>
-          <div className="rounded-2xl border border-slate-200 bg-white p-4">
-            <b>Diagnóstico avanzado</b>
-            <p className="mt-2 text-sm leading-6 text-slate-600">
-              Pensado para fallas ocultas, intermitentes, instalaciones desordenadas o casos donde
-              ya revisaron otros técnicos. Incluye una primera etapa de búsqueda técnica y propuesta
-              de próximos pasos.
-            </p>
-          </div>
-          <div className="rounded-2xl border border-amber-100 bg-amber-50/70 p-4">
-            <b>Horas adicionales</b>
-            <p className="mt-2 text-sm leading-6 text-slate-700">
-              Las horas adicionales nunca se continúan sin aprobación del cliente.
-            </p>
-          </div>
-        </div>
-        <div className="mt-6 grid gap-3 lg:grid-cols-2">
-          {diagnosticFaults.map((fault) => (
-            <details key={fault.id} className="rounded-2xl border border-slate-200 bg-white p-4">
-              <summary className="cursor-pointer text-sm font-semibold text-slate-950 sm:text-base">
-                {fault.faultName} · diagnóstico inicial {money(fault.initialPrice)}
-              </summary>
-              <div className="mt-4 grid gap-4 sm:grid-cols-2">
-                <DetailList title="Posibles causas" items={fault.possibleCauses} />
-                <DetailList title="Pruebas habituales" items={fault.usualTests} />
-                <DetailList title="Soluciones posibles" items={fault.possibleSolutions} />
-                <DetailList title="Puede requerir más tiempo" items={fault.advancedRequiredWhen} />
+                    <SelectField
+                      label="Distancia aproximada"
+                      value={selection.distance}
+                      options={distances}
+                      onChange={(distance) => setSelection({ ...selection, distance })}
+                    />
+                  </div>
+                </fieldset>
+                <fieldset>
+                  <legend className="text-sm font-bold text-slate-950">
+                    3. Contexto operativo
+                  </legend>
+                  <div className="mt-3 grid gap-4 sm:grid-cols-2">
+                    <SelectField
+                      label="Tipo de propiedad"
+                      value={selection.propertyType}
+                      options={propertyTypes}
+                      onChange={(propertyType) => setSelection({ ...selection, propertyType })}
+                    />
+                    <SelectField
+                      label="Urgencia"
+                      value={selection.urgency}
+                      options={urgencies}
+                      onChange={(urgency) => setSelection({ ...selection, urgency })}
+                    />
+                  </div>
+                </fieldset>
               </div>
-              <p className="mt-4 text-sm leading-6 text-slate-600">
-                Incluye {fault.includedMinutes} minutos. {fault.extraHourPolicy}
+            </div>
+            <aside className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm lg:sticky lg:top-24 lg:self-start">
+              <div className="flex flex-wrap items-center gap-2">
+                <StatusPill>Estimado</StatusPill>
+                <StatusPill>Pendiente de validación técnica</StatusPill>
+              </div>
+              <h3 className="mt-4 text-3xl font-semibold text-slate-950">
+                {money(estimate.labor)}
+              </h3>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                {estimate.quantity} punto(s) · {estimate.workType}
               </p>
-              <p className="mt-2 text-sm leading-6 text-slate-600">{fault.disclaimer}</p>
-              <Button
-                onClick={() =>
-                  addRequestItem(
-                    {
-                      title: `Diagnóstico: ${fault.faultName}`,
-                      quantity: 1,
-                      labor: fault.initialPrice,
-                      note: 'Diagnóstico inicial con aprobación previa para adicionales',
-                    },
-                    fault.id,
-                  )
-                }
-                className="mt-4 min-h-12 w-full sm:w-auto"
-              >
-                Pedir revisión técnica
+              <div className="mt-4 rounded-2xl bg-slate-50 p-4">
+                <DetailList title="Materiales habituales" items={estimate.materials} />
+              </div>
+              <div className="mt-4 grid gap-2 text-sm text-slate-600 sm:grid-cols-2 lg:grid-cols-1">
+                <p>
+                  <b>Duración:</b> {estimate.duration}
+                </p>
+                <p>
+                  <b>Puede requerir visita:</b>{' '}
+                  {estimate.requiresVisit ? 'sí' : 'según fotos y alcance'}
+                </p>
+                <p>
+                  <b>Fotos:</b> sí, para validar recorrido y estado existente.
+                </p>
+              </div>
+              <p className="mt-4 rounded-2xl bg-amber-50 p-3 text-sm leading-6 text-amber-950">
+                Estimación para alcances estándar. Puede ajustarse por zona, acceso, estado real,
+                materiales, recorrido o disponibilidad.
+              </p>
+              <Button onClick={addConfigurable} className="mt-4 min-h-12 w-full">
+                Agregar a solicitud
               </Button>
-            </details>
-          ))}
-        </div>
-        <p className="mt-5 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm leading-6 text-slate-600">
-          El valor del diagnóstico corresponde al tiempo técnico de revisión y a las pruebas
-          realizadas. Si no se logra confirmar una solución definitiva en el tiempo contratado, se
-          entrega un resumen con sectores revisados, hipótesis probable y próximos pasos
-          recomendados.
-        </p>
-      </section>
+            </aside>
+          </div>
+        </section>
+      ) : null}
 
-      <section
-        id="comercios-consorcios"
-        className="border-y border-slate-200 bg-slate-950 py-10 text-white"
-      >
-        <div className="container max-w-6xl">
-          <div className="grid gap-6 lg:grid-cols-[0.8fr_1.2fr]">
-            <div>
-              <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-400">
-                Comercios, consorcios y barrios privados
-              </p>
-              <h2 className="mt-2 text-3xl font-semibold">
-                Pedidos con acceso, horarios y coordinación.
-              </h2>
-              <p className="mt-3 text-sm leading-6 text-slate-300">
-                Para locales, oficinas, depósitos, galerías, consorcios y barrios privados donde
-                importan cantidad, altura, autorizaciones, materiales y horarios fuera de atención.
+      {activeMode === 'diagnostico-de-fallas' ? (
+        <section id="diagnostico-de-fallas" className="container max-w-6xl py-10">
+          <div className="max-w-3xl">
+            <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-500">
+              Diagnóstico de fallas
+            </p>
+            <h2 className="mt-2 text-3xl font-semibold text-slate-950">
+              Tiempo técnico para encontrar el problema.
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              El diagnóstico ordena síntomas, pruebas y próximos pasos. Cobra el tiempo técnico de
+              revisión; no promete una solución definitiva si la falla es oculta o intermitente.
+            </p>
+          </div>
+          <div className="mt-5 grid gap-3 md:grid-cols-3">
+            <div className="rounded-2xl border border-slate-200 bg-white p-4">
+              <b>Diagnóstico básico</b>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                Incluye hasta 90 minutos de revisión inicial. Si la falla se detecta y la reparación
+                es simple, se informa el costo antes de avanzar. Si requiere más tiempo, se solicita
+                aprobación previa.
               </p>
             </div>
-            <div className="grid gap-3 sm:grid-cols-2">
-              {commercialServices.map((service) => (
-                <div
-                  key={service}
-                  className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200"
-                >
-                  {service}
+            <div className="rounded-2xl border border-slate-200 bg-white p-4">
+              <b>Diagnóstico avanzado</b>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                Pensado para fallas ocultas, intermitentes, instalaciones desordenadas o casos donde
+                ya revisaron otros técnicos. Incluye una primera etapa de búsqueda técnica y
+                propuesta de próximos pasos.
+              </p>
+            </div>
+            <div className="rounded-2xl border border-amber-100 bg-amber-50/70 p-4">
+              <b>Horas adicionales</b>
+              <p className="mt-2 text-sm leading-6 text-slate-700">
+                Las horas adicionales nunca se continúan sin aprobación del cliente.
+              </p>
+            </div>
+          </div>
+          <div className="mt-6 grid gap-3 lg:grid-cols-2">
+            {diagnosticFaults.map((fault) => (
+              <details key={fault.id} className="rounded-2xl border border-slate-200 bg-white p-4">
+                <summary className="cursor-pointer text-sm font-semibold text-slate-950 sm:text-base">
+                  {fault.faultName} · diagnóstico inicial {money(fault.initialPrice)}
+                </summary>
+                <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                  <DetailList title="Posibles causas" items={fault.possibleCauses} />
+                  <DetailList title="Pruebas habituales" items={fault.usualTests} />
+                  <DetailList title="Soluciones posibles" items={fault.possibleSolutions} />
+                  <DetailList
+                    title="Puede requerir más tiempo"
+                    items={fault.advancedRequiredWhen}
+                  />
                 </div>
+                <p className="mt-4 text-sm leading-6 text-slate-600">
+                  Incluye {fault.includedMinutes} minutos. {fault.extraHourPolicy}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">{fault.disclaimer}</p>
+                <Button
+                  onClick={() =>
+                    addRequestItem(
+                      {
+                        title: `Diagnóstico: ${fault.faultName}`,
+                        quantity: 1,
+                        labor: fault.initialPrice,
+                        note: 'Diagnóstico inicial con aprobación previa para adicionales',
+                      },
+                      fault.id,
+                    )
+                  }
+                  className="mt-4 min-h-12 w-full sm:w-auto"
+                >
+                  Pedir revisión técnica
+                </Button>
+              </details>
+            ))}
+          </div>
+          <p className="mt-5 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm leading-6 text-slate-600">
+            El valor del diagnóstico corresponde al tiempo técnico de revisión y a las pruebas
+            realizadas. Si no se logra confirmar una solución definitiva en el tiempo contratado, se
+            entrega un resumen con sectores revisados, hipótesis probable y próximos pasos
+            recomendados.
+          </p>
+        </section>
+      ) : null}
+
+      {activeMode === 'comercios-consorcios' ? (
+        <section
+          id="comercios-consorcios"
+          className="border-y border-slate-200 bg-slate-950 py-10 text-white"
+        >
+          <div className="container max-w-6xl">
+            <div className="grid gap-6 lg:grid-cols-[0.8fr_1.2fr]">
+              <div>
+                <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-400">
+                  Comercios, consorcios y barrios privados
+                </p>
+                <h2 className="mt-2 text-3xl font-semibold">
+                  Pedidos con acceso, horarios y coordinación.
+                </h2>
+                <p className="mt-3 text-sm leading-6 text-slate-300">
+                  Para locales, oficinas, depósitos, galerías, consorcios y barrios privados donde
+                  importan cantidad, altura, autorizaciones, materiales y horarios fuera de
+                  atención.
+                </p>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200">
+                  <b>Qué se necesita para cotizar</b>
+                  <p className="mt-2 leading-6">
+                    Fotos, cantidades, horarios posibles, responsable de acceso y autorización del
+                    lugar.
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200">
+                  <b>Condiciones</b>
+                  <p className="mt-2 leading-6">
+                    Materiales no incluidos salvo acuerdo. Todo queda sujeto a zona, agenda, alcance
+                    y permisos.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-6 grid gap-4 lg:grid-cols-2">
+              {commercialRequestServices.map((service) => (
+                <article
+                  key={service.id}
+                  className="rounded-3xl border border-white/10 bg-white p-5 text-slate-950 shadow-sm"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">
+                        Servicio comercial
+                      </p>
+                      <h3 className="mt-2 text-xl font-semibold">{service.title}</h3>
+                    </div>
+                    {service.configurable ? <StatusPill>Configurable</StatusPill> : null}
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-slate-600">{service.description}</p>
+                  <div className="mt-4 grid gap-3 text-sm text-slate-600">
+                    <p className="rounded-2xl bg-slate-50 p-3">
+                      <b className="text-slate-950">Qué se necesita para cotizar:</b>
+                      <br />
+                      {service.quoteNeeds}
+                    </p>
+                    <p className="rounded-2xl bg-slate-50 p-3">
+                      <b className="text-slate-950">Acceso / autorización:</b>
+                      <br />
+                      {service.access}
+                    </p>
+                    <p className="rounded-2xl bg-slate-50 p-3">
+                      <b className="text-slate-950">Materiales:</b>
+                      <br />
+                      No incluidos salvo acuerdo previo.
+                    </p>
+                  </div>
+                  {!service.configurable ? (
+                    <Button
+                      type="button"
+                      onClick={() =>
+                        addRequestItem(
+                          {
+                            title: service.title,
+                            quantity: 1,
+                            labor: 0,
+                            note: `${service.quoteNeeds} Materiales no incluidos salvo acuerdo.`,
+                          },
+                          service.id,
+                        )
+                      }
+                      className="mt-4 min-h-12 w-full"
+                    >
+                      Agregar a solicitud
+                    </Button>
+                  ) : null}
+                </article>
               ))}
             </div>
-          </div>
-          <div className="mt-6 grid gap-4 rounded-3xl bg-white p-5 text-slate-950 lg:grid-cols-[0.9fr_1.1fr]">
-            <div>
-              <h3 className="text-xl font-semibold">Ficha: Cambio de lámparas en comercio</h3>
-              <p className="mt-2 text-sm leading-6 text-slate-600">
-                Relevamos cantidad de luminarias, altura aproximada, horario normal o fuera de
-                horario, quién aporta materiales y si se requiere escalera especial.
-              </p>
+
+            <div className="mt-6 rounded-3xl bg-white p-5 text-slate-950">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                  <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">
+                    Mini configurador comercial
+                  </p>
+                  <h3 className="mt-2 text-xl font-semibold">Cambio de lámparas en comercio</h3>
+                </div>
+                <StatusPill>Pendiente de cotización</StatusPill>
+              </div>
+              <div className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                <label className="space-y-2 text-sm font-semibold text-slate-800">
+                  <span>Cantidad de luminarias</span>
+                  <Input
+                    className="h-12"
+                    type="number"
+                    min={1}
+                    value={commercialConfig.quantity}
+                    onChange={(e) =>
+                      setCommercialConfig({ ...commercialConfig, quantity: Number(e.target.value) })
+                    }
+                  />
+                </label>
+                <SelectField
+                  label="Altura aproximada"
+                  value={commercialConfig.height}
+                  options={['hasta 3 m', '3 a 5 m', 'más de 5 m', 'no sé']}
+                  onChange={(height) => setCommercialConfig({ ...commercialConfig, height })}
+                />
+                <SelectField
+                  label="Tipo de espacio"
+                  value={commercialConfig.spaceType}
+                  options={commercialSpaces}
+                  onChange={(spaceType) => setCommercialConfig({ ...commercialConfig, spaceType })}
+                />
+                <SelectField
+                  label="Horario"
+                  value={commercialConfig.schedule}
+                  options={commercialSchedules}
+                  onChange={(schedule) => setCommercialConfig({ ...commercialConfig, schedule })}
+                />
+                <SelectField
+                  label="Materiales"
+                  value={commercialConfig.materials}
+                  options={commercialMaterials}
+                  onChange={(materials) => setCommercialConfig({ ...commercialConfig, materials })}
+                />
+                <SelectField
+                  label="Requiere escalera especial"
+                  value={commercialConfig.ladder}
+                  options={ladderOptions}
+                  onChange={(ladder) => setCommercialConfig({ ...commercialConfig, ladder })}
+                />
+                <Textarea
+                  className="min-h-24 sm:col-span-2 lg:col-span-3"
+                  placeholder="Observaciones"
+                  value={commercialConfig.observations}
+                  onChange={(e) =>
+                    setCommercialConfig({ ...commercialConfig, observations: e.target.value })
+                  }
+                />
+              </div>
+              <Button
+                type="button"
+                onClick={addCommercialLampConfig}
+                className="mt-5 min-h-12 w-full sm:w-auto"
+              >
+                Agregar configuración a solicitud
+              </Button>
             </div>
-            <div className="grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
-              <p className="rounded-2xl bg-slate-50 p-3">
-                Local, oficina, depósito, galería o consorcio.
-              </p>
-              <p className="rounded-2xl bg-slate-50 p-3">
-                Materiales aportados por cliente o por NERIN.
-              </p>
-              <p className="rounded-2xl bg-slate-50 p-3">Altura mayor a 3 m requiere revisión.</p>
-              <p className="rounded-2xl bg-slate-50 p-3">
-                Sujeto a acceso, autorización, zona y agenda.
-              </p>
-            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      ) : null}
 
       <section
+        ref={solicitudRef}
         id="solicitud"
         className="container grid max-w-6xl gap-6 py-10 lg:grid-cols-[0.9fr_1.1fr]"
       >
@@ -660,7 +917,9 @@ export function SmallJobsExperience() {
                       }
                     />
                     <span className="text-sm text-slate-600">
-                      {money(item.labor)} mano de obra base
+                      {item.labor
+                        ? `${money(item.labor)} mano de obra base`
+                        : 'A cotizar según alcance'}
                     </span>
                   </div>
                   <p className="mt-1 text-xs leading-5 text-slate-500">{item.note}</p>


### PR DESCRIPTION
### Motivation
- Evitar la página larga e informativa que obliga al usuario a scrollear por todas las secciones para pedir un servicio. 
- Transformar la experiencia en un flujo de solicitud por modo (Servicios rápidos, Instalaciones configurables, Diagnóstico, Comercios/consorcios) para reducir fricción. 
- Hacer la `Solicitud` accesible en todo momento (especialmente en mobile) y permitir agregar, editar y eliminar ítems sin enterrarla al final de la página. 
- Mantener el diseño premium, la nomenclatura de “Solicitud” (no carrito/compra/checkout) y los motores de reglas / textos de validación existentes. 

### Description
- Reemplacé la landing monolítica por navegación por modos: añadí un control de selección (cards) en el hero y una barra sticky horizontal para cambiar categoría rápidamente, y renderizo sólo la experiencia activa mediante `activeMode` en `SmallJobsExperience.tsx`.
- Implementé feedback inmediato al agregar ítems con una notificación `Agregado a solicitud` y un botón fijo móvil `Solicitud · N servicios` que lleva al resumen usando un `solicitudRef` y `openSolicitud()`.
- Mantuve y adapté las experiencias existentes: Servicios rápidos (fichas con `Agregar a solicitud`), Instalaciones configurables (configurador directo + `Agregar a solicitud`) y Diagnóstico de fallas (fichas selectables con `Pedir revisión técnica`).
- Añadí servicios comerciales seleccionables y un mini configurador para “Cambio de lámparas en comercio” con campos (cantidad, altura, tipo de espacio, horario, materiales, escalera, observaciones) y la acción `addCommercialLampConfig()` para incorporarlo a la solicitud.
- Modifiqué el resumen/formulario de solicitud para que sea siempre accesible, permita editar cantidades, eliminar ítems y muestre labor o la etiqueta “A cotizar según alcance”.
- Archivo principal modificado: `components/electrical-services/SmallJobsExperience.tsx` (nuevas constantes `commercialRequestServices`, estados y handlers, condicionales de render y UI sticky/mobile).

### Testing
- Ejecuté `npm run lint` y no se reportaron errores críticos (aparecieron warnings de imágenes en otros componentes). 
- Ejecuté `npm run build` y la compilación y generación de páginas finalizaron correctamente aunque el build muestra mensajes de DB faltante (entorno local) que no afectan la UI estática generada. 
- Intenté `npm run dev` para ver la experiencia en modo dev pero el servidor local falló por un conflicto de rutas Next.js existente (`/sitemap.xml` vs optional catch-all) ajeno a estos cambios, por lo que no se pudo completar la verificación visual en dev.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a411b662cf48331a93b40fb91ed5c1c)