### PR TITLE
Unificar admin madre de contenido eléctrico

### DIFF
--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/contacto/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/contacto/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function RedirectLegacyContactoAdminPage() {
+  redirect('/admin/contenido-comercial')
+}

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/contenido/media/MediaLibraryManager.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/contenido/media/MediaLibraryManager.tsx
@@ -9,9 +9,14 @@ import { Input } from '@/components/ui/input'
 export function MediaLibraryManager({ initialMedia, technicalStatus }: { initialMedia: MediaLibraryItem[]; technicalStatus: AdminTechnicalStatus }) {
   const [media, setMedia] = useState(initialMedia)
   const [status, setStatus] = useState('')
+  const canUpload = technicalStatus.uploadPersistent
 
   async function upload(file: File | null) {
     if (!file) return
+    if (!canUpload) {
+      setStatus('Storage persistente no configurado. No se subió el archivo para evitar uploads que se pierdan.')
+      return
+    }
     setStatus('Subiendo imagen...')
     const form = new FormData()
     form.append('file', file)
@@ -23,7 +28,7 @@ export function MediaLibraryManager({ initialMedia, technicalStatus }: { initial
       return
     }
     setMedia((items) => [payload.media ?? { id: payload.storedPath, url: payload.url, name: file.name, createdAt: new Date().toISOString() }, ...items])
-    setStatus('Imagen subida correctamente. Copiá la URL o usala en guías visuales.')
+    setStatus('Imagen subida correctamente y registrada en la biblioteca.')
   }
 
   return (
@@ -33,16 +38,32 @@ export function MediaLibraryManager({ initialMedia, technicalStatus }: { initial
         <h1 className="mt-2 text-3xl font-semibold text-slate-950">Biblioteca de medios</h1>
         <p className="mt-2 text-sm text-slate-600">Subí png, jpg, jpeg, webp o svg. No se guardan uploads dinámicos en /public.</p>
       </header>
-      {!technicalStatus.uploadPersistent ? <p className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-800">No hay storage persistente configurado. No se debe confiar en estos uploads hasta configurar Cloudinary o Render Disk.</p> : null}
+
+      <section className="grid gap-3 md:grid-cols-3">
+        <Status label="Provider" value={technicalStatus.storageProvider} danger={!canUpload} />
+        <Status label="Upload persistente" value={canUpload ? 'Sí' : 'No'} danger={!canUpload} />
+        <Status label="Storage dir" value={technicalStatus.storageDirLabel} danger={!canUpload} />
+      </section>
+
+      {!canUpload ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          <p className="font-semibold">Uploads bloqueados</p>
+          <p className="mt-1">Configurá Cloudinary, S3, R2, Supabase Storage, UploadThing o Render Disk antes de subir imágenes desde el admin.</p>
+          {technicalStatus.warnings.length ? <ul className="mt-2 list-disc pl-5">{technicalStatus.warnings.map((warning) => <li key={warning}>{warning}</li>)}</ul> : null}
+        </div>
+      ) : null}
+
       <div className="rounded-2xl border bg-white p-4">
-        <Input type="file" accept="image/png,image/jpeg,image/webp,image/svg+xml" onChange={(event) => void upload(event.target.files?.[0] ?? null)} />
+        <Input type="file" accept="image/png,image/jpeg,image/webp,image/svg+xml" disabled={!canUpload} onChange={(event) => void upload(event.target.files?.[0] ?? null)} />
         {status ? <p className="mt-3 text-sm text-slate-700">{status}</p> : null}
       </div>
+
       <div className="grid gap-4 md:grid-cols-3">
         {media.map((item) => (
           <article key={item.id} className="rounded-2xl border bg-white p-4">
             {item.url.match(/\.(png|jpe?g|webp|svg|gif)(\?|$)/i) || item.url.startsWith('http') ? <img src={item.url} alt={item.name} className="h-40 w-full rounded-xl object-cover" /> : null}
             <p className="mt-3 font-semibold text-slate-950">{item.name}</p>
+            <p className="mt-1 text-xs text-slate-500">{item.provider ?? 'storage'} · {item.mimeType ?? 'archivo'}</p>
             <Input className="mt-2" value={item.url} readOnly onFocus={(e) => e.currentTarget.select()} />
             <Button className="mt-2" type="button" variant="outline" onClick={() => void navigator.clipboard.writeText(item.url)}>Copiar URL</Button>
           </article>
@@ -50,4 +71,8 @@ export function MediaLibraryManager({ initialMedia, technicalStatus }: { initial
       </div>
     </div>
   )
+}
+
+function Status({ label, value, danger }: { label: string; value: string; danger?: boolean }) {
+  return <div className={`rounded-2xl border p-4 ${danger ? 'border-red-200 bg-red-50 text-red-900' : 'border-emerald-200 bg-emerald-50 text-emerald-900'}`}><p className="text-xs font-semibold uppercase tracking-wide">{label}</p><p className="mt-1 text-lg font-semibold">{value}</p></div>
 }

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/contenido/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/contenido/page.tsx
@@ -1,26 +1,27 @@
 import Link from 'next/link'
 import type { Route } from 'next'
 import { getAdminTechnicalStatus } from '@/lib/admin-technical-status'
-import { getElectricalAdminContent } from '@/lib/electrical-admin-content'
+import { getElectricalAdminContentState } from '@/lib/electrical-admin-content'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
 const sections: Array<{ title: string; description: string; href: Route; status: string }> = [
-  { title: 'Trabajos eléctricos', description: 'Servicios rápidos, guías visuales, diagnóstico y trabajos para comercios/consorcios/countries.', href: '/admin/contenido/trabajos-electricos' as Route, status: 'Conectado a WebsiteContent' },
-  { title: 'Imágenes / Biblioteca de medios', description: 'Carga de archivos, preview, URL final y selección para guías visuales.', href: '/admin/contenido/media' as Route, status: 'Conectado al storage configurado' },
-  { title: 'Home', description: 'Hero, textos principales, CTAs, servicios destacados e imágenes.', href: '/admin/contenido-comercial' as Route, status: 'Migración progresiva: WebsiteContent/SiteExperience' },
-  { title: 'Refacciones', description: 'Textos, secciones, CTA y configuración del formulario.', href: '/admin/contenido-comercial' as Route, status: 'Pendiente de extraer de contenido comercial' },
-  { title: 'Obras', description: 'Textos, secciones, CTA y configuración del formulario.', href: '/admin/contenido-comercial' as Route, status: 'Pendiente de extraer de contenido comercial' },
-  { title: 'Contacto', description: 'Teléfono, WhatsApp, email, zona, horarios y textos de formulario.', href: '/admin/ajustes' as Route, status: 'Conectado a ajustes generales' },
-  { title: 'Ajustes generales', description: 'Identidad, contacto y parámetros técnicos compartidos.', href: '/admin/ajustes' as Route, status: 'Configuración global' },
+  { title: 'Trabajos eléctricos', description: 'Servicios rápidos, guías visuales, diagnóstico y pedidos comerciales.', href: '/admin/contenido/trabajos-electricos' as Route, status: 'WebsiteContent' },
+  { title: 'Biblioteca de medios', description: 'Subida de imágenes, preview, URL final y selección para guías visuales.', href: '/admin/contenido/media' as Route, status: 'Storage persistente' },
+  { title: 'Home', description: 'Hero, textos principales, CTAs, servicios destacados e imágenes.', href: '/admin/contenido-comercial' as Route, status: 'SiteExperience' },
+  { title: 'Refacciones', description: 'Textos, secciones, CTA y configuración del formulario.', href: '/admin/contenido-comercial' as Route, status: 'SiteExperience' },
+  { title: 'Obras', description: 'Textos, secciones, CTA y configuración del formulario.', href: '/admin/contenido-comercial' as Route, status: 'SiteExperience' },
+  { title: 'Contacto', description: 'WhatsApp, teléfono, email, zona, horarios y textos de formulario.', href: '/admin/ajustes' as Route, status: 'Ajustes' },
+  { title: 'Ajustes generales', description: 'Identidad, contacto y parámetros técnicos compartidos.', href: '/admin/ajustes' as Route, status: 'Global' },
 ]
 
 export default async function AdminContenidoPage() {
-  const [technicalStatus, electricalContent] = await Promise.all([
+  const [technicalStatus, electricalState] = await Promise.all([
     getAdminTechnicalStatus(),
-    getElectricalAdminContent(),
+    getElectricalAdminContentState(),
   ])
+  const warnings = [...new Set([...technicalStatus.warnings, ...electricalState.status.warnings])]
 
   return (
     <div className="space-y-6">
@@ -28,25 +29,25 @@ export default async function AdminContenidoPage() {
         <p className="text-sm font-semibold uppercase tracking-wide text-amber-600">Admin madre</p>
         <h1 className="mt-2 text-3xl font-semibold text-slate-950">Contenido público de NERIN</h1>
         <p className="mt-2 max-w-4xl text-sm leading-6 text-slate-600">
-          Esta es la entrada única para contenido editable del sitio. La fuente de verdad elegida es
-          <strong> WebsiteContent</strong> para contenido público versionable en JSON, con fallback estático solo como respaldo visible.
+          Entrada única para editar contenido público. Trabajos eléctricos usa WebsiteContent; TypeScript queda solo como fallback informado.
         </p>
       </header>
 
-      <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-        <Status label="DB configurada" value={technicalStatus.dbConfigured ? 'Sí' : 'No'} danger={!technicalStatus.dbConfigured} />
+      <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        <Status label="DB persistente" value={technicalStatus.dbPersistent ? 'Sí' : 'No'} danger={!technicalStatus.dbPersistent} />
         <Status label="DB temporal" value={technicalStatus.dbTemporary ? 'Sí' : 'No'} danger={technicalStatus.dbTemporary} />
         <Status label="Storage configurado" value={technicalStatus.storageConfigured ? 'Sí' : 'No'} danger={!technicalStatus.storageConfigured} />
         <Status label="Upload persistente" value={technicalStatus.uploadPersistent ? 'Sí' : 'No'} danger={!technicalStatus.uploadPersistent} />
+        <Status label="Fallback eléctrico" value={electricalState.status.isFallback ? 'Sí' : 'No'} danger={electricalState.status.isFallback} />
       </section>
 
-      {technicalStatus.warnings.length ? (
+      {warnings.length ? (
         <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
           <p className="font-semibold">Advertencias técnicas</p>
           <ul className="mt-2 list-disc space-y-1 pl-5">
-            {technicalStatus.warnings.map((warning) => <li key={warning}>{warning}</li>)}
+            {warnings.map((warning) => <li key={warning}>{warning}</li>)}
           </ul>
-          <p className="mt-3">Provider de storage activo: <strong>{technicalStatus.storageProvider}</strong></p>
+          <p className="mt-3">DB: <strong>{technicalStatus.databaseUrlLabel}</strong> · Storage: <strong>{technicalStatus.storageProvider}</strong> · Dir: <strong>{technicalStatus.storageDirLabel}</strong></p>
         </div>
       ) : null}
 
@@ -62,8 +63,8 @@ export default async function AdminContenidoPage() {
 
       <section className="rounded-2xl border bg-white p-5 text-sm text-slate-700">
         <h2 className="text-lg font-semibold text-slate-950">Estado de contenido eléctrico</h2>
-        <p className="mt-2">Servicios rápidos: {electricalContent.quickServices.length} · Guías visuales: {electricalContent.visualGuides.length} · Diagnósticos: {electricalContent.diagnosticFaults.length} · Comercial: {electricalContent.commercialServices.length}</p>
-        <p className="mt-2 text-amber-700">Si no hay fila guardada en WebsiteContent, la web pública usa fallback estático y este admin lo informa como respaldo, no como persistencia real.</p>
+        <p className="mt-2">Servicios rápidos: {electricalState.content.quickServices.length} · Guías visuales: {electricalState.content.visualGuides.length} · Diagnósticos: {electricalState.content.diagnosticFaults.length} · Comercial: {electricalState.content.commercialServices.length}</p>
+        <p className="mt-2 text-amber-700">Contenido guardado: {electricalState.status.hasPersistedContent ? 'sí' : 'no'}.</p>
       </section>
     </div>
   )

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/contenido/trabajos-electricos/page.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/contenido/trabajos-electricos/page.tsx
@@ -1,10 +1,10 @@
-import { getElectricalAdminContent } from '@/lib/electrical-admin-content'
+import { getElectricalAdminContentState } from '@/lib/electrical-admin-content'
 import { ElectricalContentManager } from '../../trabajos-electricos/ElectricalContentManager'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
 export default async function AdminContenidoTrabajosElectricosPage() {
-  const content = await getElectricalAdminContent()
-  return <ElectricalContentManager initialContent={content} />
+  const state = await getElectricalAdminContentState()
+  return <ElectricalContentManager initialState={state} />
 }

--- a/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/trabajos-electricos/ElectricalContentManager.tsx
+++ b/nerin-electric-site-v3-fixed/app/(admin)/admin/(shell)/trabajos-electricos/ElectricalContentManager.tsx
@@ -1,13 +1,18 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import type { ElectricalAdminContent } from '@/lib/electrical-admin-content'
+import type {
+  ElectricalAdminContent,
+  ElectricalAdminContentState,
+  ManagedCommercialElectricalService,
+} from '@/lib/electrical-admin-content'
 import { AdminMediaField } from '@/components/admin/AdminMediaField'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 
 type Tab = 'quickServices' | 'visualGuides' | 'diagnosticFaults' | 'commercialServices'
+
 const tabs: Array<{ id: Tab; label: string }> = [
   { id: 'quickServices', label: 'Servicios rápidos' },
   { id: 'visualGuides', label: 'Guías visuales' },
@@ -18,156 +23,191 @@ const tabs: Array<{ id: Tab; label: string }> = [
 function lines(value: unknown) {
   return Array.isArray(value) ? value.join('\n') : ''
 }
+
 function split(value: string) {
-  return value
-    .split('\n')
-    .map((x) => x.trim())
-    .filter(Boolean)
+  return value.split('\n').map((x) => x.trim()).filter(Boolean)
 }
+
 function updateAt<T>(items: T[], index: number, patch: Partial<T>) {
   return items.map((item, i) => (i === index ? { ...item, ...patch } : item))
 }
 
-export function ElectricalContentManager({
-  initialContent,
-}: {
-  initialContent: ElectricalAdminContent
-}) {
-  const [content, setContent] = useState(initialContent)
+function parseCallouts(value: string) {
+  return split(value).map((line, index) => {
+    const match = line.match(/^(\d+)\s*[).:-]?\s*(.*)$/)
+    return { number: match ? Number(match[1]) : index + 1, label: match?.[2]?.trim() || line }
+  })
+}
+
+function calloutLines(value: Array<{ number: number; label: string }>) {
+  return value.map((item) => `${item.number}. ${item.label}`).join('\n')
+}
+
+function relatedLines(value: Array<{ label: string; targetServiceId: string }>) {
+  return value.map((item) => `${item.label}|${item.targetServiceId}`).join('\n')
+}
+
+function parseRelated(value: string) {
+  return split(value).map((line) => {
+    const [label, targetServiceId] = line.split('|')
+    return { label: label?.trim() || 'Servicio relacionado', targetServiceId: targetServiceId?.trim() || '' }
+  })
+}
+
+function emptyCommercialService(order: number): ManagedCommercialElectricalService {
+  return {
+    id: `comercial-${Date.now()}`,
+    title: 'Nuevo servicio comercial',
+    description: '',
+    quoteNeeds: '',
+    access: '',
+    requiredFields: [],
+    accessConditions: [],
+    materials: 'a definir',
+    schedule: 'a coordinar',
+    height: 'según caso',
+    authorization: 'según inmueble',
+    priceLabel: 'a cotizar',
+    basePrice: null,
+    active: true,
+    order,
+  }
+}
+
+function StatusCard({ label, value, danger }: { label: string; value: string; danger?: boolean }) {
+  return (
+    <div className={`rounded-2xl border p-4 ${danger ? 'border-red-200 bg-red-50 text-red-900' : 'border-emerald-200 bg-emerald-50 text-emerald-900'}`}>
+      <p className="text-xs font-semibold uppercase tracking-wide">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  )
+}
+
+function BooleanField({ label, checked, onChange }: { label: string; checked: boolean; onChange: (checked: boolean) => void }) {
+  return (
+    <label className="flex min-h-11 items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 text-sm font-semibold text-slate-700">
+      <input type="checkbox" checked={checked} onChange={(event) => onChange(event.target.checked)} className="h-4 w-4" />
+      {label}
+    </label>
+  )
+}
+
+export function ElectricalContentManager({ initialState }: { initialState: ElectricalAdminContentState }) {
+  const [content, setContent] = useState<ElectricalAdminContent>(initialState.content)
   const [tab, setTab] = useState<Tab>('quickServices')
-  const [status, setStatus] = useState('')
+  const [message, setMessage] = useState('')
+  const [dirty, setDirty] = useState(false)
+  const [technicalStatus, setTechnicalStatus] = useState(initialState.status.technicalStatus)
   const activeCount = useMemo(() => (content[tab] as unknown[]).length, [content, tab])
+  const canPersist = technicalStatus.dbPersistent
+
+  function patchContent(updater: (current: ElectricalAdminContent) => ElectricalAdminContent) {
+    setContent((current) => updater(current))
+    setDirty(true)
+    setMessage('Falta guardar cambios.')
+  }
 
   async function save() {
-    setStatus('Guardando...')
+    if (!canPersist) {
+      setMessage('No se guardó: la DB no es persistente o apunta a /tmp.')
+      return
+    }
+    setMessage('Guardando...')
     const response = await fetch('/api/admin/electrical-content', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(content),
     })
-    setStatus(
-      response.ok
-        ? 'Guardado. La web pública ya puede reflejar los cambios.'
-        : 'No se pudo guardar.',
-    )
+    const payload = await response.json().catch(() => null)
+    if (!response.ok) {
+      if (payload?.technicalStatus) setTechnicalStatus(payload.technicalStatus)
+      setMessage(payload?.error ?? 'Error al guardar. No se confirmó persistencia.')
+      return
+    }
+    if (payload?.technicalStatus) setTechnicalStatus(payload.technicalStatus)
+    setDirty(false)
+    setMessage('Guardado correctamente. La web pública refleja estos cambios desde la misma fuente de datos.')
   }
 
   return (
     <div className="space-y-6">
       <header className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-        <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">
-          Panel administrativo
-        </p>
+        <p className="text-sm font-semibold uppercase tracking-wide text-amber-600">Admin madre · contenido público</p>
         <h1 className="mt-2 text-3xl font-semibold text-slate-950">Trabajos eléctricos</h1>
-        <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
-          Editor persistente conectado a la tabla WebsiteContent. Permite modificar servicios
-          rápidos, guías visuales, diagnósticos y pedidos comerciales. Si no hay contenido guardado,
-          la web usa el fallback estático versionado.
+        <p className="mt-2 max-w-4xl text-sm leading-6 text-slate-600">
+          Esta pantalla edita la fuente única <strong>WebsiteContent/{initialState.status.key}</strong>. Las rutas legacy redirigen acá; el fallback TypeScript queda solo como respaldo visible.
         </p>
       </header>
+
+      <section className="grid gap-3 md:grid-cols-4">
+        <StatusCard label="Contenido guardado" value={initialState.status.hasPersistedContent ? 'Sí' : 'No'} danger={!initialState.status.hasPersistedContent} />
+        <StatusCard label="Fallback activo" value={initialState.status.isFallback ? 'Sí' : 'No'} danger={initialState.status.isFallback} />
+        <StatusCard label="DB persistente" value={technicalStatus.dbPersistent ? 'Sí' : 'No'} danger={!technicalStatus.dbPersistent} />
+        <StatusCard label="Storage persistente" value={technicalStatus.uploadPersistent ? 'Sí' : 'No'} danger={!technicalStatus.uploadPersistent} />
+      </section>
+
+      {initialState.status.warnings.length ? (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950">
+          <p className="font-semibold">Advertencias reales del admin</p>
+          <ul className="mt-2 list-disc space-y-1 pl-5">
+            {initialState.status.warnings.map((warning) => <li key={warning}>{warning}</li>)}
+          </ul>
+          <p className="mt-3">DB: <strong>{technicalStatus.databaseUrlLabel}</strong> · Storage: <strong>{technicalStatus.storageProvider}</strong> · Dir: <strong>{technicalStatus.storageDirLabel}</strong></p>
+        </div>
+      ) : null}
+
       <div className="flex flex-wrap gap-2">
         {tabs.map((item) => (
-          <Button
-            key={item.id}
-            type="button"
-            variant={tab === item.id ? 'primary' : 'outline'}
-            onClick={() => setTab(item.id)}
-          >
+          <Button key={item.id} type="button" variant={tab === item.id ? 'primary' : 'outline'} onClick={() => setTab(item.id)}>
             {item.label}
           </Button>
         ))}
       </div>
-      <div className="flex items-center justify-between rounded-2xl border bg-white p-4">
-        <span className="text-sm text-slate-600">{activeCount} items</span>
-        <div className="flex gap-2">
-          <Button type="button" variant="outline" onClick={() => setContent(initialContent)}>
+
+      <div className="flex flex-col gap-3 rounded-2xl border bg-white p-4 sm:flex-row sm:items-center sm:justify-between">
+        <span className="text-sm text-slate-600">{activeCount} items · {dirty ? 'falta guardar cambios' : 'sin cambios pendientes'}</span>
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" variant="outline" onClick={() => { setContent(initialState.content); setDirty(false); setMessage('Restaurado a la última carga del servidor.') }}>
             Restaurar últimos cargados
           </Button>
-          <Button type="button" onClick={save}>
+          <Button type="button" onClick={save} disabled={!canPersist}>
             Guardar cambios
           </Button>
         </div>
       </div>
-      {status ? (
-        <p className="rounded-xl bg-slate-100 p-3 text-sm text-slate-700">{status}</p>
-      ) : null}
+      {message ? <p className="rounded-xl bg-slate-100 p-3 text-sm text-slate-700">{message}</p> : null}
+      {!canPersist ? <p className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm font-semibold text-red-800">Guardado bloqueado: configurá una DB persistente antes de usar este admin como CMS real.</p> : null}
 
       {tab === 'quickServices' ? (
         <div className="space-y-4">
           {content.quickServices.map((service, index) => (
             <article key={service.id} className="space-y-3 rounded-2xl border bg-white p-4">
-              <div className="grid gap-3 md:grid-cols-3">
-                <Input
-                  value={service.title}
-                  onChange={(e) =>
-                    setContent((c) => ({
-                      ...c,
-                      quickServices: updateAt(c.quickServices, index, { title: e.target.value }),
-                    }))
-                  }
-                />
-                <Input
-                  type="number"
-                  value={service.baseLaborPrice}
-                  onChange={(e) =>
-                    setContent((c) => ({
-                      ...c,
-                      quickServices: updateAt(c.quickServices, index, {
-                        baseLaborPrice: Number(e.target.value),
-                      }),
-                    }))
-                  }
-                />
-                <Input value={`${service.durationMin}-${service.durationMax} min`} readOnly />
+              <div className="grid gap-3 md:grid-cols-4">
+                <Input value={service.title} onChange={(e) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { title: e.target.value }) }))} />
+                <Input type="number" value={service.baseLaborPrice} onChange={(e) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { baseLaborPrice: Number(e.target.value) }) }))} />
+                <Input type="number" value={service.order} onChange={(e) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { order: Number(e.target.value) }) }))} />
+                <BooleanField label="Activo" checked={service.active} onChange={(active) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { active }) }))} />
               </div>
-              <Textarea
-                value={service.description}
-                onChange={(e) =>
-                  setContent((c) => ({
-                    ...c,
-                    quickServices: updateAt(c.quickServices, index, {
-                      description: e.target.value,
-                    }),
-                  }))
-                }
-              />
+              <Textarea value={service.description} onChange={(e) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { description: e.target.value }) }))} />
+              <div className="grid gap-3 md:grid-cols-4">
+                <Input type="number" value={service.durationMin} onChange={(e) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { durationMin: Number(e.target.value) }) }))} placeholder="Duración min" />
+                <Input type="number" value={service.durationMax} onChange={(e) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { durationMax: Number(e.target.value) }) }))} placeholder="Duración max" />
+                <select className="h-11 rounded-xl border border-border bg-white px-3 text-sm" value={String(service.requiresVisit)} onChange={(e) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { requiresVisit: e.target.value === 'segun_caso' ? 'segun_caso' : e.target.value === 'true' }) }))}>
+                  <option value="false">No requiere visita</option>
+                  <option value="true">Requiere visita</option>
+                  <option value="segun_caso">Según caso</option>
+                </select>
+                <BooleanField label="Requiere fotos" checked={service.photoRequired} onChange={(photoRequired) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { photoRequired }) }))} />
+              </div>
               <div className="grid gap-3 md:grid-cols-3">
