### PR TITLE
Connect electrical admin content

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/trabajos-electricos/ElectricalContentManager.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/trabajos-electricos/ElectricalContentManager.tsx
@@ -1,0 +1,359 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import type { ElectricalAdminContent } from '@/lib/electrical-admin-content'
+import { AdminMediaField } from '@/components/admin/AdminMediaField'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+
+type Tab = 'quickServices' | 'visualGuides' | 'diagnosticFaults' | 'commercialServices'
+const tabs: Array<{ id: Tab; label: string }> = [
+  { id: 'quickServices', label: 'Servicios rápidos' },
+  { id: 'visualGuides', label: 'Guías visuales' },
+  { id: 'diagnosticFaults', label: 'Diagnóstico de fallas' },
+  { id: 'commercialServices', label: 'Comercios / consorcios / countries' },
+]
+
+function lines(value: unknown) {
+  return Array.isArray(value) ? value.join('\n') : ''
+}
+function split(value: string) {
+  return value
+    .split('\n')
+    .map((x) => x.trim())
+    .filter(Boolean)
+}
+function updateAt<T>(items: T[], index: number, patch: Partial<T>) {
+  return items.map((item, i) => (i === index ? { ...item, ...patch } : item))
+}
+
+export function ElectricalContentManager({
+  initialContent,
+}: {
+  initialContent: ElectricalAdminContent
+}) {
+  const [content, setContent] = useState(initialContent)
+  const [tab, setTab] = useState<Tab>('quickServices')
+  const [status, setStatus] = useState('')
+  const activeCount = useMemo(() => (content[tab] as unknown[]).length, [content, tab])
+
+  async function save() {
+    setStatus('Guardando...')
+    const response = await fetch('/api/admin/electrical-content', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(content),
+    })
+    setStatus(
+      response.ok
+        ? 'Guardado. La web pública ya puede reflejar los cambios.'
+        : 'No se pudo guardar.',
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+          Panel administrativo
+        </p>
+        <h1 className="mt-2 text-3xl font-semibold text-slate-950">Trabajos eléctricos</h1>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+          Editor persistente conectado a la tabla WebsiteContent. Permite modificar servicios
+          rápidos, guías visuales, diagnósticos y pedidos comerciales. Si no hay contenido guardado,
+          la web usa el fallback estático versionado.
+        </p>
+      </header>
+      <div className="flex flex-wrap gap-2">
+        {tabs.map((item) => (
+          <Button
+            key={item.id}
+            type="button"
+            variant={tab === item.id ? 'primary' : 'outline'}
+            onClick={() => setTab(item.id)}
+          >
+            {item.label}
+          </Button>
+        ))}
+      </div>
+      <div className="flex items-center justify-between rounded-2xl border bg-white p-4">
+        <span className="text-sm text-slate-600">{activeCount} items</span>
+        <div className="flex gap-2">
+          <Button type="button" variant="outline" onClick={() => setContent(initialContent)}>
+            Restaurar últimos cargados
+          </Button>
+          <Button type="button" onClick={save}>
+            Guardar cambios
+          </Button>
+        </div>
+      </div>
+      {status ? (
+        <p className="rounded-xl bg-slate-100 p-3 text-sm text-slate-700">{status}</p>
+      ) : null}
+
+      {tab === 'quickServices' ? (
+        <div className="space-y-4">
+          {content.quickServices.map((service, index) => (
+            <article key={service.id} className="space-y-3 rounded-2xl border bg-white p-4">
+              <div className="grid gap-3 md:grid-cols-3">
+                <Input
+                  value={service.title}
+                  onChange={(e) =>
+                    setContent((c) => ({
+                      ...c,
+                      quickServices: updateAt(c.quickServices, index, { title: e.target.value }),
+                    }))
+                  }
+                />
+                <Input
+                  type="number"
+                  value={service.baseLaborPrice}
+                  onChange={(e) =>
+                    setContent((c) => ({
+                      ...c,
+                      quickServices: updateAt(c.quickServices, index, {
+                        baseLaborPrice: Number(e.target.value),
+                      }),
+                    }))
+                  }
+                />
+                <Input value={`${service.durationMin}-${service.durationMax} min`} readOnly />
+              </div>
+              <Textarea
+                value={service.description}
+                onChange={(e) =>
+                  setContent((c) => ({
+                    ...c,
+                    quickServices: updateAt(c.quickServices, index, {
+                      description: e.target.value,
+                    }),
+                  }))
+                }
+              />
+              <div className="grid gap-3 md:grid-cols-3">
+                <Textarea
+                  value={lines(service.usualMaterials)}
+                  onChange={(e) =>
+                    setContent((c) => ({
+                      ...c,
+                      quickServices: updateAt(c.quickServices, index, {
+                        usualMaterials: split(e.target.value),
+                      }),
+                    }))
+                  }
+                  placeholder="Materiales habituales"
+                />
+                <Textarea
+                  value={service.appliesWhen}
+                  onChange={(e) =>
+                    setContent((c) => ({
+                      ...c,
+                      quickServices: updateAt(c.quickServices, index, {
+                        appliesWhen: e.target.value,
+                      }),
+                    }))
+                  }
+                  placeholder="Aplica si"
+                />
+                <Textarea
+                  value={service.doesNotApplyWhen}
+                  onChange={(e) =>
+                    setContent((c) => ({
+                      ...c,
+                      quickServices: updateAt(c.quickServices, index, {
+                        doesNotApplyWhen: e.target.value,
+                      }),
+                    }))
+                  }
+                  placeholder="No aplica si"
+                />
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null}
+
+      {tab === 'visualGuides' ? (
+        <div className="space-y-4">
+          {content.visualGuides.map((item, index) => (
+            <article key={item.serviceId} className="space-y-3 rounded-2xl border bg-white p-4">
+              <div className="grid gap-3 md:grid-cols-2">
+                <Input
+                  value={item.visualGuide.diagramTitle}
+                  onChange={(e) =>
+                    setContent((c) => ({
+                      ...c,
+                      visualGuides: updateAt(c.visualGuides, index, {
+                        visualGuide: { ...item.visualGuide, diagramTitle: e.target.value },
+                      }),
+                    }))
+                  }
+                />
+                <Input
+                  value={item.visualGuide.diagramSubtitle}
+                  onChange={(e) =>
+                    setContent((c) => ({
+                      ...c,
+                      visualGuides: updateAt(c.visualGuides, index, {
+                        visualGuide: { ...item.visualGuide, diagramSubtitle: e.target.value },
+                      }),
+                    }))
+                  }
+                />
+              </div>
+              <AdminMediaField
+                id={`guide-${item.serviceId}`}
+                label="Subir imagen"
+                value={item.visualGuide.imageSrc}
+                uploadFolder="service-guides"
+                allowManualUrl
+                onChange={(value) =>
+                  setContent((c) => ({
+                    ...c,
+                    visualGuides: updateAt(c.visualGuides, index, {
+                      visualGuide: { ...item.visualGuide, imageSrc: value },
+                    }),
+                  }))
+                }
+              />
+              <Input
+                value={item.visualGuide.imageAlt}
+                onChange={(e) =>
+                  setContent((c) => ({
+                    ...c,
+                    visualGuides: updateAt(c.visualGuides, index, {
+                      visualGuide: { ...item.visualGuide, imageAlt: e.target.value },
+                    }),
+                  }))
+                }
+                placeholder="Alt de imagen"
+              />
+              <div className="grid gap-3 md:grid-cols-3">
+                <Textarea
+                  value={lines(item.visualGuide.appliesIf)}
+                  onChange={(e) =>
+                    setContent((c) => ({
+                      ...c,
+                      visualGuides: updateAt(c.visualGuides, index, {
+                        visualGuide: { ...item.visualGuide, appliesIf: split(e.target.value) },
+                      }),
+                    }))
+                  }
+                  placeholder="Aplica si"
+                />
+                <Textarea
+                  value={lines(item.visualGuide.doesNotApplyIf)}
+                  onChange={(e) =>
+                    setContent((c) => ({
+                      ...c,
+                      visualGuides: updateAt(c.visualGuides, index, {
+                        visualGuide: { ...item.visualGuide, doesNotApplyIf: split(e.target.value) },
+                      }),
+                    }))
+                  }
+                  placeholder="No aplica si"
+                />
+                <Input
+                  value={item.visualGuide.durationLabel}
+                  onChange={(e) =>
+                    setContent((c) => ({
+                      ...c,
+                      visualGuides: updateAt(c.visualGuides, index, {
+                        visualGuide: { ...item.visualGuide, durationLabel: e.target.value },
+                      }),
+                    }))
+                  }
+                  placeholder="Duración"
+                />
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null}
+
+      {tab === 'diagnosticFaults' ? (
+        <div className="space-y-4">
+          {content.diagnosticFaults.map((fault, index) => (
+            <article key={fault.id} className="space-y-3 rounded-2xl border bg-white p-4">
+              <div className="grid gap-3 md:grid-cols-3">
+                <Input
+                  value={fault.faultName}
+                  onChange={(e) =>
+                    setContent((c) => ({
+                      ...c,
+                      diagnosticFaults: updateAt(c.diagnosticFaults, index, {
+                        faultName: e.target.value,
+                      }),
+                    }))
+                  }
+                />
+                <Input
+                  type="number"
+                  value={fault.initialPrice}
+                  onChange={(e) =>
+                    setContent((c) => ({
+                      ...c,
+                      diagnosticFaults: updateAt(c.diagnosticFaults, index, {
+                        initialPrice: Number(e.target.value),
+                      }),
+                    }))
+                  }
+                />
+                <Input
+                  type="number"
+                  value={fault.includedMinutes}
+                  onChange={(e) =>
+                    setContent((c) => ({
+                      ...c,
+                      diagnosticFaults: updateAt(c.diagnosticFaults, index, {
+                        includedMinutes: Number(e.target.value),
+                      }),
+                    }))
+                  }
+                />
+              </div>
+              <Textarea
+                value={lines(fault.possibleCauses)}
+                onChange={(e) =>
+                  setContent((c) => ({
+                    ...c,
+                    diagnosticFaults: updateAt(c.diagnosticFaults, index, {
+                      possibleCauses: split(e.target.value),
+                    }),
+                  }))
+                }
+                placeholder="Posibles causas"
+              />
+              <Textarea
+                value={fault.disclaimer}
+                onChange={(e) =>
+                  setContent((c) => ({
+                    ...c,
+                    diagnosticFaults: updateAt(c.diagnosticFaults, index, {
+                      disclaimer: e.target.value,
+                    }),
+                  }))
+                }
+                placeholder="Disclaimer"
+              />
+            </article>
+          ))}
+        </div>
+      ) : null}
+      {tab === 'commercialServices' ? (
+        <Textarea
+          className="min-h-[420px] font-mono"
+          value={JSON.stringify(content.commercialServices, null, 2)}
+          onChange={(e) => {
+            try {
+              setContent((c) => ({ ...c, commercialServices: JSON.parse(e.target.value) }))
+            } catch {
+              setStatus('JSON comercial inválido; corregilo antes de guardar.')
+            }
+          }}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/trabajos-electricos/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/trabajos-electricos/page.tsx
@@ -1,0 +1,10 @@
+import { getElectricalAdminContent } from '@/lib/electrical-admin-content'
+import { ElectricalContentManager } from './ElectricalContentManager'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export default async function AdminTrabajosElectricosPage() {
+  const content = await getElectricalAdminContent()
+  return <ElectricalContentManager initialContent={content} />
+}

--- a/nerin-electric-site-v3-fixed/app/(site)/trabajos-electricos/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(site)/trabajos-electricos/page.tsx
@@ -1,4 +1,5 @@
 import { SmallJobsExperience } from '@/components/electrical-services/SmallJobsExperience'
+import { getElectricalAdminContent } from '@/lib/electrical-admin-content'
 import { breadcrumbJsonLd, buildSeoMetadata } from '@/lib/seo'
 
 export const metadata = buildSeoMetadata({
@@ -8,7 +9,8 @@ export const metadata = buildSeoMetadata({
   path: '/trabajos-electricos',
 })
 
-export default function TrabajosElectricosPage() {
+export default async function TrabajosElectricosPage() {
+  const content = await getElectricalAdminContent()
   const breadcrumbs = breadcrumbJsonLd([
     { name: 'Inicio', path: '/' },
     { name: 'Trabajos electricos', path: '/trabajos-electricos' },
@@ -20,7 +22,7 @@ export default function TrabajosElectricosPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }}
       />
-      <SmallJobsExperience />
+      <SmallJobsExperience content={content} />
     </>
   )
 }

--- a/nerin-electric-site-v3-fixed/app/api/admin/electrical-content/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/electrical-content/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import { revalidatePath } from 'next/cache'
+import { requireAdmin } from '@/lib/auth'
+import {
+  getElectricalAdminContent,
+  saveElectricalAdminContent,
+} from '@/lib/electrical-admin-content'
+
+export const runtime = 'nodejs'
+
+export async function GET() {
+  await requireAdmin()
+  const content = await getElectricalAdminContent()
+  return NextResponse.json(content)
+}
+
+export async function PUT(req: Request) {
+  await requireAdmin()
+  const body = await req.json()
+  await saveElectricalAdminContent(body)
+  revalidatePath('/trabajos-electricos')
+  revalidatePath('/admin/trabajos-electricos')
+  return NextResponse.json({ ok: true })
+}

--- a/nerin-electric-site-v3-fixed/components/admin/nav.ts
+++ b/nerin-electric-site-v3-fixed/components/admin/nav.ts
@@ -18,6 +18,7 @@ export const adminNav: AdminNavSection[] = [
       { title: 'Consultas', href: '/admin/consultas' as Route },
       { title: 'Presupuestos', href: '/admin/presupuestos' as Route },
       { title: 'Trabajos chicos', href: '/admin/trabajos-chicos' as Route },
+      { title: 'Trabajos eléctricos', href: '/admin/trabajos-electricos' as Route },
       { title: 'Refacciones', href: '/admin/refacciones' as Route },
       { title: 'Obras', href: '/admin/obras' as Route },
       { title: 'Dinero', href: '/admin/dinero' as Route },
@@ -32,5 +33,7 @@ export function findAdminNavMatch(pathname: string) {
   )
 
   const sorted = [...flatItems].sort((a, b) => b.href.length - a.href.length)
-  return sorted.find((item) => pathname === item.href || pathname.startsWith(`${item.href}/`)) ?? null
+  return (
+    sorted.find((item) => pathname === item.href || pathname.startsWith(`${item.href}/`)) ?? null
+  )
 }

--- a/nerin-electric-site-v3-fixed/components/electrical-services/SmallJobsExperience.tsx
+++ b/nerin-electric-site-v3-fixed/components/electrical-services/SmallJobsExperience.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import Image from 'next/image'
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import {
   CheckCircle2,
@@ -27,6 +26,7 @@ import {
   visualGuidesByServiceId,
   type ElectricalServiceVisualGuide,
 } from '@/data/electricalServiceVisualGuides'
+import type { ElectricalAdminContent } from '@/lib/electrical-admin-content'
 import { generateTechnicalSummary, type InstallationSelection } from './estimateRules'
 
 function money(value: number) {
@@ -522,13 +522,11 @@ function ServiceGuideImage({
       className={`relative overflow-hidden rounded-3xl border border-slate-200 bg-gradient-to-br from-white via-slate-50 to-blue-50/60 ${large ? 'min-h-[280px]' : 'min-h-[210px]'}`}
     >
       {showImage ? (
-        <Image
+        <img
           src={guide.imageSrc}
           alt={guide.imageAlt}
-          fill
-          sizes={large ? '(min-width: 1024px) 50vw, 100vw' : '(min-width: 1024px) 45vw, 100vw'}
           onError={() => setFailed(true)}
-          className="object-cover"
+          className="absolute inset-0 h-full w-full object-cover"
         />
       ) : (
         <div className="flex min-h-[inherit] flex-col justify-between p-5">
@@ -773,9 +771,19 @@ function ServiceGuideModal({
   )
 }
 
-export function SmallJobsExperience() {
+export function SmallJobsExperience({ content }: { content?: ElectricalAdminContent } = {}) {
+  const quickServicesData = content?.quickServices ?? quickServices
+  const diagnosticFaultsData = content?.diagnosticFaults ?? diagnosticFaults
+  const visualGuidesData = content?.visualGuides?.length
+    ? (Object.fromEntries(
+        content.visualGuides.map((guide) => [guide.serviceId, guide.visualGuide]),
+      ) as typeof visualGuidesByServiceId)
+    : visualGuidesByServiceId
+  const commercialRequestServicesData = content?.commercialServices?.length
+    ? (content.commercialServices as typeof commercialRequestServices)
+    : commercialRequestServices
   const [activeMode, setActiveMode] = useState(entryCards[0].id)
-  const [openService, setOpenService] = useState<string | null>(quickServices[0]?.id ?? null)
+  const [openService, setOpenService] = useState<string | null>(quickServicesData[0]?.id ?? null)
   const [guideService, setGuideService] = useState<ElectricalService | null>(null)
   const [addedLabel, setAddedLabel] = useState<string | null>(null)
   const [lastAddedId, setLastAddedId] = useState<string | null>(null)
@@ -1145,7 +1153,7 @@ export function SmallJobsExperience() {
       {guideService ? (
         <ServiceGuideModal
           service={guideService}
-          guide={visualGuidesByServiceId[guideService.id]}
+          guide={visualGuidesData[guideService.id]}
           onClose={() => setGuideService(null)}
           onChoose={() => {
             setGuideService(null)
@@ -1332,11 +1340,11 @@ export function SmallJobsExperience() {
             </p>
           </div>
           <div className="mt-6 grid gap-4 lg:grid-cols-2">
-            {quickServices.map((service) => (
+            {quickServicesData.map((service) => (
               <ServiceVisualCard
                 key={service.id}
                 service={service}
-                guide={visualGuidesByServiceId[service.id]}
+                guide={visualGuidesData[service.id]}
                 isOpen={openService === service.id}
                 onToggleDetail={() =>
                   setOpenService(openService === service.id ? null : service.id)
@@ -1509,7 +1517,7 @@ export function SmallJobsExperience() {
             </div>
           </div>
           <div className="mt-6 grid gap-3 lg:grid-cols-2">
-            {diagnosticFaults.map((fault) => (
+            {diagnosticFaultsData.map((fault) => (
               <details key={fault.id} className="rounded-2xl border border-slate-200 bg-white p-4">
                 <summary className="cursor-pointer text-sm font-semibold text-slate-950 sm:text-base">
                   {fault.faultName} · diagnóstico inicial {money(fault.initialPrice)}
@@ -1595,7 +1603,7 @@ export function SmallJobsExperience() {
             </div>
 
             <div className="mt-6 grid gap-4 lg:grid-cols-2">
-              {commercialRequestServices.map((service) => (
+              {commercialRequestServicesData.map((service) => (
                 <article
                   key={service.id}
                   className="rounded-3xl border border-white/10 bg-white p-5 text-slate-950 shadow-sm"

--- a/nerin-electric-site-v3-fixed/lib/electrical-admin-content.ts
+++ b/nerin-electric-site-v3-fixed/lib/electrical-admin-content.ts
@@ -1,0 +1,60 @@
+import { prisma } from '@/lib/db'
+import { quickServices, diagnosticFaults } from '@/data/electricalServices'
+import { electricalServiceVisualGuides } from '@/data/electricalServiceVisualGuides'
+
+export type ElectricalAdminContent = {
+  quickServices: typeof quickServices
+  visualGuides: typeof electricalServiceVisualGuides
+  diagnosticFaults: typeof diagnosticFaults
+  commercialServices: Array<Record<string, unknown>>
+}
+
+export const ELECTRICAL_CONTENT_KEY = 'electrical_services_admin_v1'
+
+export const defaultElectricalContent: ElectricalAdminContent = {
+  quickServices,
+  visualGuides: electricalServiceVisualGuides,
+  diagnosticFaults,
+  commercialServices: [],
+}
+
+function mergeContent(raw: unknown): ElectricalAdminContent {
+  if (!raw || typeof raw !== 'object') return defaultElectricalContent
+  const value = raw as Partial<ElectricalAdminContent>
+  return {
+    quickServices: Array.isArray(value.quickServices)
+      ? (value.quickServices as typeof quickServices)
+      : quickServices,
+    visualGuides: Array.isArray(value.visualGuides)
+      ? (value.visualGuides as typeof electricalServiceVisualGuides)
+      : electricalServiceVisualGuides,
+    diagnosticFaults: Array.isArray(value.diagnosticFaults)
+      ? (value.diagnosticFaults as typeof diagnosticFaults)
+      : diagnosticFaults,
+    commercialServices: Array.isArray(value.commercialServices) ? value.commercialServices : [],
+  }
+}
+
+export async function getElectricalAdminContent(): Promise<ElectricalAdminContent> {
+  try {
+    const row = await prisma.websiteContent.findUnique({ where: { key: ELECTRICAL_CONTENT_KEY } })
+    if (!row?.content) return defaultElectricalContent
+    return mergeContent(JSON.parse(row.content))
+  } catch (error) {
+    console.warn('[electrical-content] Using static fallback.', error)
+    return defaultElectricalContent
+  }
+}
+
+export async function saveElectricalAdminContent(content: ElectricalAdminContent) {
+  return prisma.websiteContent.upsert({
+    where: { key: ELECTRICAL_CONTENT_KEY },
+    create: {
+      key: ELECTRICAL_CONTENT_KEY,
+      title: 'Trabajos eléctricos',
+      content: JSON.stringify(content),
+      visible: true,
+    },
+    update: { content: JSON.stringify(content), visible: true },
+  })
+}

--- a/nerin-electric-site-v3-fixed/lib/media.ts
+++ b/nerin-electric-site-v3-fixed/lib/media.ts
@@ -79,7 +79,43 @@ export function resolveMediaPath(parts: string[]) {
 }
 
 export function getMediaPublicUrl(filename: string) {
-  return `/media/${filename.split('/').map((part) => encodeURIComponent(part)).join('/')}`
+  return `/media/${filename
+    .split('/')
+    .map((part) => encodeURIComponent(part))
+    .join('/')}`
+}
+
+async function storeCloudinaryImage(file: File, folder: string): Promise<StoredMediaFile> {
+  const cloudName = process.env.CLOUDINARY_CLOUD_NAME
+  const uploadPreset = process.env.CLOUDINARY_UPLOAD_PRESET
+  if (!cloudName || !uploadPreset) {
+    throw new Error(
+      'Storage externo no configurado: faltan CLOUDINARY_CLOUD_NAME y CLOUDINARY_UPLOAD_PRESET.',
+    )
+  }
+  const formData = new FormData()
+  formData.append('file', file)
+  formData.append('upload_preset', uploadPreset)
+  if (folder) formData.append('folder', folder)
+  const response = await fetch(`https://api.cloudinary.com/v1_1/${cloudName}/image/upload`, {
+    method: 'POST',
+    body: formData,
+  })
+  const payload = (await response.json().catch(() => null)) as {
+    secure_url?: string
+    public_id?: string
+    error?: { message?: string }
+  } | null
+  if (!response.ok || !payload?.secure_url) {
+    throw new Error(payload?.error?.message ?? 'No se pudo subir la imagen a Cloudinary')
+  }
+  return {
+    originalName: file.name,
+    mimeType: file.type,
+    size: file.size,
+    storedPath: payload.public_id ?? payload.secure_url,
+    publicUrl: payload.secure_url,
+  }
 }
 
 export async function storeMediaFile({
@@ -100,6 +136,14 @@ export async function storeMediaFile({
   }
 
   const safeFolder = sanitizeMediaFolder(folder)
+
+  if (process.env.STORAGE_PROVIDER === 'cloudinary') {
+    if (!file.type.startsWith('image/')) {
+      throw new Error('Cloudinary está configurado solo para imágenes en este endpoint.')
+    }
+    return storeCloudinaryImage(file, safeFolder)
+  }
+
   const originalName = preferredName ?? file.name ?? 'archivo'
   const safeName = sanitizeMediaFilename(originalName)
   const uniqueName = `${Date.now()}-${crypto.randomUUID()}-${safeName}`

--- a/nerin-electric-site-v3-fixed/middleware.ts
+++ b/nerin-electric-site-v3-fixed/middleware.ts
@@ -6,5 +6,7 @@ export const middleware: NextMiddleware = (request: NextRequest) => baseMiddlewa
 export default middleware
 
 export const config = {
-  matcher: ['/((?!api/auth|api/health|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)'],
+  matcher: [
+    '/((?!api/auth|api/health|_next/static|_next/image|images|media|uploads|favicon.ico|robots.txt|sitemap.xml|.*\\.(?:png|jpg|jpeg|webp|svg|gif|ico)$).*)',
+  ],
 }


### PR DESCRIPTION
### Motivation

- Unir la parte pública de `/trabajos-electricos` con el admin para que los cambios hechos por el panel sean persistentes y se reflejen en la web pública. 
- Permitir carga de imágenes desde el admin como archivos (no solo URL) y ofrecer una opción de storage externo para producción. 
- Evitar errores de `next/image` al intentar optimizar rutas inexistentes y mantener fallback seguro a los datos estáticos si la DB no está preparada. 

### Description

- Añadí un adaptador persistente para el contenido eléctrico en `lib/electrical-admin-content.ts` que guarda/lee JSON en la tabla `WebsiteContent` de Prisma y devuelve un fallback a los datos TypeScript estáticos si no hay fila o la DB falla. 
- Creé endpoints protegidos para administrar ese contenido en `app/api/admin/electrical-content/route.ts` y una UI administrativa en `app/(admin)/admin/(shell)/trabajos-electricos/ElectricalContentManager.tsx` + `page.tsx` que permite editar servicios rápidos, guías visuales, diagnósticos y datos comerciales. 
- Conecté la página pública `app/(site)/trabajos-electricos/page.tsx` para consumir `getElectricalAdminContent()` y pasarlo al componente público `SmallJobsExperience`, el cual ahora acepta contenido administrado con fallback; además cambié las guías visuales para usar `<img>` con `onError` y placeholder para evitar que `next/image` falle con archivos inexistentes. 
- Añadí soporte de storage externo en `lib/media.ts` (opción `STORAGE_PROVIDER=cloudinary`) manteniendo el almacenamiento local para desarrollo, y ajusté `middleware.ts` para excluir assets estáticos y rutas de imágenes/media/uploads de la evaluación del middleware. 

### Testing

- Ejecuté `npm run lint` y la ejecución terminó con éxito mostrando solo advertencias de uso de `<img>` en algunos componentes (aceptadas en este cambio); resultado: lint OK (warnings). 
- Ejecuté la suite de tests con `npm test` (Vitest) y todos los tests unitarios pasaron (`22 passed`). 
- Ejecuté `npm run build` y la build se completó correctamente con mensajes de advertencia relacionados con entorno/DB ausente durante la compilación y con logs de Prisma sobre tablas faltantes en el entorno de build; resultado: build OK (warnings y fallback a datos estáticos durante la build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47ae5dab8c8331aa28e42680140991)