-                <Textarea
-                  value={lines(service.usualMaterials)}
-                  onChange={(e) =>
-                    setContent((c) => ({
-                      ...c,
-                      quickServices: updateAt(c.quickServices, index, {
-                        usualMaterials: split(e.target.value),
-                      }),
-                    }))
-                  }
-                  placeholder="Materiales habituales"
-                />
-                <Textarea
-                  value={service.appliesWhen}
-                  onChange={(e) =>
-                    setContent((c) => ({
-                      ...c,
-                      quickServices: updateAt(c.quickServices, index, {
-                        appliesWhen: e.target.value,
-                      }),
-                    }))
-                  }
-                  placeholder="Aplica si"
-                />
-                <Textarea
-                  value={service.doesNotApplyWhen}
-                  onChange={(e) =>
-                    setContent((c) => ({
-                      ...c,
-                      quickServices: updateAt(c.quickServices, index, {
-                        doesNotApplyWhen: e.target.value,
-                      }),
-                    }))
-                  }
-                  placeholder="No aplica si"
-                />
+                <Textarea value={lines(service.usualMaterials)} onChange={(e) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { usualMaterials: split(e.target.value) }) }))} placeholder="Materiales habituales" />
+                <Textarea value={service.appliesWhen} onChange={(e) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { appliesWhen: e.target.value }) }))} placeholder="Aplica si" />
+                <Textarea value={service.doesNotApplyWhen} onChange={(e) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { doesNotApplyWhen: e.target.value }) }))} placeholder="No aplica si" />
+              </div>
+              <div className="grid gap-3 md:grid-cols-3">
+                <Textarea value={lines(service.includes)} onChange={(e) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { includes: split(e.target.value) }) }))} placeholder="Qué incluye" />
+                <Textarea value={lines(service.excludes)} onChange={(e) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { excludes: split(e.target.value) }) }))} placeholder="Qué no incluye" />
+                <Textarea value={lines(service.priceModifiers)} onChange={(e) => patchContent((c) => ({ ...c, quickServices: updateAt(c.quickServices, index, { priceModifiers: split(e.target.value) }) }))} placeholder="Cuándo cambia el precio" />
               </div>
             </article>
           ))}
@@ -178,94 +218,26 @@ export function ElectricalContentManager({
         <div className="space-y-4">
           {content.visualGuides.map((item, index) => (
             <article key={item.serviceId} className="space-y-3 rounded-2xl border bg-white p-4">
-              <div className="grid gap-3 md:grid-cols-2">
-                <Input
-                  value={item.visualGuide.diagramTitle}
-                  onChange={(e) =>
-                    setContent((c) => ({
-                      ...c,
-                      visualGuides: updateAt(c.visualGuides, index, {
-                        visualGuide: { ...item.visualGuide, diagramTitle: e.target.value },
-                      }),
-                    }))
-                  }
-                />
-                <Input
-                  value={item.visualGuide.diagramSubtitle}
-                  onChange={(e) =>
-                    setContent((c) => ({
-                      ...c,
-                      visualGuides: updateAt(c.visualGuides, index, {
-                        visualGuide: { ...item.visualGuide, diagramSubtitle: e.target.value },
-                      }),
-                    }))
-                  }
-                />
+              <div className="grid gap-3 md:grid-cols-4">
+                <Input value={item.serviceId} onChange={(e) => patchContent((c) => ({ ...c, visualGuides: updateAt(c.visualGuides, index, { serviceId: e.target.value }) }))} />
+                <Input type="number" value={item.order} onChange={(e) => patchContent((c) => ({ ...c, visualGuides: updateAt(c.visualGuides, index, { order: Number(e.target.value) }) }))} />
+                <BooleanField label="Activa" checked={item.active} onChange={(active) => patchContent((c) => ({ ...c, visualGuides: updateAt(c.visualGuides, index, { active }) }))} />
               </div>
-              <AdminMediaField
-                id={`guide-${item.serviceId}`}
-                label="Subir imagen"
-                value={item.visualGuide.imageSrc}
-                uploadFolder="service-guides"
-                allowManualUrl
-                onChange={(value) =>
-                  setContent((c) => ({
-                    ...c,
-                    visualGuides: updateAt(c.visualGuides, index, {
-                      visualGuide: { ...item.visualGuide, imageSrc: value },
-                    }),
-                  }))
-                }
-              />
-              <Input
-                value={item.visualGuide.imageAlt}
-                onChange={(e) =>
-                  setContent((c) => ({
-                    ...c,
-                    visualGuides: updateAt(c.visualGuides, index, {
-                      visualGuide: { ...item.visualGuide, imageAlt: e.target.value },
-                    }),
-                  }))
-                }
-                placeholder="Alt de imagen"
-              />
+              <div className="grid gap-3 md:grid-cols-2">
+                <Input value={item.visualGuide.diagramTitle} onChange={(e) => patchContent((c) => ({ ...c, visualGuides: updateAt(c.visualGuides, index, { visualGuide: { ...item.visualGuide, diagramTitle: e.target.value } }) }))} />
+                <Input value={item.visualGuide.diagramSubtitle} onChange={(e) => patchContent((c) => ({ ...c, visualGuides: updateAt(c.visualGuides, index, { visualGuide: { ...item.visualGuide, diagramSubtitle: e.target.value } }) }))} />
+              </div>
+              <AdminMediaField id={`guide-${item.serviceId}`} label="Imagen principal" value={item.visualGuide.imageSrc} uploadFolder="service-guides" accept="image/png,image/jpeg,image/webp,image/svg+xml" allowManualUrl onChange={(value) => patchContent((c) => ({ ...c, visualGuides: updateAt(c.visualGuides, index, { visualGuide: { ...item.visualGuide, imageSrc: value } }) }))} />
+              <Input value={item.visualGuide.imageAlt} onChange={(e) => patchContent((c) => ({ ...c, visualGuides: updateAt(c.visualGuides, index, { visualGuide: { ...item.visualGuide, imageAlt: e.target.value } }) }))} placeholder="Alt de imagen" />
               <div className="grid gap-3 md:grid-cols-3">
-                <Textarea
-                  value={lines(item.visualGuide.appliesIf)}
-                  onChange={(e) =>
-                    setContent((c) => ({
-                      ...c,
-                      visualGuides: updateAt(c.visualGuides, index, {
-                        visualGuide: { ...item.visualGuide, appliesIf: split(e.target.value) },
-                      }),
-                    }))
-                  }
-                  placeholder="Aplica si"
-                />
-                <Textarea
-                  value={lines(item.visualGuide.doesNotApplyIf)}
-                  onChange={(e) =>
-                    setContent((c) => ({
-                      ...c,
-                      visualGuides: updateAt(c.visualGuides, index, {
-                        visualGuide: { ...item.visualGuide, doesNotApplyIf: split(e.target.value) },
-                      }),
-                    }))
-                  }
-                  placeholder="No aplica si"
-                />
-                <Input
-                  value={item.visualGuide.durationLabel}
-                  onChange={(e) =>
-                    setContent((c) => ({
-                      ...c,
-                      visualGuides: updateAt(c.visualGuides, index, {
-                        visualGuide: { ...item.visualGuide, durationLabel: e.target.value },
-                      }),
-                    }))
-                  }
-                  placeholder="Duración"
-                />
+                <Textarea value={calloutLines(item.visualGuide.callouts)} onChange={(e) => patchContent((c) => ({ ...c, visualGuides: updateAt(c.visualGuides, index, { visualGuide: { ...item.visualGuide, callouts: parseCallouts(e.target.value) } }) }))} placeholder="1. tapa" />
+                <Textarea value={lines(item.visualGuide.appliesIf)} onChange={(e) => patchContent((c) => ({ ...c, visualGuides: updateAt(c.visualGuides, index, { visualGuide: { ...item.visualGuide, appliesIf: split(e.target.value) } }) }))} placeholder="Aplica si" />
+                <Textarea value={lines(item.visualGuide.doesNotApplyIf)} onChange={(e) => patchContent((c) => ({ ...c, visualGuides: updateAt(c.visualGuides, index, { visualGuide: { ...item.visualGuide, doesNotApplyIf: split(e.target.value) } }) }))} placeholder="No aplica si" />
+              </div>
+              <div className="grid gap-3 md:grid-cols-3">
+                <Input value={item.visualGuide.usualMaterialsShort} onChange={(e) => patchContent((c) => ({ ...c, visualGuides: updateAt(c.visualGuides, index, { visualGuide: { ...item.visualGuide, usualMaterialsShort: e.target.value } }) }))} placeholder="Materiales habituales" />
+                <Input value={item.visualGuide.durationLabel} onChange={(e) => patchContent((c) => ({ ...c, visualGuides: updateAt(c.visualGuides, index, { visualGuide: { ...item.visualGuide, durationLabel: e.target.value } }) }))} placeholder="Duración" />
+                <Textarea value={relatedLines(item.visualGuide.relatedIfNotApplies)} onChange={(e) => patchContent((c) => ({ ...c, visualGuides: updateAt(c.visualGuides, index, { visualGuide: { ...item.visualGuide, relatedIfNotApplies: parseRelated(e.target.value) } }) }))} placeholder="Servicio relacionado|target-id" />
               </div>
             </article>
           ))}
@@ -276,83 +248,54 @@ export function ElectricalContentManager({
         <div className="space-y-4">
           {content.diagnosticFaults.map((fault, index) => (
             <article key={fault.id} className="space-y-3 rounded-2xl border bg-white p-4">
-              <div className="grid gap-3 md:grid-cols-3">
-                <Input
-                  value={fault.faultName}
-                  onChange={(e) =>
-                    setContent((c) => ({
-                      ...c,
-                      diagnosticFaults: updateAt(c.diagnosticFaults, index, {
-                        faultName: e.target.value,
-                      }),
-                    }))
-                  }
-                />
-                <Input
-                  type="number"
-                  value={fault.initialPrice}
-                  onChange={(e) =>
-                    setContent((c) => ({
-                      ...c,
-                      diagnosticFaults: updateAt(c.diagnosticFaults, index, {
-                        initialPrice: Number(e.target.value),
-                      }),
-                    }))
-                  }
-                />
-                <Input
-                  type="number"
-                  value={fault.includedMinutes}
-                  onChange={(e) =>
-                    setContent((c) => ({
-                      ...c,
-                      diagnosticFaults: updateAt(c.diagnosticFaults, index, {
-                        includedMinutes: Number(e.target.value),
-                      }),
-                    }))
-                  }
-                />
+              <div className="grid gap-3 md:grid-cols-5">
+                <Input value={fault.faultName} onChange={(e) => patchContent((c) => ({ ...c, diagnosticFaults: updateAt(c.diagnosticFaults, index, { faultName: e.target.value }) }))} />
+                <Input type="number" value={fault.initialPrice} onChange={(e) => patchContent((c) => ({ ...c, diagnosticFaults: updateAt(c.diagnosticFaults, index, { initialPrice: Number(e.target.value) }) }))} />
+                <Input type="number" value={fault.includedMinutes} onChange={(e) => patchContent((c) => ({ ...c, diagnosticFaults: updateAt(c.diagnosticFaults, index, { includedMinutes: Number(e.target.value) }) }))} />
+                <Input type="number" value={fault.order} onChange={(e) => patchContent((c) => ({ ...c, diagnosticFaults: updateAt(c.diagnosticFaults, index, { order: Number(e.target.value) }) }))} />
+                <BooleanField label="Activo" checked={fault.active} onChange={(active) => patchContent((c) => ({ ...c, diagnosticFaults: updateAt(c.diagnosticFaults, index, { active }) }))} />
               </div>
-              <Textarea
-                value={lines(fault.possibleCauses)}
-                onChange={(e) =>
-                  setContent((c) => ({
-                    ...c,
-                    diagnosticFaults: updateAt(c.diagnosticFaults, index, {
-                      possibleCauses: split(e.target.value),
-                    }),
-                  }))
-                }
-                placeholder="Posibles causas"
-              />
-              <Textarea
-                value={fault.disclaimer}
-                onChange={(e) =>
-                  setContent((c) => ({
-                    ...c,
-                    diagnosticFaults: updateAt(c.diagnosticFaults, index, {
-                      disclaimer: e.target.value,
-                    }),
-                  }))
-                }
-                placeholder="Disclaimer"
-              />
+              <div className="grid gap-3 md:grid-cols-3">
+                <Textarea value={lines(fault.possibleCauses)} onChange={(e) => patchContent((c) => ({ ...c, diagnosticFaults: updateAt(c.diagnosticFaults, index, { possibleCauses: split(e.target.value) }) }))} placeholder="Posibles causas" />
+                <Textarea value={lines(fault.usualTests)} onChange={(e) => patchContent((c) => ({ ...c, diagnosticFaults: updateAt(c.diagnosticFaults, index, { usualTests: split(e.target.value) }) }))} placeholder="Pruebas habituales" />
+                <Textarea value={lines(fault.possibleSolutions)} onChange={(e) => patchContent((c) => ({ ...c, diagnosticFaults: updateAt(c.diagnosticFaults, index, { possibleSolutions: split(e.target.value) }) }))} placeholder="Soluciones posibles" />
+              </div>
+              <Textarea value={fault.disclaimer} onChange={(e) => patchContent((c) => ({ ...c, diagnosticFaults: updateAt(c.diagnosticFaults, index, { disclaimer: e.target.value }) }))} placeholder="Disclaimer" />
             </article>
           ))}
         </div>
       ) : null}
+
       {tab === 'commercialServices' ? (
-        <Textarea
-          className="min-h-[420px] font-mono"
-          value={JSON.stringify(content.commercialServices, null, 2)}
-          onChange={(e) => {
-            try {
-              setContent((c) => ({ ...c, commercialServices: JSON.parse(e.target.value) }))
-            } catch {
-              setStatus('JSON comercial inválido; corregilo antes de guardar.')
-            }
-          }}
-        />
+        <div className="space-y-4">
+          <Button type="button" variant="outline" onClick={() => patchContent((c) => ({ ...c, commercialServices: [...c.commercialServices, emptyCommercialService(c.commercialServices.length + 1)] }))}>Agregar servicio comercial</Button>
+          {content.commercialServices.map((service, index) => (
+            <article key={service.id} className="space-y-3 rounded-2xl border bg-white p-4">
+              <div className="grid gap-3 md:grid-cols-5">
+                <Input value={service.title} onChange={(e) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { title: e.target.value }) }))} />
+                <Input type="number" value={service.basePrice ?? 0} onChange={(e) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { basePrice: e.target.value ? Number(e.target.value) : null }) }))} />
+                <Input value={service.priceLabel} onChange={(e) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { priceLabel: e.target.value }) }))} />
+                <Input type="number" value={service.order} onChange={(e) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { order: Number(e.target.value) }) }))} />
+                <BooleanField label="Activo" checked={service.active} onChange={(active) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { active }) }))} />
+              </div>
+              <Textarea value={service.description} onChange={(e) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { description: e.target.value }) }))} placeholder="Descripción" />
+              <div className="grid gap-3 md:grid-cols-2">
+                <Textarea value={service.quoteNeeds} onChange={(e) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { quoteNeeds: e.target.value }) }))} placeholder="Qué datos necesita" />
+                <Textarea value={service.access} onChange={(e) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { access: e.target.value }) }))} placeholder="Condiciones de acceso" />
+              </div>
+              <div className="grid gap-3 md:grid-cols-4">
+                <Input value={service.materials} onChange={(e) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { materials: e.target.value }) }))} placeholder="Materiales" />
+                <Input value={service.schedule} onChange={(e) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { schedule: e.target.value }) }))} placeholder="Horario" />
+                <Input value={service.height} onChange={(e) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { height: e.target.value }) }))} placeholder="Altura" />
+                <Input value={service.authorization} onChange={(e) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { authorization: e.target.value }) }))} placeholder="Autorización" />
+              </div>
+              <div className="grid gap-3 md:grid-cols-2">
+                <Textarea value={lines(service.requiredFields)} onChange={(e) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { requiredFields: split(e.target.value) }) }))} placeholder="Campos requeridos" />
+                <Textarea value={lines(service.accessConditions)} onChange={(e) => patchContent((c) => ({ ...c, commercialServices: updateAt(c.commercialServices, index, { accessConditions: split(e.target.value) }) }))} placeholder="Condiciones de acceso" />
+              </div>
+            </article>
+          ))}
+        </div>
       ) : null}
     </div>
   )

--- a/nerin-electric-site-v3-fixed/app/api/admin/electrical-content/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/electrical-content/route.ts
@@ -1,24 +1,56 @@
 import { NextResponse } from 'next/server'
 import { revalidatePath } from 'next/cache'
 import { requireAdmin } from '@/lib/auth'
+import { getAdminTechnicalStatus } from '@/lib/admin-technical-status'
 import {
-  getElectricalAdminContent,
+  getElectricalAdminContentState,
   saveElectricalAdminContent,
 } from '@/lib/electrical-admin-content'
 
 export const runtime = 'nodejs'
 
+function unauthorized() {
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+}
+
 export async function GET() {
-  await requireAdmin()
-  const content = await getElectricalAdminContent()
-  return NextResponse.json(content)
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') return unauthorized()
+    throw error
+  }
+
+  const state = await getElectricalAdminContentState()
+  return NextResponse.json(state)
 }
 
 export async function PUT(req: Request) {
-  await requireAdmin()
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') return unauthorized()
+    throw error
+  }
+
+  const technicalStatus = getAdminTechnicalStatus()
+  if (!technicalStatus.dbPersistent) {
+    return NextResponse.json(
+      {
+        ok: false,
+        persisted: false,
+        error: 'La base de datos no es persistente. No se guardaron cambios para evitar un guardado falso.',
+        technicalStatus,
+      },
+      { status: 503 },
+    )
+  }
+
   const body = await req.json()
   await saveElectricalAdminContent(body)
   revalidatePath('/trabajos-electricos')
+  revalidatePath('/admin/contenido')
+  revalidatePath('/admin/contenido/trabajos-electricos')
   revalidatePath('/admin/trabajos-electricos')
-  return NextResponse.json({ ok: true })
+  return NextResponse.json({ ok: true, persisted: true, technicalStatus })
 }

--- a/nerin-electric-site-v3-fixed/app/api/admin/upload/route.ts
+++ b/nerin-electric-site-v3-fixed/app/api/admin/upload/route.ts
@@ -1,16 +1,49 @@
 import { NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
+import { getAdminTechnicalStatus } from '@/lib/admin-technical-status'
 import { storeMediaFile, sanitizeMediaFolder } from '@/lib/media'
 import { addMediaLibraryItem } from '@/lib/media-library'
 
+export const runtime = 'nodejs'
+
+const ADMIN_IMAGE_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/svg+xml'])
+
+function unauthorized() {
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+}
+
 export async function POST(req: Request) {
-  await requireAdmin()
+  try {
+    await requireAdmin()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') return unauthorized()
+    throw error
+  }
+
+  const technicalStatus = getAdminTechnicalStatus()
+  if (!technicalStatus.uploadPersistent) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Storage persistente no configurado. No se subió el archivo para evitar imágenes que se pierdan en refresh, restart o redeploy.',
+        technicalStatus,
+      },
+      { status: 503 },
+    )
+  }
 
   const form = await req.formData()
   const file = form.get('file') as File | null
 
   if (!file) {
     return NextResponse.json({ error: 'No file' }, { status: 400 })
+  }
+
+  if (!ADMIN_IMAGE_MIME_TYPES.has(file.type)) {
+    return NextResponse.json(
+      { error: 'Formato no permitido. Usá PNG, JPG, JPEG, WEBP o SVG.' },
+      { status: 400 },
+    )
   }
 
   const folder = sanitizeMediaFolder(form.get('folder')?.toString())

--- a/nerin-electric-site-v3-fixed/docs/admin-contenido-arquitectura.md
+++ b/nerin-electric-site-v3-fixed/docs/admin-contenido-arquitectura.md
@@ -1,56 +1,81 @@
 # Admin madre de contenido NERIN
 
-## Auditoría anterior
-
-| Lugar | Qué editaba/mostraba | Fuente | Consumo público | Problema |
-| --- | --- | --- | --- | --- |
-| `/admin/trabajos-electricos` | Servicios rápidos, guías visuales, diagnóstico y JSON comercial | `WebsiteContent` key `electrical_services_admin_v1` con fallback `data/electricalServices.ts` y `data/electricalServiceVisualGuides.ts` | `/trabajos-electricos` por `getElectricalAdminContent()` | Correcto como fuente, pero aislado del admin madre. |
-| `/admin/trabajos-chicos` | Vista operativa de trabajos chicos y catálogo vendible | `SmallJob` y `ServiceCatalogItem` | No alimentaba directamente `/trabajos-electricos` | Duplicaba concepto comercial con otro modelo. Redirigido. |
-| `/admin/refacciones` | Admin separado de refacciones | Página propia | Contenido público mayormente estático/fallback | Desconectado del admin madre. Redirigido para consolidación. |
-| `/admin/obras` | Admin separado de obras | Página propia | Contenido público mayormente estático/fallback | Desconectado del admin madre. Redirigido para consolidación. |
-| `/admin/contenido-comercial` | Home y contenido comercial general | Site/content JSON | Home y secciones comerciales | Queda como módulo legacy enlazado desde admin madre hasta migrar campos finos. |
-| `data/electricalServices.ts` | Fallback estático de servicios y diagnóstico | TypeScript | `/trabajos-electricos` solo si no hay DB | No debe ser CMS; queda como respaldo explícito. |
-| `data/electricalServiceVisualGuides.ts` | Fallback estático de guías | TypeScript | `/trabajos-electricos` solo si no hay DB | No debe ser CMS; queda como respaldo explícito. |
-| `ContentPage` / `ContentService` | CMS genérico histórico | Prisma | Parcial/legacy | Potencial duplicación; no se usa como fuente madre nueva. |
-| `Service` / `ServiceCategory` / `ServiceCatalogItem` | Catálogo operativo/cotizador | Prisma | Solicitudes/catálogo operativo | No debe competir con contenido público editable. |
-| Upload admin | Archivos subidos por `/api/admin/upload` | Storage local o Cloudinary | Campos admin/media | Antes no registraba biblioteca madre; ahora registra en `WebsiteContent`. |
-
-## Nueva arquitectura
+## Decisión de arquitectura
 
 - Ruta madre: `/admin/contenido`.
-- Ruta de trabajos eléctricos consolidada: `/admin/contenido/trabajos-electricos`.
-- Media library: `/admin/contenido/media`.
-- Fuente única para contenido público editable: `WebsiteContent`.
-  - `electrical_services_admin_v1`: contenido editable de `/trabajos-electricos`.
-  - `site_media_library_v1`: índice de medios subidos.
-- Fallback estático: permitido solo como respaldo cuando no existe contenido guardado o la DB falla. El admin muestra advertencias técnicas.
-- Storage de imágenes: `STORAGE_PROVIDER=cloudinary` preferido. Alternativa local solo si `STORAGE_DIR` apunta a Render Disk persistente.
+- Ruta canónica para trabajos eléctricos: `/admin/contenido/trabajos-electricos`.
+- Ruta canónica para imágenes dinámicas: `/admin/contenido/media`.
+- Fuente única para trabajos eléctricos: tabla `WebsiteContent`, key `electrical_services_admin_v1`.
+- Fuente única para la biblioteca de medios: tabla `WebsiteContent`, key `site_media_library_v1`.
+- Fallback TypeScript permitido solo como respaldo explícito, nunca como CMS silencioso.
+- Upload dinámico permitido solo con storage persistente configurado.
 
-## Rutas redirigidas
+## Auditoría de rutas y fuentes
 
-- `/admin/trabajos-chicos` → `/admin/contenido/trabajos-electricos`.
-- `/admin/trabajos-electricos` → `/admin/contenido/trabajos-electricos`.
-- `/admin/refacciones` → `/admin/contenido`.
-- `/admin/obras` → `/admin/contenido`.
+| Lugar | Qué toca | Fuente actual | Consumo público | Estado |
+| --- | --- | --- | --- | --- |
+| `/admin/contenido` | Entrada madre, estado DB/storage/fallback | `WebsiteContent` + status técnico | No renderiza público; coordina editores | Canónico |
+| `/admin/contenido/trabajos-electricos` | Servicios rápidos, guías, diagnóstico, comercial | `WebsiteContent/electrical_services_admin_v1` | `/trabajos-electricos` por `getElectricalAdminContent()` | Canónico |
+| `/admin/trabajos-electricos` | Legacy | Redirección | No aplica | Redirigido |
+| `/admin/trabajos-chicos` | Legacy | Redirección | No aplica | Redirigido |
+| `/admin/refacciones` | Legacy | Redirección a madre | No aplica | Redirigido |
+| `/admin/obras` | Legacy | Redirección a madre | No aplica | Redirigido |
+| `/admin/contacto` | Legacy | Redirección a contenido comercial | No aplica | Redirigido |
+| `/admin/contenido/media` | Biblioteca de imágenes | `WebsiteContent/site_media_library_v1` + storage externo/local persistente | Campos de imágenes en admin y web pública | Canónico |
+| `/admin/contenido-comercial` | Home/refacciones/obras/contacto comercial | `SiteSetting.siteExperience` vía `/api/admin/site` | Home, contacto, obras, refacciones y secciones comerciales | Módulo legacy conectado |
+| `data/electricalServices.ts` | Seed/fallback de servicios | TypeScript | Solo si no hay contenido guardado o falla DB | Respaldo explícito |
+| `data/electricalServiceVisualGuides.ts` | Seed/fallback de guías | TypeScript | Solo si no hay contenido guardado o falla DB | Respaldo explícito |
+| `Service/ServiceCategory/ServiceCatalogItem` | Catálogo operativo/cotizador | Prisma normalizado | Operación y solicitudes | No es fuente madre pública |
+| `ContentPage/ContentService` | CMS histórico | Prisma | Parcial/legacy | No usar para trabajos eléctricos |
 
-## Endpoints admin relevantes
+## Reglas implementadas
 
-- `GET/PUT /api/admin/electrical-content`: protegido por `requireAdmin`, lee/escribe `WebsiteContent`.
-- `POST /api/admin/upload`: protegido por `requireAdmin`, valida formato/tamaño, guarda en storage y registra en media library.
+- El endpoint `GET /api/admin/electrical-content` devuelve contenido y estado técnico: DB, storage, fallback y warnings.
+- El endpoint `PUT /api/admin/electrical-content` bloquea el guardado si la DB no es persistente.
+- El endpoint `POST /api/admin/upload` bloquea uploads si el storage no es persistente.
+- Los uploads admin aceptan solo `png`, `jpg`, `jpeg`, `webp` y `svg`.
+- La web pública recibe solo items activos y ordenados.
+- El admin conserva items inactivos para reactivarlos o editarlos.
+- El admin muestra “falta guardar cambios”, errores reales y advertencias si se está usando fallback.
 
-## Variables de entorno Render
+## Variables necesarias en Render
 
-- `DATABASE_URL`: debe apuntar a PostgreSQL o DB persistente. Crítico: no usar `/tmp`.
-- `STORAGE_PROVIDER`: `cloudinary` recomendado o `local` con Render Disk.
-- Cloudinary: `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_UPLOAD_PRESET`.
-- Local con Render Disk: `STORAGE_DIR=/var/data/...` o ruta montada persistente. No usar `/tmp` ni `/public`.
+### DB persistente
 
-## Prueba manual
+Configurar `DATABASE_URL` para una base persistente. Si se usa SQLite con Render Disk, debe apuntar al disco montado, por ejemplo:
 
-1. Entrar a `/admin/contenido` y revisar estado técnico.
-2. Abrir `/admin/contenido/trabajos-electricos`, editar un título y guardar.
-3. Refrescar el admin y confirmar que el texto persiste.
-4. Abrir `/trabajos-electricos` y confirmar que consume el mismo contenido.
-5. Abrir `/admin/contenido/media`, subir una imagen válida y copiar su URL.
-6. Pegar la URL en una guía visual, guardar y verificar preview/admin y web pública.
-7. Reiniciar/redeployar y confirmar persistencia si `DATABASE_URL` y storage son persistentes.
+```bash
+DATABASE_URL=file:/var/data/nerin.db
+STORAGE_DIR=/var/data
+```
+
+No usar `file:/tmp/nerin.db`.
+
+### Storage de imágenes recomendado
+
+Preferido:
+
+```bash
+STORAGE_PROVIDER=cloudinary
+CLOUDINARY_CLOUD_NAME=...
+CLOUDINARY_UPLOAD_PRESET=...
+```
+
+Alternativas aceptables: S3, Cloudflare R2, Supabase Storage o UploadThing si se implementa el provider. Render Disk local solo es aceptable si se decide explícitamente y `STORAGE_DIR` apunta al disco persistente.
+
+## Criterios de aceptación cubiertos
+
+- Existe una entrada madre de contenido público.
+- Las rutas legacy de trabajos chicos/eléctricos no quedan como admins separados.
+- Trabajos eléctricos lee y escribe una sola fuente: `WebsiteContent/electrical_services_admin_v1`.
+- La web pública lee desde esa misma fuente.
+- Los cambios no se guardan si la DB no es persistente.
+- Los uploads no se aceptan si el storage no es persistente.
+- Las imágenes no se suben dinámicamente a `/public`.
+- Los endpoints admin revisados están protegidos por `requireAdmin`.
+- El fallback existe solo como respaldo visible.
+
+## Pendiente recomendado
+
+- Migrar progresivamente `/admin/contenido-comercial` dentro de subrutas de `/admin/contenido` para que Home, Refacciones, Obras y Contacto dejen de vivir en un módulo legacy.
+- Si se elige S3/R2/Supabase/UploadThing, agregar provider real en `lib/media.ts` y mantener el bloqueo cuando falten credenciales.

--- a/nerin-electric-site-v3-fixed/lib/admin-technical-status.ts
+++ b/nerin-electric-site-v3-fixed/lib/admin-technical-status.ts
@@ -2,29 +2,53 @@ import path from 'node:path'
 
 export type AdminTechnicalStatus = {
   dbConfigured: boolean
+  dbPersistent: boolean
   dbTemporary: boolean
   storageConfigured: boolean
   uploadPersistent: boolean
   storageProvider: string
+  databaseUrlLabel: string
+  storageDirLabel: string
   warnings: string[]
 }
 
+function redactDatabaseUrl(value: string) {
+  if (!value) return 'No configurada'
+  if (value.startsWith('file:')) return value
+  const protocol = value.split(':')[0] || 'db'
+  return `${protocol}://***`
+}
+
 export function getAdminTechnicalStatus(): AdminTechnicalStatus {
-  const databaseUrl = process.env.DATABASE_URL || ''
-  const storageProvider = process.env.STORAGE_PROVIDER || 'local'
-  const storageDir = process.env.STORAGE_DIR || ''
+  const databaseUrl = process.env.DATABASE_URL?.trim() || ''
+  const storageProvider = (process.env.STORAGE_PROVIDER || 'local').trim().toLowerCase()
+  const storageDir = process.env.STORAGE_DIR?.trim() || ''
   const dbTemporary = databaseUrl.includes('/tmp') || databaseUrl.includes('file:/tmp')
+  const dbConfigured = Boolean(databaseUrl) && !dbTemporary
+  const dbPersistent = dbConfigured && !dbTemporary
   const localStorageTemporary = storageProvider === 'local' && (!storageDir || path.resolve(storageDir).startsWith('/tmp'))
   const cloudinaryReady = storageProvider === 'cloudinary' && Boolean(process.env.CLOUDINARY_CLOUD_NAME && process.env.CLOUDINARY_UPLOAD_PRESET)
-  const storageConfigured = storageProvider === 'cloudinary' ? cloudinaryReady : Boolean(storageDir)
-  const uploadPersistent = storageProvider === 'cloudinary' ? cloudinaryReady : storageConfigured && !localStorageTemporary
+  const localStoragePersistent = storageProvider === 'local' && Boolean(storageDir) && !localStorageTemporary
+  const storageConfigured = cloudinaryReady || localStoragePersistent
+  const uploadPersistent = storageConfigured && (cloudinaryReady || localStoragePersistent)
   const warnings: string[] = []
 
-  if (!databaseUrl) warnings.push('Falta DATABASE_URL: el admin no debe prometer persistencia sin base configurada.')
-  if (dbTemporary) warnings.push('DATABASE_URL apunta a /tmp: los cambios pueden perderse en restart/redeploy.')
-  if (!storageConfigured) warnings.push('Falta storage persistente. Configurá Cloudinary/S3/R2/Supabase o STORAGE_DIR sobre Render Disk.')
-  if (localStorageTemporary) warnings.push('Storage local sin Render Disk persistente: no guardar uploads dinámicos en /public ni en filesystem efímero.')
+  if (!databaseUrl) warnings.push('Falta DATABASE_URL: el admin no puede garantizar persistencia de contenido.')
+  if (dbTemporary) warnings.push('DATABASE_URL apunta a /tmp: los cambios pueden perderse en restart o redeploy.')
+  if (!dbPersistent) warnings.push('La base no está marcada como persistente. No se debe mostrar “guardado definitivo”.')
+  if (!storageConfigured) warnings.push('Falta storage persistente. Configurá Cloudinary, S3, R2, Supabase Storage, UploadThing o un Render Disk explícito.')
+  if (localStorageTemporary) warnings.push('Storage local sin directorio persistente: los uploads pueden perderse. No guardar imágenes dinámicas en /public ni /tmp.')
   if (storageProvider === 'cloudinary' && !cloudinaryReady) warnings.push('STORAGE_PROVIDER=cloudinary requiere CLOUDINARY_CLOUD_NAME y CLOUDINARY_UPLOAD_PRESET.')
 
-  return { dbConfigured: Boolean(databaseUrl), dbTemporary, storageConfigured, uploadPersistent, storageProvider, warnings }
+  return {
+    dbConfigured,
+    dbPersistent,
+    dbTemporary,
+    storageConfigured,
+    uploadPersistent,
+    storageProvider,
+    databaseUrlLabel: redactDatabaseUrl(databaseUrl),
+    storageDirLabel: storageDir || 'No configurado',
+    warnings,
+  }
 }

--- a/nerin-electric-site-v3-fixed/lib/electrical-admin-content.ts
+++ b/nerin-electric-site-v3-fixed/lib/electrical-admin-content.ts
@@ -1,60 +1,238 @@
 import { prisma } from '@/lib/db'
-import { quickServices, diagnosticFaults } from '@/data/electricalServices'
-import { electricalServiceVisualGuides } from '@/data/electricalServiceVisualGuides'
+import {
+  diagnosticFaults,
+  quickServices,
+  type DiagnosticFault,
+  type ElectricalService,
+} from '@/data/electricalServices'
+import {
+  electricalServiceVisualGuides,
+  type ElectricalServiceVisualGuide,
+} from '@/data/electricalServiceVisualGuides'
+import { getAdminTechnicalStatus, type AdminTechnicalStatus } from '@/lib/admin-technical-status'
+
+export type ManagedElectricalService = ElectricalService & {
+  active: boolean
+  order: number
+  visualGuideServiceId?: string
+}
+
+export type ManagedElectricalVisualGuide = ElectricalServiceVisualGuide & {
+  active: boolean
+  order: number
+}
+
+export type ManagedDiagnosticFault = DiagnosticFault & {
+  active: boolean
+  order: number
+}
+
+export type ManagedCommercialElectricalService = {
+  id: string
+  title: string
+  description: string
+  quoteNeeds: string
+  access: string
+  requiredFields: string[]
+  accessConditions: string[]
+  materials: string
+  schedule: string
+  height: string
+  authorization: string
+  priceLabel: string
+  basePrice: number | null
+  active: boolean
+  order: number
+  configurable?: boolean
+}
 
 export type ElectricalAdminContent = {
-  quickServices: typeof quickServices
-  visualGuides: typeof electricalServiceVisualGuides
-  diagnosticFaults: typeof diagnosticFaults
-  commercialServices: Array<Record<string, unknown>>
+  quickServices: ManagedElectricalService[]
+  visualGuides: ManagedElectricalVisualGuide[]
+  diagnosticFaults: ManagedDiagnosticFault[]
+  commercialServices: ManagedCommercialElectricalService[]
+}
+
+export type ElectricalAdminContentState = {
+  content: ElectricalAdminContent
+  status: {
+    key: string
+    hasPersistedContent: boolean
+    isFallback: boolean
+    technicalStatus: AdminTechnicalStatus
+    warnings: string[]
+  }
 }
 
 export const ELECTRICAL_CONTENT_KEY = 'electrical_services_admin_v1'
 
-export const defaultElectricalContent: ElectricalAdminContent = {
-  quickServices,
-  visualGuides: electricalServiceVisualGuides,
-  diagnosticFaults,
-  commercialServices: [],
+const commercialSeed = [
+  ['cambio-lamparas-comercio', 'Cambio de lámparas en comercio', 'Cantidad de luminarias, altura aproximada, tipo de espacio, horario, materiales y fotos.', 'Ingreso autorizado, sector despejado y medio de acceso validado.'],
+  ['mantenimiento-luminarias', 'Mantenimiento de luminarias', 'Cantidad, altura, tipo de artefacto, fotos del espacio y horario disponible.', 'Acceso autorizado, corte coordinado si corresponde y responsable presente.'],
+  ['revision-tablero-local', 'Revisión de tablero de local', 'Fotos del tablero abierto/cerrado, síntomas, potencia de equipos y horarios posibles.', 'Puede requerir corte parcial, autorización del local/administración y sector despejado.'],
+  ['tomas-mostrador-equipos', 'Tomas para mostrador/equipos', 'Cantidad, consumo de equipos, distancia al tablero, recorrido posible y fotos.', 'Se valida canalización, interferencias, horarios y permisos del inmueble.'],
+  ['urgencia-fuera-horario', 'Urgencia fuera de horario', 'Síntoma, criticidad, dirección, contacto responsable y fotos/videos si existen.', 'Sujeto a disponibilidad, seguridad de acceso y aprobación previa del adicional horario.'],
+  ['preventivo-mensual', 'Mantenimiento preventivo mensual', 'Superficie, cantidad de sectores, frecuencia, horarios y listado de equipos críticos.', 'Requiere referente operativo, permiso de ingreso y agenda recurrente aprobada.'],
+  ['trabajo-consorcio', 'Trabajo en consorcio', 'Autorización, alcance, fotos, ubicación de llaves/tableros y horario permitido.', 'Debe coordinarse con administración, encargado o consejo.'],
+  ['trabajo-country', 'Trabajo en country / barrio privado', 'Lote/unidad, autorización de ingreso, contacto de seguridad, fotos y alcance.', 'Sujeto a ingreso aprobado, documentación requerida, zona y ventana horaria.'],
+] as const
+
+const defaultCommercialServices: ManagedCommercialElectricalService[] = commercialSeed.map(
+  ([id, title, quoteNeeds, access], index) => ({
+    id,
+    title,
+    description: quoteNeeds,
+    quoteNeeds,
+    access,
+    requiredFields: quoteNeeds.split(',').map((item) => item.trim()),
+    accessConditions: access.split(',').map((item) => item.trim()),
+    materials: 'cliente / cotiza NERIN / a definir',
+    schedule: 'a coordinar',
+    height: 'según caso',
+    authorization: 'según inmueble',
+    priceLabel: 'a cotizar',
+    basePrice: null,
+    active: true,
+    order: index + 1,
+    configurable: index === 0,
+  }),
+)
+
+function numberOrDefault(value: unknown, fallback: number) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
 }
 
-function mergeContent(raw: unknown): ElectricalAdminContent {
-  if (!raw || typeof raw !== 'object') return defaultElectricalContent
-  const value = raw as Partial<ElectricalAdminContent>
+function stringArray(value: unknown, fallback: string[] = []) {
+  if (Array.isArray(value)) return value.map((item) => String(item)).filter(Boolean)
+  if (typeof value === 'string') return value.split('\n').map((item) => item.trim()).filter(Boolean)
+  return fallback
+}
+
+function normalizeQuickServices(value: unknown): ManagedElectricalService[] {
+  const source = Array.isArray(value) && value.length ? value : quickServices
+  return source.map((raw, index) => {
+    const item = raw as Partial<ManagedElectricalService>
+    const fallback = quickServices.find((service) => service.id === item.id) ?? quickServices[index] ?? quickServices[0]
+    return {
+      ...fallback,
+      ...item,
+      active: item.active ?? true,
+      order: numberOrDefault(item.order, index + 1),
+      visualGuideServiceId: item.visualGuideServiceId ?? item.id ?? fallback.id,
+    } as ManagedElectricalService
+  })
+}
+
+function normalizeVisualGuides(value: unknown): ManagedElectricalVisualGuide[] {
+  const source = Array.isArray(value) && value.length ? value : electricalServiceVisualGuides
+  return source.map((raw, index) => {
+    const item = raw as Partial<ManagedElectricalVisualGuide>
+    const fallback = electricalServiceVisualGuides.find((guide) => guide.serviceId === item.serviceId) ?? electricalServiceVisualGuides[index] ?? electricalServiceVisualGuides[0]
+    return {
+      ...fallback,
+      ...item,
+      visualGuide: {
+        ...fallback.visualGuide,
+        ...(item.visualGuide ?? {}),
+        appliesIf: stringArray(item.visualGuide?.appliesIf, fallback.visualGuide.appliesIf),
+        doesNotApplyIf: stringArray(item.visualGuide?.doesNotApplyIf, fallback.visualGuide.doesNotApplyIf),
+        callouts: Array.isArray(item.visualGuide?.callouts) ? item.visualGuide.callouts : fallback.visualGuide.callouts,
+        relatedIfNotApplies: Array.isArray(item.visualGuide?.relatedIfNotApplies) ? item.visualGuide.relatedIfNotApplies : fallback.visualGuide.relatedIfNotApplies,
+      },
+      active: item.active ?? true,
+      order: numberOrDefault(item.order, index + 1),
+    } as ManagedElectricalVisualGuide
+  })
+}
+
+function normalizeDiagnosticFaults(value: unknown): ManagedDiagnosticFault[] {
+  const source = Array.isArray(value) && value.length ? value : diagnosticFaults
+  return source.map((raw, index) => {
+    const item = raw as Partial<ManagedDiagnosticFault>
+    const fallback = diagnosticFaults.find((fault) => fault.id === item.id) ?? diagnosticFaults[index] ?? diagnosticFaults[0]
+    return {
+      ...fallback,
+      ...item,
+      possibleCauses: stringArray(item.possibleCauses, fallback.possibleCauses),
+      usualTests: stringArray(item.usualTests, fallback.usualTests),
+      possibleSolutions: stringArray(item.possibleSolutions, fallback.possibleSolutions),
+      advancedRequiredWhen: stringArray(item.advancedRequiredWhen, fallback.advancedRequiredWhen),
+      active: item.active ?? true,
+      order: numberOrDefault(item.order, index + 1),
+    } as ManagedDiagnosticFault
+  })
+}
+
+function normalizeCommercialServices(value: unknown): ManagedCommercialElectricalService[] {
+  const source = Array.isArray(value) && value.length ? value : defaultCommercialServices
+  return source.map((raw, index) => {
+    const item = raw as Partial<ManagedCommercialElectricalService>
+    const fallback = defaultCommercialServices.find((service) => service.id === item.id) ?? defaultCommercialServices[index] ?? defaultCommercialServices[0]
+    const requiredFields = stringArray(item.requiredFields, fallback.requiredFields)
+    const accessConditions = stringArray(item.accessConditions, fallback.accessConditions)
+    return {
+      ...fallback,
+      ...item,
+      id: item.id || fallback.id || `comercial-${index + 1}`,
+      title: item.title || fallback.title || 'Servicio comercial',
+      requiredFields,
+      accessConditions,
+      quoteNeeds: item.quoteNeeds || requiredFields.join(', ') || fallback.quoteNeeds,
+      access: item.access || accessConditions.join(', ') || fallback.access,
+      basePrice: item.basePrice === undefined || item.basePrice === null ? null : numberOrDefault(item.basePrice, 0),
+      active: item.active ?? true,
+      order: numberOrDefault(item.order, index + 1),
+    }
+  })
+}
+
+export function normalizeElectricalContent(raw: unknown): ElectricalAdminContent {
+  const value = raw && typeof raw === 'object' ? (raw as Partial<ElectricalAdminContent>) : {}
   return {
-    quickServices: Array.isArray(value.quickServices)
-      ? (value.quickServices as typeof quickServices)
-      : quickServices,
-    visualGuides: Array.isArray(value.visualGuides)
-      ? (value.visualGuides as typeof electricalServiceVisualGuides)
-      : electricalServiceVisualGuides,
-    diagnosticFaults: Array.isArray(value.diagnosticFaults)
-      ? (value.diagnosticFaults as typeof diagnosticFaults)
-      : diagnosticFaults,
-    commercialServices: Array.isArray(value.commercialServices) ? value.commercialServices : [],
+    quickServices: normalizeQuickServices(value.quickServices),
+    visualGuides: normalizeVisualGuides(value.visualGuides),
+    diagnosticFaults: normalizeDiagnosticFaults(value.diagnosticFaults),
+    commercialServices: normalizeCommercialServices(value.commercialServices),
+  }
+}
+
+export const defaultElectricalContent: ElectricalAdminContent = normalizeElectricalContent({})
+
+export async function getElectricalAdminContentState(): Promise<ElectricalAdminContentState> {
+  const technicalStatus = getAdminTechnicalStatus()
+  const warnings = [...technicalStatus.warnings]
+
+  try {
+    const row = await prisma.websiteContent.findUnique({ where: { key: ELECTRICAL_CONTENT_KEY } })
+    if (!row?.content) {
+      warnings.push('No existe contenido guardado para trabajos eléctricos: se está usando fallback TypeScript visible.')
+      return { content: defaultElectricalContent, status: { key: ELECTRICAL_CONTENT_KEY, hasPersistedContent: false, isFallback: true, technicalStatus, warnings } }
+    }
+
+    return { content: normalizeElectricalContent(JSON.parse(row.content)), status: { key: ELECTRICAL_CONTENT_KEY, hasPersistedContent: true, isFallback: false, technicalStatus, warnings } }
+  } catch (error) {
+    console.warn('[electrical-content] Using static fallback.', error)
+    warnings.push('Falló la lectura de DB para trabajos eléctricos: la web usa fallback estático.')
+    return { content: defaultElectricalContent, status: { key: ELECTRICAL_CONTENT_KEY, hasPersistedContent: false, isFallback: true, technicalStatus, warnings } }
   }
 }
 
 export async function getElectricalAdminContent(): Promise<ElectricalAdminContent> {
-  try {
-    const row = await prisma.websiteContent.findUnique({ where: { key: ELECTRICAL_CONTENT_KEY } })
-    if (!row?.content) return defaultElectricalContent
-    return mergeContent(JSON.parse(row.content))
-  } catch (error) {
-    console.warn('[electrical-content] Using static fallback.', error)
-    return defaultElectricalContent
-  }
+  const state = await getElectricalAdminContentState()
+  return state.content
 }
 
 export async function saveElectricalAdminContent(content: ElectricalAdminContent) {
+  const normalized = normalizeElectricalContent(content)
   return prisma.websiteContent.upsert({
     where: { key: ELECTRICAL_CONTENT_KEY },
     create: {
       key: ELECTRICAL_CONTENT_KEY,
       title: 'Trabajos eléctricos',
-      content: JSON.stringify(content),
+      content: JSON.stringify(normalized),
       visible: true,
     },
-    update: { content: JSON.stringify(content), visible: true },
+    update: { content: JSON.stringify(normalized), visible: true },
   })
 }

--- a/nerin-electric-site-v3-fixed/lib/electrical-admin-content.ts
+++ b/nerin-electric-site-v3-fixed/lib/electrical-admin-content.ts
@@ -187,6 +187,10 @@ function normalizeCommercialServices(value: unknown): ManagedCommercialElectrica
   })
 }
 
+function publicList<T extends { active: boolean; order: number }>(items: T[]) {
+  return items.filter((item) => item.active !== false).sort((a, b) => a.order - b.order)
+}
+
 export function normalizeElectricalContent(raw: unknown): ElectricalAdminContent {
   const value = raw && typeof raw === 'object' ? (raw as Partial<ElectricalAdminContent>) : {}
   return {
@@ -194,6 +198,15 @@ export function normalizeElectricalContent(raw: unknown): ElectricalAdminContent
     visualGuides: normalizeVisualGuides(value.visualGuides),
     diagnosticFaults: normalizeDiagnosticFaults(value.diagnosticFaults),
     commercialServices: normalizeCommercialServices(value.commercialServices),
+  }
+}
+
+export function toPublicElectricalContent(content: ElectricalAdminContent): ElectricalAdminContent {
+  return {
+    quickServices: publicList(content.quickServices),
+    visualGuides: publicList(content.visualGuides),
+    diagnosticFaults: publicList(content.diagnosticFaults),
+    commercialServices: publicList(content.commercialServices),
   }
 }
 
@@ -220,7 +233,7 @@ export async function getElectricalAdminContentState(): Promise<ElectricalAdminC
 
 export async function getElectricalAdminContent(): Promise<ElectricalAdminContent> {
   const state = await getElectricalAdminContentState()
-  return state.content
+  return toPublicElectricalContent(state.content)
 }
 
 export async function saveElectricalAdminContent(content: ElectricalAdminContent) {


### PR DESCRIPTION
## Qué se cambió

- Unifiqué el contenido de trabajos eléctricos alrededor de `WebsiteContent/electrical_services_admin_v1` como fuente editable.
- Agregué estado explícito de persistencia para DB, storage, fallback y warnings técnicos.
- El admin de trabajos eléctricos ahora recibe `content + status`, muestra fallback/DB/storage y bloquea guardado si la DB no es persistente.
- `PUT /api/admin/electrical-content` ya no promete guardado si `DATABASE_URL` apunta a `/tmp` o no es persistente.
- `POST /api/admin/upload` bloquea uploads si no hay storage persistente y restringe el admin a imágenes `png/jpg/jpeg/webp/svg`.
- La biblioteca de medios muestra provider, storage dir, upload persistente y bloquea el input si no hay persistencia real.
- La web pública recibe solo contenido activo y ordenado desde la misma fuente.
- Agregué redirect legacy para `/admin/contacto`.
- Actualicé `docs/admin-contenido-arquitectura.md` con mapa de rutas, fuentes, duplicaciones y pendientes.

## Auditoría resumida

- `/admin/contenido` queda como entrada madre.
- `/admin/contenido/trabajos-electricos` queda como editor canónico para servicios rápidos, guías visuales, diagnóstico y comercial.
- `/admin/trabajos-electricos` y `/admin/trabajos-chicos` ya redirigen al editor canónico.
- `/admin/refacciones` y `/admin/obras` ya redirigen a `/admin/contenido`.
- `/admin/contenido-comercial` sigue siendo módulo legacy conectado para Home/Refacciones/Obras/Contacto vía `SiteSetting.siteExperience`; queda documentado como migración progresiva, no como fuente de trabajos eléctricos.
- `Service`, `ServiceCategory` y `ServiceCatalogItem` quedan como modelos operativos/cotizador, no como CMS público de trabajos eléctricos.
- `data/electricalServices.ts` y `data/electricalServiceVisualGuides.ts` quedan como fallback explícito, no CMS.

## Criterios cubiertos

- No hay guardado falso si la DB no es persistente.
- No hay uploads dinámicos en `/public`.
- No se aceptan uploads admin si el storage puede perderse.
- Los endpoints admin revisados están protegidos por `requireAdmin`.
- La web pública de `/trabajos-electricos` lee la misma fuente que edita el admin.
- Las imágenes subidas desde admin solo se aceptan cuando el storage persistente está configurado.

## Pendiente recomendado

Migrar `/admin/contenido-comercial` a subrutas dentro de `/admin/contenido` para que Home, Refacciones, Obras y Contacto también queden visualmente integrados en el admin madre, aunque hoy ya están conectados por `SiteSetting.siteExperience`.

## Tests

No pude ejecutar build/test local desde el conector de GitHub. Conviene validar en Render Preview o CI con:

```bash
npm run build
npm run lint
```
